### PR TITLE
Add AWS auth backend role resource.

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -88,10 +88,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"vault_auth_backend":   authBackendResource(),
-			"vault_generic_secret": genericSecretResource(),
-			"vault_policy":         policyResource(),
-			"vault_mount":          mountResource(),
+			"vault_auth_backend":          authBackendResource(),
+			"vault_aws_auth_backend_role": awsAuthBackendRoleResource(),
+			"vault_generic_secret":        genericSecretResource(),
+			"vault_policy":                policyResource(),
+			"vault_mount":                 mountResource(),
 		},
 	}
 }

--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -1,0 +1,456 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	awsAuthBackendRoleBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/role/.+$")
+	awsAuthBackendRoleNameFromPathRegex    = regexp.MustCompile("^auth/.+/role/(.+)$")
+)
+
+func awsAuthBackendRoleResource() *schema.Resource {
+	return &schema.Resource{
+		Create: awsAuthBackendRoleCreate,
+		Read:   awsAuthBackendRoleRead,
+		Update: awsAuthBackendRoleUpdate,
+		Delete: awsAuthBackendRoleDelete,
+		Exists: awsAuthBackendRoleExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the role.",
+			},
+			"auth_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "iam",
+				Description: "The auth type permitted for this role.",
+				ForceNew:    true,
+			},
+			"bound_ami_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances using this AMI ID will be permitted to log in.",
+			},
+			"bound_account_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances with this account ID in their identity document will be permitted to log in.",
+			},
+			"bound_region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances in this region will be permitted to log in.",
+			},
+			"bound_vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances associated with this VPC ID will be permitted to log in.",
+			},
+			"bound_subnet_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances associated with this subnet ID will be permitted to log in.",
+			},
+			"bound_iam_role_arn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances that match this IAM role ARN will be permitted to log in.",
+			},
+			"bound_iam_instance_profile_arn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances associated with an IAM instance profile ARN that matches this value will be permitted to log in.",
+			},
+			"role_tag": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The key of the tag on EC2 instance to use for role tags.",
+			},
+			"bound_iam_principal_arn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The IAM principal that must be authenticated using the iam auth method.",
+			},
+			"inferred_entity_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of inferencing Vault should do.",
+			},
+			"inferred_aws_region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region to search for the inferred entities in.",
+			},
+			"resolve_aws_unique_ids": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether or not Vault should resolve the bound_iam_principal_arn to an AWS Unique ID. When true, deleting a principal and recreating it with the same name won't automatically grant the new principal the same roles in Vault that the old principal had.",
+				Computed:    true,
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The TTL period of tokens issued using this role, provided as the number of minutes.",
+			},
+			"max_ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The maximum allowed lifetime of tokens issued using this role.",
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The duration in which a token should be renewed. At each renewal, the token's TTL will be set to the value of this parameter.",
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Policies to be set on tokens issued using this role.",
+			},
+			"allow_instance_migration": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "When true, allows migration of the underlying instance where the client resides. Use with caution.",
+				Computed:    true,
+			},
+			"disallow_reauthentication": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "When true, only allows a single token to be granted per instance ID.",
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the auth backend to configure.",
+				ForceNew:    true,
+				Default:     "aws",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+		},
+	}
+}
+
+func awsAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+	role := d.Get("role").(string)
+
+	path := awsAuthBackendRolePath(backend, role)
+
+	log.Printf("[DEBUG] Writing AWS auth backend role %q", path)
+	iPolicies := d.Get("policies").([]interface{})
+	policies := make([]string, 0, len(iPolicies))
+	for _, iPolicy := range iPolicies {
+		policies = append(policies, iPolicy.(string))
+	}
+
+	authType := d.Get("auth_type").(string)
+	inferred := d.Get("inferred_entity_type").(string)
+
+	data := map[string]interface{}{
+		"auth_type": authType,
+	}
+	if v, ok := d.GetOk("ttl"); ok {
+		data["ttl"] = v.(int)
+	}
+	if v, ok := d.GetOk("max_ttl"); ok {
+		data["max_ttl"] = v.(int)
+	}
+	if v, ok := d.GetOk("period"); ok {
+		data["period"] = v.(int)
+	}
+	if len(policies) > 0 {
+		data["policies"] = policies
+	}
+	if authType == "ec2" || (inferred == "ec2_instance" && authType == "iam") {
+		if v, ok := d.GetOk("bound_ami_id"); ok {
+			data["bound_ami_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_account_id"); ok {
+			data["bound_account_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_region"); ok {
+			data["bound_region"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_vpc_id"); ok {
+			data["bound_vpc_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_subnet_id"); ok {
+			data["bound_subnet_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_iam_role_arn"); ok {
+			data["bound_iam_role_arn"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_iam_instance_profile_arn"); ok {
+			data["bound_iam_instance_profile_arn"] = v.(string)
+		}
+	}
+	if authType == "ec2" {
+		if v, ok := d.GetOk("role_tag"); ok {
+			data["role_tag"] = v.(string)
+		}
+		if v, ok := d.GetOk("allow_instance_migration"); ok {
+			data["allow_instance_migration"] = v.(bool)
+		}
+		if v, ok := d.GetOk("disallow_reauthentication"); ok {
+			data["disallow_reauthentication"] = v.(bool)
+		}
+	}
+	if authType == "iam" {
+		if inferred != "" {
+			data["inferred_entity_type"] = inferred
+		}
+		if v, ok := d.GetOk("bound_iam_principal_arn"); ok {
+			data["bound_iam_principal_arn"] = v.(string)
+		}
+		if v, ok := d.GetOk("inferred_aws_region"); ok {
+			data["inferred_aws_region"] = v.(string)
+		}
+		if v, ok := d.GetOk("resolve_aws_unique_ids"); ok {
+			data["resolve_aws_unique_ids"] = v.(bool)
+		}
+	}
+	_, err := client.Logical().Write(path, data)
+
+	d.SetId(path)
+
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error writing AWS auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Wrote AWS auth backend role %q", path)
+
+	return awsAuthBackendRoleRead(d, meta)
+}
+
+func awsAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	backend, err := awsAuthBackendRoleBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("Invalid path %q for AWS auth backend role: %s", path, err)
+	}
+
+	role, err := awsAuthBackendRoleNameFromPath(path)
+	if err != nil {
+		return fmt.Errorf("Invalid path %q for AWS auth backend role: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading AWS auth backend role %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("Error reading AWS auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read AWS auth backend role %q", path)
+	if resp == nil {
+		log.Printf("[WARN] AWS auth backend role %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+	iPolicies := resp.Data["policies"].([]interface{})
+	policies := make([]string, 0, len(iPolicies))
+	for _, iPolicy := range iPolicies {
+		policies = append(policies, iPolicy.(string))
+	}
+
+	ttl, err := resp.Data["ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("Expected ttl %q to be a number, isn't", resp.Data["ttl"])
+	}
+
+	maxTTL, err := resp.Data["max_ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("Expected max_ttl %q to be a number, isn't", resp.Data["max_ttl"])
+	}
+
+	period, err := resp.Data["period"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("Expected period %q to be a number, isn't", resp.Data["period"])
+	}
+
+	d.Set("backend", backend)
+	d.Set("role", role)
+	d.Set("auth_type", resp.Data["auth_type"])
+	d.Set("bound_ami_id", resp.Data["bound_ami_id"])
+	d.Set("bound_account_id", resp.Data["bound_account_id"])
+	d.Set("bound_region", resp.Data["bound_region"])
+	d.Set("bound_vpc_id", resp.Data["bound_vpc_id"])
+	d.Set("bound_subnet_id", resp.Data["bound_subnet_id"])
+	d.Set("bound_iam_role_arn", resp.Data["bound_iam_role_arn"])
+	d.Set("bound_iam_instance_profile_arn", resp.Data["bound_iam_instance_profile_arn"])
+	d.Set("role_tag", resp.Data["role_tag"])
+	d.Set("bound_iam_principal_arn", resp.Data["bound_iam_principal_arn"])
+	d.Set("inferred_entity_type", resp.Data["inferred_entity_type"])
+	d.Set("inferred_aws_region", resp.Data["inferred_aws_region"])
+	d.Set("resolve_aws_unique_ids", resp.Data["resolve_aws_unique_ids"])
+	d.Set("ttl", ttl)
+	d.Set("max_ttl", maxTTL)
+	d.Set("period", period)
+	d.Set("policies", policies)
+	d.Set("allow_instance_migration", resp.Data["allow_instance_migration"])
+	d.Set("disallow_reauthentication", resp.Data["disallow_reauthentication"])
+
+	return nil
+}
+
+func awsAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Updating AWS auth backend role %q", path)
+	iPolicies := d.Get("policies").([]interface{})
+	policies := make([]string, 0, len(iPolicies))
+	for _, iPolicy := range iPolicies {
+		policies = append(policies, iPolicy.(string))
+	}
+
+	authType := d.Get("auth_type").(string)
+	inferred := d.Get("inferred_entity_type").(string)
+
+	data := map[string]interface{}{}
+	if v, ok := d.GetOk("ttl"); ok {
+		data["ttl"] = v.(int)
+	}
+	if v, ok := d.GetOk("max_ttl"); ok {
+		data["max_ttl"] = v.(int)
+	}
+	if v, ok := d.GetOk("period"); ok {
+		data["period"] = v.(int)
+	}
+	if len(policies) > 0 {
+		data["policies"] = policies
+	}
+	if authType == "ec2" || (inferred == "ec2_instance" && authType == "iam") {
+		if v, ok := d.GetOk("bound_ami_id"); ok {
+			data["bound_ami_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_account_id"); ok {
+			data["bound_account_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_region"); ok {
+			data["bound_region"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_vpc_id"); ok {
+			data["bound_vpc_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_subnet_id"); ok {
+			data["bound_subnet_id"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_iam_role_arn"); ok {
+			data["bound_iam_role_arn"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_iam_instance_profile_arn"); ok {
+			data["bound_iam_instance_profile_arn"] = v.(string)
+		}
+	}
+	if authType == "ec2" {
+		if v, ok := d.GetOk("role_tag"); ok {
+			data["role_tag"] = v.(string)
+		}
+		if v, ok := d.GetOk("allow_instance_migration"); ok {
+			data["allow_instance_migration"] = v.(bool)
+		}
+		if v, ok := d.GetOk("disallow_reauthentication"); ok {
+			data["disallow_reauthentication"] = v.(bool)
+		}
+	}
+	if authType == "iam" {
+		if inferred != "" {
+			data["inferred_entity_type"] = inferred
+		}
+		if v, ok := d.GetOk("bound_iam_principal_arn"); ok {
+			data["bound_iam_principal_arn"] = v.(string)
+		}
+		if v, ok := d.GetOk("inferred_aws_region"); ok {
+			data["inferred_aws_region"] = v.(string)
+		}
+		if v, ok := d.GetOk("resolve_aws_unique_ids"); ok {
+			data["resolve_aws_unique_ids"] = v.(bool)
+		}
+	}
+
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("Error updating AWS auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated AWS auth backend role %q", path)
+
+	return awsAuthBackendRoleRead(d, meta)
+}
+
+func awsAuthBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting AWS auth backend role %q", path)
+	_, err := client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("Error deleting AWS auth backend role %q", path)
+	}
+	log.Printf("[DEBUG] Deleted AWS auth backend role %q", path)
+
+	return nil
+}
+
+func awsAuthBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	log.Printf("[DEBUG] Checking if AWS auth backend role %q exists", path)
+
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("Error checking if AWS auth backend role %q exists: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if AWS auth backend role %q exists", path)
+
+	return resp != nil, nil
+}
+
+func awsAuthBackendRolePath(backend, role string) string {
+	return "auth/" + strings.Trim(backend, "/") + "/role/" + strings.Trim(role, "/")
+}
+
+func awsAuthBackendRoleNameFromPath(path string) (string, error) {
+	if !awsAuthBackendRoleNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no role found")
+	}
+	res := awsAuthBackendRoleNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}
+
+func awsAuthBackendRoleBackendFromPath(path string) (string, error) {
+	if !awsAuthBackendRoleBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := awsAuthBackendRoleBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}

--- a/vault/resource_aws_auth_backend_role_test.go
+++ b/vault/resource_aws_auth_backend_role_test.go
@@ -1,0 +1,376 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestAccAWSAuthBackendRole_importInferred(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_inferred(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+			{
+				ResourceName:      "vault_aws_auth_backend_role.role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendRole_importEC2(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_ec2(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+			{
+				ResourceName:      "vault_aws_auth_backend_role.role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendRole_importIAM(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_iam(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+			{
+				ResourceName:      "vault_aws_auth_backend_role.role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendRole_inferred(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_inferred(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendRole_ec2(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_ec2(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendRole_iam(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_iam(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendRole_iamUpdate(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_iam(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+			{
+				Config: testAccAWSAuthBackendRoleConfig_iamUpdate(backend, role),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
+						"bound_iam_principal_arn", "arn:aws:iam::123456789012:role/MyRole/*"),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
+						"ttl", "30"),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
+						"max_ttl", "60"),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
+						"policies.#", "2"),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
+						"policies.1", "dev"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAuthBackendRoleDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_aws_auth_backend_role" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error checking for AWS auth backend role %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("AWS auth backend role %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccAWSAuthBackendRoleCheck_attrs(backend, role string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_aws_auth_backend_role.role"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		endpoint := instanceState.ID
+
+		if endpoint != "auth/"+backend+"/role/"+role {
+			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/"+backend+"/role/"+role, endpoint)
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		resp, err := client.Logical().Read(endpoint)
+		if err != nil {
+			return fmt.Errorf("%q doesn't exist", endpoint)
+		}
+
+		attrs := map[string]string{
+			"auth_type":                      "auth_type",
+			"bound_ami_id":                   "bound_ami_id",
+			"bound_account_id":               "bound_account_id",
+			"bound_region":                   "bound_region",
+			"bound_vpc_id":                   "bound_vpc_id",
+			"bound_subnet_id":                "bound_subnet_id",
+			"bound_iam_role_arn":             "bound_iam_role_arn",
+			"bound_iam_instance_profile_arn": "bound_iam_instance_profile_arn",
+			"role_tag":                       "role_tag",
+			"bound_iam_principal_arn":        "bound_iam_principal_arn",
+			"inferred_entity_type":           "inferred_entity_type",
+			"inferred_aws_region":            "inferred_aws_region",
+			"resolve_aws_unique_ids":         "resolve_aws_unique_ids",
+			"ttl":                       "ttl",
+			"max_ttl":                   "max_ttl",
+			"period":                    "period",
+			"policies":                  "policies",
+			"allow_instance_migration":  "allow_instance_migration",
+			"disallow_reauthentication": "disallow_reauthentication",
+		}
+		for stateAttr, apiAttr := range attrs {
+			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+				continue
+			}
+			var match bool
+			switch resp.Data[apiAttr].(type) {
+			case json.Number:
+				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
+				if err != nil {
+					return fmt.Errorf("Expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
+				}
+				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
+				if err != nil {
+					return fmt.Errorf("Expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
+				}
+				match = apiData == stateData
+			case bool:
+				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
+					match = true
+				} else {
+					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
+					if err != nil {
+						return fmt.Errorf("Expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
+					}
+					match = resp.Data[apiAttr] == stateData
+				}
+			case []interface{}:
+				apiData := resp.Data[apiAttr].([]interface{})
+				length := instanceState.Attributes[stateAttr+".#"]
+				if length == "" {
+					if len(resp.Data[apiAttr].([]interface{})) != 0 {
+						return fmt.Errorf("Expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
+					}
+					match = true
+				} else {
+					count, err := strconv.Atoi(length)
+					if err != nil {
+						return fmt.Errorf("Expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
+					}
+					if count != len(apiData) {
+						return fmt.Errorf("Expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
+					}
+					for i := 0; i < count; i++ {
+						stateData := instanceState.Attributes[stateAttr+"."+strconv.Itoa(i)]
+						if stateData != apiData[i] {
+							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be %q, got %q", i, apiAttr, stateAttr, endpoint, stateData, apiData[i])
+						}
+					}
+					match = true
+				}
+			default:
+				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+			}
+			if !match {
+				return fmt.Errorf("Expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
+			}
+		}
+		return nil
+	}
+}
+
+func testAccAWSAuthBackendRoleConfig_inferred(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+
+resource "vault_aws_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "iam"
+  bound_ami_id = "ami-8c1be5f6"
+  bound_account_id = "123456789012"
+  bound_vpc_id = "vpc-b61106d4"
+  bound_subnet_id = "vpc-a33128f1"
+  bound_iam_role_arn = "arn:aws:iam::123456789012:role/S3Access"
+  bound_iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/Webserver"
+  inferred_entity_type = "ec2_instance"
+  inferred_aws_region = "us-east-1"
+  ttl = 60
+  max_ttl = 120
+  policies = ["default", "dev", "prod"]
+}`, backend, role)
+}
+
+func testAccAWSAuthBackendRoleConfig_iam(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+
+resource "vault_aws_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "iam"
+  bound_iam_principal_arn = "arn:aws:iam::123456789012:role/*"
+  resolve_aws_unique_ids = true
+  ttl = 60
+  max_ttl = 120
+  policies = ["default", "dev", "prod"]
+}`, backend, role)
+}
+
+func testAccAWSAuthBackendRoleConfig_iamUpdate(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+
+resource "vault_aws_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "iam"
+  bound_iam_principal_arn = "arn:aws:iam::123456789012:role/MyRole/*"
+  resolve_aws_unique_ids = true
+  ttl = 30
+  max_ttl = 60
+  policies = ["default", "dev"]
+}`, backend, role)
+}
+
+func testAccAWSAuthBackendRoleConfig_ec2(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+
+resource "vault_aws_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "ec2"
+  bound_ami_id = "ami-8c1be5f6"
+  bound_account_id = "123456789012"
+  bound_region = "us-east-1"
+  bound_vpc_id = "vpc-b61106d4"
+  bound_subnet_id = "vpc-a33128f1"
+  bound_iam_role_arn = "arn:aws:iam::123456789012:role/S3Access"
+  bound_iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/Webserver"
+  role_tag = "VaultRoleTag"
+  allow_instance_migration = true
+  disallow_reauthentication = true
+  ttl = 60
+  max_ttl = 120
+  policies = ["default", "dev", "prod"]
+}`, backend, role)
+}

--- a/website/docs/r/aws_auth_backend_role.md
+++ b/website/docs/r/aws_auth_backend_role.md
@@ -1,0 +1,146 @@
+---
+layout: "vault"
+page_title: "Vault: vault_aws_auth_backend_role resource"
+sidebar_current: "docs-vault-aws-auth-backend-role"
+description: |-
+  Manages AWS auth backend roles in Vault.
+---
+
+# vault\_aws\_auth\_backend\_role
+
+Manages an AWS auth backend role in a Vault server. Roles constrain the
+instances or principals that can perform the login operation against the
+backend. See the [Vault
+documentation](https://www.vaultproject.io/docs/auth/aws.html) for more
+information.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+}
+
+resource "vault_aws_auth_backend_role" "example" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "test-role"
+  auth_type = "iam"
+  bound_ami_id = "ami-8c1be5f6"
+  bound_account_id = "123456789012"
+  bound_vpc_id = "vpc-b61106d4"
+  bound_subnet_id = "vpc-133128f1"
+  bound_iam_role_arn = "arn:aws:iam::123456789012:role/MyRole"
+  bound_iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/MyProfile"
+  inferred_entity_type = "ec2_instance"
+  inferred_aws_region = "us-east-1"
+  ttl = 60
+  max_ttl = 120
+  policies = ["default", "dev", "prod"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `role` - (Required) The name of the role.
+
+* `auth_type` - (Optional) The auth type permitted for this role. Valid choices
+  are `ec2` and `iam`. Defaults to `iam`.
+
+* `bound_ami_id` - (Optional) If set, defines a constraint on the EC2 instances
+  that can perform the login operation that they should be using the AMI ID
+  specified by this field. `auth_type` must be set to `ec2` or
+  `inferred_entity_type` must be set to `ec2_instance` to use this constraint.
+
+* `bound_account_id` - (Optional) If set, defines a constraint on the EC2
+  instances that can perform the login operation that they should be using the
+  account ID specified by this field. `auth_type` must be set to `ec2` or
+  `inferred_entity_type` must be set to `ec2_instance` to use this constraint.
+
+* `bound_region` - (Optional) If set, defines a constraint on the EC2 instances
+  that can perform the login operation that the region in their identity
+  document must match the one specified by this field. `auth_type` must be set
+  to `ec2` or `inferred_entity_type` must be set to `ec2_instance` to use this
+  constraint.
+
+* `bound_vpc_id` - (Optional) If set, defines a constraint on the EC2 instances
+  that can perform the login operation that they be associated with the VPC ID
+  that matches the value specified by this field. `auth_type` must be set to
+  `ec2` or `inferred_entity_type` must be set to `ec2_instance` to use this
+  constraint.
+
+* `bound_subnet_id` - (Optional) If set, defines a constraint on the EC2
+  instances that can perform the login operation that they be associated with
+  the subnet ID that matches the value specified by this field. `auth_type`
+  must be set to `ec2` or `inferred_entity_type` must be set to `ec2_instance`
+  to use this constraint.
+
+* `bound_iam_role_arn` - (Optional) If set, defines a constraint on the EC2
+  instances that can perform the login operation that they must match the IAM
+  role ARN specified by this field. `auth_type` must be set to `ec2` or
+  `inferred_entity_type` must be set to `ec2_instance` to use this constraint.
+
+* `bound_iam_instance_profile_arn` - (Optional) If set, defines a constraint on
+  the EC2 instances that can perform the login operation that they must be
+  associated with an IAM instance profile ARN which has a prefix that matches
+  the value specified by this field. The value is prefix-matched as though it
+  were a glob ending in `*`. `auth_type` must be set to `ec2` or
+  `inferred_entity_type` must be set to `ec2_instance` to use this constraint.
+
+* `role_tag` - (Optional) If set, enable role tags for this role. The value set
+  for this field should be the key of the tag on the EC2 instance. `auth_type`
+  must be set to `ec2` or `inferred_entity_type` must be set to `ec2_instance`
+  to use this constraint.
+
+* `bound_iam_principal_arn` - (Optional) If set, defines the IAM principal that
+  must be authenticated when `auth_type` is set to `iam`. Wildcards are
+  supported at the end of the ARN.
+
+* `inferred_entity_type` - (Optional) If set, instructs Vault to turn on
+  inferencing. The only valid value is `ec2_instance`, which instructs Vault to
+  infer that the role comes from an EC2 instance in an IAM instance profile.
+  This only applies when `auth_type` is set to `iam`.
+
+* `inferred_aws_region` - (Optional) When `inferred_entity_type` is set, this
+  is the region to search for the inferred entities. Required if
+  `inferred_entity_type` is set. This only applies when `auth_type` is set to
+  `iam`.
+
+* `resolve_aws_unique_ids` - (Optional) If set to `true`, the
+  `bound_iam_principal_arn` is resolved to an [AWS Unique
+  ID](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids)
+  for the bound principal ARN. This field is ignored when
+  `bound_iam_principal_arn` ends in a wildcard. Resolving to unique IDs more
+  closely mimics the behavior of AWS services in that if an IAM user or role is
+  deleted and a new one is recreated with the same name, those new users or
+  roles won't get access to roles in Vault that were permissioned to the prioer
+  principals of the same name. Defaults to `true`. Once set to `true`, this
+  cannot be changed to `false`--the role must be deleted and recreated, with
+  the value set to `true`.
+
+* `ttl` - (Optional) The TTL period of tokens issued using this role, provided
+  as a number of minutes.
+
+* `max_ttl` - (Optional) The maximum allowed lifetime of tokens issued using
+  this role, provided as a number of minutes.
+
+* `period` - (Optional) If set, indicates that the token generated using this
+  role should never expire. The token should be renewed within the duration
+  specified by this value. At each renewal, the token's TTL will be set to the
+  value of this field. The maximum allowed lifetime of token issued using this
+  role. Specified as a number of minutes.
+
+* `policies` - (Optional) An array of strings specifying the policies to be set
+  on tokens issued using this role.
+
+* `allow_instance_migration` - (Optional) If set to `true`, allows migration of
+  the underlying instance where the client resides.
+
+* `disallow_reauthentication` - (Optional) IF set to `true`, only allows a
+  single token to be granted per instance ID. This can only be set when
+  `auth_type` is set to `ec2`.
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.


### PR DESCRIPTION
Implements the AWS auth backend role resource, allowing users to set
constraints on what can authenticate using an AWS auth backend.