### PR TITLE
Support for wrapped secrets

### DIFF
--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
+
+	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -20,6 +23,27 @@ func genericSecretDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Full path from which a secret will be read.",
+			},
+
+			"command": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "read",
+				ValidateFunc: validateVaultCommand,
+				Description:  "Vault command to use to get the secret.",
+			},
+
+			"wrap_ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Setting this value will wrap response with specified TTL.",
+			},
+
+			"write_data_json": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Data to send on write command.",
+				ValidateFunc: ValidateDataJSON,
 			},
 
 			"data_json": {
@@ -57,8 +81,55 @@ func genericSecretDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "True if the duration of this lease can be extended through renewal.",
 			},
+
+			"wrap_information": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Wrapping response information",
+			},
 		},
 	}
+}
+
+func validateVaultCommand(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	switch value {
+	case "read", "write":
+	default:
+		errors = append(errors, fmt.Errorf("%s command is not supported", value))
+	}
+	return
+}
+
+func runVaultCommand(c *api.Client, command, path, wrapTTL string, writeData map[string]interface{}) (*api.Secret, error) {
+	if wrapTTL != "" {
+		c.SetWrappingLookupFunc(func(string, string) string {
+			log.Printf("[DEBUG] Setting wrap TTL %s for %s", wrapTTL, path)
+			return wrapTTL
+		})
+		defer c.SetWrappingLookupFunc(nil)
+	}
+
+	switch command {
+	case "read":
+		return c.Logical().Read(path)
+	case "write":
+		return c.Logical().Write(path, writeData)
+	}
+	return nil, fmt.Errorf("unsupported command %s", command)
+}
+
+func getWriteData(d *schema.ResourceData) (map[string]interface{}, error) {
+	data := d.Get("write_data_json").(string)
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var writeData map[string]interface{}
+	err := json.Unmarshal([]byte(data), &writeData)
+	if err != nil {
+		return nil, fmt.Errorf("write_data_json %#v syntax error: %s", data, err)
+	}
+	return writeData, nil
 }
 
 func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error {
@@ -67,15 +138,32 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 	path := d.Get("path").(string)
 
 	log.Printf("[DEBUG] Reading %s from Vault", path)
-	secret, err := client.Logical().Read(path)
+
+	command := d.Get("command").(string)
+	wrapTTL := d.Get("wrap_ttl").(string)
+
+	writeData, err := getWriteData(d)
+	if err != nil {
+		return err
+	}
+
+	secret, err := runVaultCommand(client, command, path, wrapTTL, writeData)
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
 	if secret == nil {
-		return fmt.Errorf("No secret found at %q", path)
+		return fmt.Errorf("no secret found at %q", path)
 	}
 
-	d.SetId(secret.RequestID)
+	id := secret.RequestID
+	if id == "" {
+		// Wrapped responses don't have a request ID
+		id, err = uuid.GenerateUUID()
+		if err != nil {
+			return fmt.Errorf("couldn't generate an uuid: %s", err)
+		}
+	}
+	d.SetId(id)
 
 	// Ignoring error because this value came from JSON in the
 	// first place so no reason why it should fail to re-encode.
@@ -104,6 +192,16 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("lease_duration", secret.LeaseDuration)
 	d.Set("lease_start_time", time.Now().Format("RFC3339"))
 	d.Set("lease_renewable", secret.Renewable)
+
+	if secret.WrapInfo != nil {
+		wrapInfo := map[string]string{
+			"token":            secret.WrapInfo.Token,
+			"ttl":              strconv.Itoa(secret.WrapInfo.TTL),
+			"creation_time":    secret.WrapInfo.CreationTime.Format("RFC3339"),
+			"wrapped_accessor": secret.WrapInfo.WrappedAccessor,
+		}
+		d.Set("wrap_information", wrapInfo)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Adds a `wrap_ttl option` to `vault_generic_secret` so wrapped secrets can be requested in a generic way.
It also adds a `command` option so write operations can also be performed, this allows to obtain secrets that are requested with write operations as secret IDs in AppRole auth (this would fix #4) or keys in PKI module.