### PR TITLE
[WIP] Add AWS secret data source.

### DIFF
--- a/vault/data_source_aws_secret.go
+++ b/vault/data_source_aws_secret.go
@@ -1,0 +1,97 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func awsSecretDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: awsSecretDataSourceRead,
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Full path from which the secret will be read.",
+			},
+
+			"access_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "AWS access key ID read from Vault.",
+			},
+
+			"secret_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "AWS secret key read from Vault.",
+			},
+
+			"security_token": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "AWS security token read from Vault. (Only returned for STS.)",
+			},
+
+			"lease_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Lease identifier assigned by vault.",
+			},
+
+			"lease_duration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Lease duration in seconds relative to the time in lease_start_time.",
+			},
+
+			"lease_start_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time at which the lease was read, using the clock of the system where Terraform was running",
+			},
+
+			"lease_renewable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if the duration of this lease can be extended through renewal.",
+			},
+		},
+	}
+}
+
+func awsSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+
+	log.Printf("[DEBUG] Reading %q from Vault", path)
+	secret, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading from Vault: %s", err)
+	}
+	log.Printf("[DEBUG] Read %q from Vault", path)
+
+	if secret == nil {
+		return fmt.Errorf("No role found at %q; are you sure you're using the right path?", path)
+	}
+
+	d.SetId(secret.RequestID)
+	d.Set("access_key", secret.Data["access_key"])
+	d.Set("secret_key", secret.Data["secret_key"])
+	d.Set("security_token", secret.Data["security_token"])
+	d.Set("lease_id", secret.LeaseID)
+	d.Set("lease_duration", secret.LeaseDuration)
+	d.Set("lease_start_time", time.Now().Format(time.RFC3339))
+	d.Set("lease_renewable", secret.Renewable)
+
+	// TODO(paddy): poll until we think credentials are available
+
+	return nil
+}

--- a/vault/data_source_aws_secret_test.go
+++ b/vault/data_source_aws_secret_test.go
@@ -1,0 +1,86 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAWSSecret(t *testing.T) {
+	mountPath := acctest.RandomWithPrefix("aws")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSSecret_config(mountPath),
+				Check:  testAccDataSourceAWSSecret_check(mountPath),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSSecret_config(mountPath string) string {
+	accessKey := "AKIAIAXPQ6LSO42THTHQ"
+	secretKey := "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"
+	return fmt.Sprintf(`
+resource "vault_mount" "aws" {
+    path = "%s"
+    type = "aws"
+    description = "Obtain AWS credentials."
+}
+
+resource "vault_generic_secret" "root" {
+    path = "${vault_mount.aws.path}/config/root"
+    data_json = <<EOT
+{
+    "access_key": "%s",
+    "secret_key": "%s",
+    "region": "us-east-1"
+}
+EOT
+}
+
+resource "vault_generic_secret" "policy" {
+    path = "${vault_mount.aws.path}/roles/test"
+    data_json = <<EOT
+{
+    "policy": "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
+}
+EOT
+}
+
+data "vault_aws_secret" "test" {
+    path = "${vault_mount.aws.path}/creds/test"
+    depends_on = ["vault_generic_secret.policy", "vault_generic_secret.root"]
+}
+`, mountPath, accessKey, secretKey)
+}
+
+func testAccDataSourceAWSSecret_check(mountPath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["data.vault_generic_secret.test"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state %v", s.Modules[0].Resources)
+		}
+
+		iState := resourceState.Primary
+		if iState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		wantJson := `{"zip":"zap"}`
+		if got, want := iState.Attributes["data_json"], wantJson; got != want {
+			return fmt.Errorf("data_json contains %s; want %s", got, want)
+		}
+
+		if got, want := iState.Attributes["data.zip"], "zap"; got != want {
+			return fmt.Errorf("data[\"zip\"] contains %s; want %s", got, want)
+		}
+
+		return nil
+	}
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -85,6 +85,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"vault_generic_secret": genericSecretDataSource(),
+			"vault_aws_secret":     awsSecretDataSource(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
This is a fully-functioning data source for retrieving AWS access tokens
and secret tokens from Vault.

To do still:

* Our test fails, because the special {aws mount point}/config/root
  generic secret we're writing doesn't support DELETE, which the test
  framework automatically tries to call. The solution to this is to
  create a vault_aws_config resource, I think.
* We need to document the new data source on the website.
* We should poll until we think the access key/secret key are active, to
  compensate for AWS' eventual consistency, which would be frustrating
  for users.