### PR TITLE
Check for TF_ACC before retrieving metadata info.

### DIFF
--- a/vault/resource_aws_auth_backend_login_test.go
+++ b/vault/resource_aws_auth_backend_login_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -65,6 +66,9 @@ func TestAccAWSAuthBackendLogin_iamIdentity(t *testing.T) {
 }
 
 func TestAccAWSAuthBackendLogin_pkcs7(t *testing.T) {
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(resource.TestEnvVar + " not set.")
+	}
 	mountPath := acctest.RandomWithPrefix("tf-test-aws")
 	roleName := acctest.RandomWithPrefix("tf-test")
 	accessKey, secretKey := getTestAWSCreds(t)
@@ -117,6 +121,9 @@ func TestAccAWSAuthBackendLogin_pkcs7(t *testing.T) {
 }
 
 func TestAccAWSAuthBackendLogin_ec2Identity(t *testing.T) {
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(resource.TestEnvVar + " not set.")
+	}
 	mountPath := acctest.RandomWithPrefix("tf-test-aws")
 	roleName := acctest.RandomWithPrefix("tf-test")
 	accessKey, secretKey := getTestAWSCreds(t)


### PR DESCRIPTION
Even though our tests that rely on metadata info won't run if TF_ACC
isn't set, they'll still try to retrieve metadata info. Because of the
short timeout for unit tests, this causes the tests to fail.

We also get a weird error about the endpoint not being found, even
though the Available method should gate that, but that's a matter for a
different day.