### PR TITLE
Allow secret backend role paths to contain forward-slashes

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -84,8 +84,8 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
 	path := d.Id()
-	pathPieces := strings.Split(path, "/")
-	if len(pathPieces) != 3 || pathPieces[1] != "roles" {
+	pathPieces := strings.Split(path, "/roles/")
+	if len(pathPieces) != 2 {
 		return fmt.Errorf("Invalid id %q; must be {backend}/roles/{name}", path)
 	}
 
@@ -103,7 +103,7 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("policy", secret.Data["policy"])
 	d.Set("policy_arn", secret.Data["arn"])
 	d.Set("backend", pathPieces[0])
-	d.Set("name", pathPieces[2])
+	d.Set("name", pathPieces[1])
 	return nil
 }
 


### PR DESCRIPTION
The current validation assumes that the only `/`'s in a vault path are on either side of 'roles', when Vault actually allows for any number of non-consecutive `/`'s. We use additional slashes for namespacing in our Vault paths:

```
/users/aws/<account_name>/
/users/<some_other_backend>/
/services/aws/<account_name>/
```

This commit changes the validation to splitting the string by `/roles/`, allowing for any number of `/` on either side.