### PR TITLE
Add the ability to generate tokens from AWS auth backend.

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -92,6 +92,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_auth_backend":              authBackendResource(),
 			"vault_aws_auth_backend_cert":     awsAuthBackendCertResource(),
 			"vault_aws_auth_backend_client":   awsAuthBackendClientResource(),
+			"vault_aws_auth_backend_login":    awsAuthBackendLoginResource(),
 			"vault_aws_auth_backend_role":     awsAuthBackendRoleResource(),
 			"vault_aws_auth_backend_sts_role": awsAuthBackendSTSRoleResource(),
 			"vault_aws_secret_backend":        awsSecretBackendResource(),

--- a/vault/resource_aws_auth_backend_login.go
+++ b/vault/resource_aws_auth_backend_login.go
@@ -1,0 +1,250 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func awsAuthBackendLoginResource() *schema.Resource {
+	return &schema.Resource{
+		Create: awsAuthBackendLoginCreate,
+		Read:   awsAuthBackendLoginRead,
+		Delete: awsAuthBackendLoginDelete,
+
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "AWS Auth Backend to read the token from.",
+				ForceNew:    true,
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "AWS Auth Role to read the token from.",
+				ForceNew:    true,
+			},
+
+			"identity": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Base64-encoded EC2 instance identity document to authenticate with.",
+				ForceNew:    true,
+			},
+
+			"signature": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Base64-encoded SHA256 RSA signature of the instance identtiy document to authenticate with.",
+				ForceNew:    true,
+			},
+
+			"pkcs7": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "PKCS7 signature of the identity document to authenticate with, with all newline characters removed.",
+				ForceNew:    true,
+			},
+
+			"nonce": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The nonce to be used for subsequent login requests.",
+				Computed:    true,
+				ForceNew:    true,
+			},
+
+			"iam_http_request_method": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The HTTP method used in the signed request.",
+				ForceNew:    true,
+			},
+
+			"iam_request_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Base64-encoded HTTP URL used in the signed request.",
+				ForceNew:    true,
+			},
+
+			"iam_request_body": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Base64-encoded body of the signed request.",
+				ForceNew:    true,
+			},
+
+			"iam_request_headers": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Base64-encoded, JSON serialized representation of the sts:GetCallerIdentity HTTP request headers.",
+				ForceNew:    true,
+			},
+
+			"lease_duration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Lease duration in seconds relative to the time in lease_start_time.",
+			},
+
+			"lease_start_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time at which the lease was read, using the clock of the system where Terraform was running",
+			},
+
+			"renewable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if the duration of this lease can be extended through renewal.",
+			},
+
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The metadata reported by the Vault server.",
+				Elem:        schema.TypeString,
+			},
+
+			"auth_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The auth method used to generate this token.",
+			},
+
+			"policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The policies assigned to this token.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"accessor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The accessor returned from Vault for this token.",
+			},
+
+			"client_token": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The token returned by Vault.",
+				Sensitive:   true,
+			},
+		},
+	}
+}
+
+func awsAuthBackendLoginCreate(d *schema.ResourceData, meta interface{}) error {
+	return awsAuthBackendLoginRead(d, meta)
+}
+
+func awsAuthBackendLoginRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := strings.Trim(d.Get("backend").(string), "/")
+	path := "auth/" + backend + "/login"
+
+	data := map[string]interface{}{}
+
+	if v, ok := d.GetOk("role"); ok {
+		data["role"] = v
+	}
+
+	if v, ok := d.GetOk("identity"); ok {
+		data["identity"] = v
+	}
+
+	if v, ok := d.GetOk("signature"); ok {
+		data["signature"] = v
+	}
+
+	if v, ok := d.GetOk("pkcs7"); ok {
+		data["pkcs7"] = v
+	}
+
+	if v, ok := d.GetOk("nonce"); ok {
+		data["nonce"] = v
+	}
+
+	if v, ok := d.GetOk("iam_http_request_method"); ok {
+		data["iam_http_request_method"] = v
+	}
+
+	if v, ok := d.GetOk("iam_request_url"); ok {
+		data["iam_request_url"] = v
+	}
+
+	if v, ok := d.GetOk("iam_request_body"); ok {
+		data["iam_request_body"] = v
+	}
+
+	if v, ok := d.GetOk("iam_request_headers"); ok {
+		data["iam_request_headers"] = v
+	}
+
+	log.Printf("[DEBUG] Reading %q from Vault", path)
+	secret, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error reading from Vault: %s", err)
+	}
+	log.Printf("[DEBUG] Read %q from Vault", path)
+
+	id := "accessor:" + secret.Auth.Accessor
+	nonce, ok := secret.Auth.Metadata["nonce"]
+	if ok {
+		// when nonce is set, prefer that over accessor
+		// as instances can only auth once every so often and
+		// need the nonce to return the token, so if we ever
+		// want to support import, we can just import the nonce
+		// and use that.
+		//
+		// however, when using iam auth, the nonce isn't set, so
+		// we can't use that solely as the identifier
+		//
+		// to help keep things straight, we prefix with the type of
+		// ID that's actually set
+		id = "nonce:" + nonce
+	}
+	d.SetId(id)
+	d.Set("lease_id", secret.LeaseID)
+	d.Set("lease_duration", secret.Auth.LeaseDuration)
+	d.Set("lease_start_time", time.Now().Format(time.RFC3339))
+	d.Set("renewable", secret.Auth.Renewable)
+	d.Set("metadata", secret.Auth.Metadata)
+	d.Set("policies", secret.Auth.Policies)
+	d.Set("accessor", secret.Auth.Accessor)
+	d.Set("client_token", secret.Auth.ClientToken)
+	d.Set("nonce", nonce)
+
+	return nil
+}
+
+func awsAuthBackendLoginDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	accessor := d.Get("accessor").(string)
+	token, ok := d.GetOk("client_token")
+	if !ok {
+		log.Printf("[DEBUG] Token %q has no token set in state, removing from state", accessor)
+		return nil
+	}
+	log.Printf("[DEBUG] Revoking token %q", accessor)
+	err := client.Auth().Token().RevokeTree(token.(string))
+	if err != nil {
+		log.Printf("[ERROR] Error revoking token %q: %s", accessor, err)
+		return err
+	}
+	log.Printf("[DEBUG] Revoked token %q", accessor)
+	return nil
+}

