### PR TITLE
If secret has been deleted from vault, drop it from the state.

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -147,6 +147,10 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error reading from Vault: %s", err)
 		}
+		if secret == nil {
+			d.SetId("")
+			return nil
+		}
 
 		log.Printf("[DEBUG] secret: %#v", secret)
 

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -148,6 +148,7 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error reading from Vault: %s", err)
 		}
 		if secret == nil {
+			log.Printf("vault_generic_secret at %s has been deleted, so removing it from state", path)
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
I cribbed this from https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_ami.go#L151, might not be the right way of signalling the resource has been deleted.

Fixes #55