### PR TITLE
Allow secret backend role paths to contain forward-slashes

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -84,8 +84,8 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
 	path := d.Id()
-	pathPieces := strings.Split(path, "/")
-	if len(pathPieces) != 3 || pathPieces[1] != "roles" {
+	pathPieces := strings.Split(path, "/roles/")
+	if len(pathPieces) != 2 {
 		return fmt.Errorf("Invalid id %q; must be {backend}/roles/{name}", path)
 	}
 
@@ -103,7 +103,7 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("policy", secret.Data["policy"])
 	d.Set("policy_arn", secret.Data["arn"])
 	d.Set("backend", pathPieces[0])
-	d.Set("name", pathPieces[2])
+	d.Set("name", pathPieces[1])
 	return nil
 }
 


### PR DESCRIPTION
Currently vault_aws_secret_backend_role performs a validation on the role path. That validation splits the string by `/`, making the assumption that there are no forward slashes outside of those surrounding "roles". However, Vault has no such restriction on forward slashes. We use slashes in our generate Vault paths for namespacing purposes. An example:

```
/users/aws/<account>/
/services/aws/<account>/
```

vault_aws_secret_backend_role would split such a path incorrectly. This commit instead splits the string by the more complete `/roles/`, allowing for any number of slashes before and after.

The only possible hiccup with this solution (that I'm aware of) would be if you had '/roles/' in your path elsewhere, but I imagine Vault itself would have trouble with that (and it'd be a confusing choice to make).

We are successfully using this commit in production to manage vault roles with backends that include multiple forward slashes.