--- a/vault/resource_aws_auth_backend_login_test.go
+++ b/vault/resource_aws_auth_backend_login_test.go
@@ -1,0 +1,275 @@
+package vault
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSAuthBackendLogin_iamIdentity(t *testing.T) {
+	mountPath := acctest.RandomWithPrefix("tf-test-aws")
+	roleName := acctest.RandomWithPrefix("tf-test")
+	accessKey, secretKey := getTestAWSCreds(t)
+
+	awsConfig := &aws.Config{
+		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
+		HTTPClient:  cleanhttp.DefaultClient(),
+	}
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		t.Errorf("Error creating AWS session: %s", err)
+	}
+	stsService := sts.New(sess)
+	testIdentity, err := stsService.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Errorf("Error obtaining identity document: %s", err)
+	}
+	stsRequest, _ := stsService.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
+	stsRequest.Sign()
+	loginDataHeaders, err := json.Marshal(stsRequest.HTTPRequest.Header)
+	if err != nil {
+		t.Errorf("Error marshaling login headers: %s", err)
+	}
+	loginDataBody, err := ioutil.ReadAll(stsRequest.HTTPRequest.Body)
+	if err != nil {
+		t.Errorf("Error reading login body: %s", err)
+	}
+	reqMethod := stsRequest.HTTPRequest.Method
+	reqURL := base64.StdEncoding.EncodeToString([]byte(stsRequest.HTTPRequest.URL.String()))
+	reqHeaders := base64.StdEncoding.EncodeToString(loginDataHeaders)
+	reqBody := base64.StdEncoding.EncodeToString(loginDataBody)
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSAuthBackendLoginConfig_iamIdentity(mountPath, accessKey, secretKey, reqMethod, reqURL, reqHeaders, reqBody, roleName, *testIdentity.Arn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vault_aws_auth_backend_login.test", "client_token"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendLogin_pkcs7(t *testing.T) {
+	mountPath := acctest.RandomWithPrefix("tf-test-aws")
+	roleName := acctest.RandomWithPrefix("tf-test")
+	accessKey, secretKey := getTestAWSCreds(t)
+
+	awsConfig := &aws.Config{
+		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
+		HTTPClient:  cleanhttp.DefaultClient(),
+	}
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		t.Errorf("Error creating AWS session: %s", err)
+	}
+	metadata := ec2metadata.New(sess)
+
+	if !metadata.Available() {
+		t.Skip("Not running on EC2 instance, can't test ec2 auth methods.")
+	}
+
+	iamInfo, err := metadata.IAMInfo()
+	if err != nil {
+		t.Errorf("Error retrieving IAM info for instance: %s", err)
+	}
+	arn := iamInfo.InstanceProfileArn
+
+	doc, err := metadata.GetInstanceIdentityDocument()
+	if err != nil {
+		t.Errorf("Error retrieving instance identity document: %s", err)
+	}
+	ami := doc.ImageID
+	account := doc.AccountID
+
+	pkcs7, err := metadata.GetDynamicData("instance-identity/pkcs7")
+	if err != nil {
+		t.Errorf("Error retrieving pkcs7 signature: %s", err)
+	}
+	pkcs7 = strings.Replace(pkcs7, "\n", "", -1)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSAuthBackendLoginConfig_pkcs7(mountPath, accessKey, secretKey, roleName, ami, account, arn, pkcs7),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vault_aws_auth_backend_login.test", "client_token"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAuthBackendLogin_ec2Identity(t *testing.T) {
+	mountPath := acctest.RandomWithPrefix("tf-test-aws")
+	roleName := acctest.RandomWithPrefix("tf-test")
+	accessKey, secretKey := getTestAWSCreds(t)
+
+	awsConfig := &aws.Config{
+		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
+		HTTPClient:  cleanhttp.DefaultClient(),
+	}
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		t.Errorf("Error creating AWS session: %s", err)
+	}
+	metadata := ec2metadata.New(sess)
+
+	if !metadata.Available() {
+		t.Skip("Not running on EC2 instance, can't test ec2 auth methods.")
+	}
+
+	iamInfo, err := metadata.IAMInfo()
+	if err != nil {
+		t.Errorf("Error retrieving IAM info for instance: %s", err)
+	}
+	arn := iamInfo.InstanceProfileArn
+
+	doc, err := metadata.GetInstanceIdentityDocument()
+	if err != nil {
+		t.Errorf("Error retrieving instance identity document: %s", err)
+	}
+	ami := doc.ImageID
+	account := doc.AccountID
+
+	identity, err := metadata.GetDynamicData("instance-identity/document")
+	if err != nil {
+		t.Errorf("Error retrieving raw identity: %s", err)
+	}
+	identity = base64.StdEncoding.EncodeToString([]byte(identity))
+
+	sig, err := metadata.GetDynamicData("instance-identity/signature")
+	if err != nil {
+		t.Errorf("Error retrieving signature: %s", err)
+	}
+	sig = strings.Replace(sig, "\n", "", -1)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSAuthBackendLoginConfig_ec2Identity(mountPath, accessKey, secretKey, roleName, ami, account, arn, identity, sig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vault_aws_auth_backend_login.test", "client_token"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSAuthBackendLoginConfig_iamIdentity(mountPath, accessKey, secretKey, reqMethod, reqURL, reqHeaders, reqBody, roleName, arn string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+
+resource "vault_aws_auth_backend_client" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  access_key = "%s"
+  secret_key = "%s"
+}
+
+resource "vault_aws_auth_backend_role" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "iam"
+  bound_iam_principal_arn = "%s"
+  policies = ["default"]
+  depends_on = ["vault_aws_auth_backend_client.test"]
+}
+
+resource "vault_aws_auth_backend_login" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "${vault_aws_auth_backend_role.test.role}"
+  iam_http_request_method = "%s"
+  iam_request_url = "%s"
+  iam_request_headers = "%s"
+  iam_request_body = "%s"
+}
+`, mountPath, accessKey, secretKey, roleName, arn, reqMethod, reqURL, reqHeaders, reqBody)
+}
+
+func testAccDataSourceAWSAuthBackendLoginConfig_ec2Identity(mountPath, accessKey, secretKey, roleName, ami, account, arn, identity, signature string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+
+resource "vault_aws_auth_backend_client" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  access_key = "%s"
+  secret_key = "%s"
+}
+
+resource "vault_aws_auth_backend_role" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "ec2"
+  policies = ["default"]
+  bound_ami_id = "%s"
+  bound_account_id = "%s"
+  bound_iam_instance_profile_arn = "%s"
+
+  depends_on = ["vault_aws_auth_backend_client.test"]
+}
+
+resource "vault_aws_auth_backend_login" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "${vault_aws_auth_backend_role.test.role}"
+  identity = "%s"
+  signature = "%s"
+}
+`, mountPath, accessKey, secretKey, roleName, ami, account, arn, identity, signature)
+}
+
+func testAccDataSourceAWSAuthBackendLoginConfig_pkcs7(mountPath, accessKey, secretKey, roleName, ami, account, arn, pkcs7 string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+
+resource "vault_aws_auth_backend_client" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  access_key = "%s"
+  secret_key = "%s"
+}
+
+resource "vault_aws_auth_backend_role" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "ec2"
+  policies = ["default"]
+  bound_ami_id = "%s"
+  bound_account_id = "%s"
+  bound_iam_instance_profile_arn = "%s"
+
+  depends_on = ["vault_aws_auth_backend_client.test"]
+}
+
+resource "vault_aws_auth_backend_login" "test" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "${vault_aws_auth_backend_role.test.role}"
+  pkcs7 = "%s"
+}
+`, mountPath, accessKey, secretKey, roleName, ami, account, arn, pkcs7)
+}

--- a/website/docs/r/aws_auth_backend_login.md
+++ b/website/docs/r/aws_auth_backend_login.md
@@ -1,0 +1,112 @@
+---
+layout: "vault"
+page_title: "Vault: vault_aws_auth_backend_login resource"
+sidebar_current: "docs-vault-aws-auth-backend-login"
+description: |-
+  Manages Vault tokens acquired using the AWS auth backend.
+---
+
+# vault\_aws\_auth\_backend\_login
+
+Logs into a Vault server using an AWS auth backend. Login can be
+accomplished using a signed identity request from IAM or using ec2
+instance metadata. For more informtion, see the [Vault
+documentation](https://www.vaultproject.io/docs/auth/aws.html).
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+}
+
+resource "vault_aws_auth_backend_client" "example" {
+  backend    = "${vault_auth_backend.aws.path}"
+  access_key = "123456789012"
+  secret_key = "AWSSECRETKEYGOESHERE"
+}
+
+resource "vault_aws_auth_backend_role" "example" {
+  backend                        = "${vault_auth_backend.aws.path}"
+  role                           = "test-role"
+  auth_type                      = "ec2"
+  bound_ami_id                   = "ami-8c1be5f6"
+  bound_account_id               = "123456789012"
+  bound_vpc_id                   = "vpc-b61106d4"
+  bound_subnet_id                = "vpc-133128f1"
+  bound_iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/MyProfile"
+  ttl                            = 60
+  max_ttl                        = 120
+  policies                       = ["default", "dev", "prod"]
+
+  depends_on                     = ["vault_aws_auth_backend_client.example"]
+}
+
+resource "vault_aws_auth_backend_login" "example" {
+  backend = "${vault_auth_backend.example.path}"
+  role = "${vault_aws_auth_backend_role.example.role}"
+  identity = "BASE64ENCODEDIDENTITYDOCUMENT"
+  signature = "BASE64ENCODEDSHA256IDENTITYDOCUMENTSIGNATURE"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `backend` - (Optional) The unique name of the AWS auth backend. Defaults to
+  'aws'.
+
+* `role` - (Optional) The name of the AWS auth backend role to create tokens
+  against.
+
+* `identity` - (Optional) The base64-encoded EC2 instance identity document to
+  authenticate with. Can be retrieved from the EC2 metadata server.
+
+* `signature` - (Optional) The base64-encoded SHA256 RSA signature of the
+  instance identity document to authenticate with, with all newline characters
+  removed. Can be retrieved from the EC2 metadata server.
+
+* `pkcs7` - (Optional) The PKCS#7 signature of the identity document to
+  authenticate with, with all newline characters removed. Can be retrieved from
+  the EC2 metadata server.
+
+* `nonce` - (Optional) The unique nonce to be used for login requests. Can be
+  set to a user-specified value, or will contain the server-generated value
+  once a token is issued. EC2 instances can only acquire a single token until
+  the whitelist is tidied again unless they keep track of this nonce.e
+
+* `iam_http_request_method` - (Optional) The HTTP method used in the signed IAM
+  request.
+
+* `iam_request_url` - (Optional) The base64-encoded HTTP URL used in the signed
+  request.
+
+* `iam_request_body` - (Optional) The base64-encoded body of the signed
+  request.
+
+* `iam_request_headers` - (Optional) The base64-encoded, JSON serialized
+  representation of the GetCallerIdentity HTTP request headers.
+
+## Attributes Reference
+
+In addition to the fields above, the following attributes are also exposed:
+
+* `lease_duration` - The duration in seconds the token will be valid, relative
+  to the time in `lease_start_time`.
+
+* `lease_start_time` - The approximate time at which the token was created,
+  using the clock of the system where Terraform was running.
+
+* `renewable` - Set to true if the token can be extended through renewal.
+
+* `metadata` - A map of information returned by the Vault server about the
+  authentication used to generate this token.
+
+* `auth_type` - The authentication type used to generate this token.
+
+* `policies` - The Vault policies assigned to this token.
+
+* `accessor` - The token's accessor.
+
+* `client_token` - The token returned by Vault.

--- a/website/docs/r/aws_auth_backend_login.md
+++ b/website/docs/r/aws_auth_backend_login.md
@@ -74,7 +74,7 @@ The following arguments are supported:
 * `nonce` - (Optional) The unique nonce to be used for login requests. Can be
   set to a user-specified value, or will contain the server-generated value
   once a token is issued. EC2 instances can only acquire a single token until
-  the whitelist is tidied again unless they keep track of this nonce.e
+  the whitelist is tidied again unless they keep track of this nonce.
 
 * `iam_http_request_method` - (Optional) The HTTP method used in the signed IAM
   request.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -39,6 +39,10 @@
                         <li<%= sidebar_current("docs-vault-resource-aws-auth-backend-client") %>>
                             <a href="/docs/providers/vault/r/aws_auth_backend_client.html">vault_aws_auth_backend_client</a>
                         </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-aws-auth-backend-login") %>>
+                            <a href="/docs/providers/vault/r/aws_auth_backend_login.html">vault_aws_auth_backend_login</a>
+                        </li>
 			
                         <li<%= sidebar_current("docs-vault-resource-aws-auth-backend-sts-role") %>>
 			    <a href="/docs/providers/vault/r/aws_auth_backend_sts_role.html">vault_aws_auth_backend_sts_role</a>


### PR DESCRIPTION
Add the vault_aws_auth_backend_login resource, which manages a "login",
basically a token session. Ideally, this would be a data source that
would generate a token on every read, and that's how the implementation
started. However, because the EC2 instance auth method only allows a
single authentication per host for a set amount of time, the refresh
cycle made this useless as a data source--an API error would be thrown
on every subsequent plan until the instance's identity was removed from
the whitelist. Which isn't ideal.

So instead this became a resource, so it could manage the requisite
state (namely, the nonce) that is needed to reissue tokens to an
instance that is already present in the whitelist. I opted to use the
Read method to do the actual token creation, rather than in the Create
function, to make this work essentially like a data source, issuing a
new token on every call. The plus side of this is that the resource
"just works". This could also be managed more like a typical resource,
with the Create function creating the token, but due to limitations in
the API, we can't read all the information about a token back, so the
usefulness of that approach is more limited.

Testing of this is weird, largely because Vault requires an EC2 instance
be actually running to issue tokens on its auth info. And access to
EC2's metadata server is needed, as well. Rather than trying to stand up
EC2 instances and SSH into them as part of the tests, the tests that
require the metadata server are skipped if the metadata server is
unavailable.