### PR TITLE
new resource: resource_pki_generate

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -108,6 +108,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_okta_auth_backend":                   oktaAuthBackendResource(),
 			"vault_okta_auth_backend_user":              oktaAuthBackendUserResource(),
 			"vault_okta_auth_backend_group":             oktaAuthBackendGroupResource(),
+			"vault_pki_generate":                        pkiGenerateResource(),
 			"vault_policy":                              policyResource(),
 			"vault_mount":                               mountResource(),
 		},

--- a/vault/resource_pki_generate.go
+++ b/vault/resource_pki_generate.go
@@ -1,0 +1,180 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func pkiGenerateResource() *schema.Resource {
+	return &schema.Resource{
+		Create: pkiGenerateResourceWrite,
+		Delete: pkiGenerateResourceDelete,
+		Read:   pkiGenerateResourceRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"root", "intermediate"}, false),
+				Description:  "Type of the CA, 'root' or 'intermediate'.",
+			},
+			"common_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Specifies the requested CN for the certificate.",
+			},
+			"alt_names": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Specifies the requested Subject Alternative Names.",
+			},
+			"ip_sans": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Specifies the requested IP Subject Alternative Names.",
+			},
+			"ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Specifies the requested Time To Live (after which the certificate will be expired).",
+			},
+			"key_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "rsa",
+				ValidateFunc: validation.StringInSlice([]string{"rsa", "ec"}, false),
+				Description:  "Specifies the type of key to generate for generated private keys. Currently, rsa and ec are supported.",
+			},
+			"key_bits": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     2048,
+				Description: "Specifies the number of bits to use for the generated keys.",
+			},
+			"exclude_cn_from_sans": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     false,
+				Description: "If true, the given common_name will not be included in DNS or Email Subject Alternate Names (as appropriate).",
+			},
+			"secret_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Path to write private key and cert as generic secret. Key material will _not_ be stored in state. Defaults to internal generation.",
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique name of the backend to generate certs for.",
+				ForceNew:    true,
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+		},
+	}
+}
+
+func pkiGenerateResourceWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	log.Printf("common name is %s", d.Get("common_name").(string))
+	data := map[string]interface{}{
+		"common_name": d.Get("common_name").(string),
+	}
+
+	rawAltNames := d.Get("alt_names").([]interface{})
+	altNames := make([]string, 0, len(rawAltNames))
+	for _, rawAltName := range rawAltNames {
+		altNames = append(altNames, rawAltName.(string))
+	}
+	if len(altNames) > 0 {
+		data["alt_names"] = altNames
+	}
+
+	rawIpSans := d.Get("ip_sans").([]interface{})
+	ipSans := make([]string, 0, len(rawIpSans))
+	for _, rawIpSan := range rawIpSans {
+		ipSans = append(ipSans, rawIpSan.(string))
+	}
+	if len(ipSans) > 0 {
+		data["ip_sans"] = ipSans
+	}
+
+	data["ttl"] = d.Get("ttl").(string)
+	data["key_type"] = d.Get("key_type").(string)
+	data["key_bits"] = d.Get("key_bits").(int)
+	data["exclude_cn_from_sans"] = d.Get("exclude_cn_from_sans").(bool)
+
+	secretType := "internal"
+	secretPath := d.Get("secret_path").(string)
+	if secretPath != "" {
+		secretType = "exported"
+	}
+
+	path := fmt.Sprintf("%s/%s/generate/%s", d.Get("backend").(string), d.Get("type").(string), secretType)
+
+	log.Printf("[DEBUG] Generating Vault pki cert at %s", path)
+	secret, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error writing to Vault: %s", err)
+	}
+
+	if secretPath != "" {
+		log.Printf("[DEBUG] Writing Vault pki values as secret at %s", secretPath)
+		if _, err := client.Logical().Write(secretPath, secret.Data); err != nil {
+			return fmt.Errorf("error writing to Vault: %s", err)
+		}
+	}
+
+	d.SetId(path)
+
+	return pkiGenerateResourceRead(d, meta)
+}
+
+func pkiGenerateResourceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	delPath := fmt.Sprintf("%s/root", d.Get("backend").(string))
+
+	log.Printf("[DEBUG] Deleting Vault generated certificate from %q", delPath)
+	_, err := client.Logical().Delete(delPath)
+	if err != nil {
+		return fmt.Errorf("error deleting %q from Vault: %q", path, err)
+	}
+
+	return nil
+}
+
+func pkiGenerateResourceRead(d *schema.ResourceData, meta interface{}) error {
+	path := d.Id()
+
+	log.Printf("[DEBUG] Vault generated certificate does not support reading: %s", path)
+	return nil
+}

--- a/vault/resource_pki_generate_test.go
+++ b/vault/resource_pki_generate_test.go
@@ -1,0 +1,94 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestResourcePkiGenerate(t *testing.T) {
+	path := "example-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourcePkiMount_initialConfig(path, "intermediate", "example.com", ""),
+				Check:  testResourcePkiMount_initialCheck(path, "intermediate", "example.com", ""),
+			},
+			{
+				Config: testResourcePkiMount_initialConfig(path, "root", "example.com", ""),
+				Check:  testResourcePkiMount_initialCheck(path, "root", "example.com", ""),
+			},
+			{
+				Config: testResourcePkiMount_initialConfig(path, "root", "example.com", fmt.Sprintf("secret/%s", path)),
+				Check:  testResourcePkiMount_initialCheck(path, "root", "example.com", fmt.Sprintf("secret/%s", path)),
+			},
+		},
+	})
+}
+
+func testResourcePkiMount_initialConfig(path, caType, caCommonName, secretPath string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "pki" {
+	path = "%s"
+	type = "pki"
+	description = "test pki backend"
+}
+
+resource "vault_pki_generate" "cacert" {
+	backend = "${vault_mount.pki.path}"
+	type = "%s"
+	common_name = "%s"
+	secret_path = "%s"
+}
+`, path, caType, caCommonName, secretPath)
+}
+
+func testResourcePkiMount_initialCheck(expectedPath, caType, commonName, secretPath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_pki_generate.cacert"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		if actual := instanceState.Attributes["type"]; caType != actual {
+			return fmt.Errorf("type %q doesn't match type %q", caType, actual)
+		}
+
+		if actual := instanceState.Attributes["common_name"]; commonName != actual {
+			return fmt.Errorf("common_name %q doesn't match common_name %q: %v", commonName, actual, instanceState.Attributes)
+		}
+
+		if secretPath != "" {
+			secret, err := findSecret(secretPath)
+			if err != nil {
+				return fmt.Errorf("secret not found at secret_path %s: %s", secretPath, err)
+			}
+
+			fields := []string{"certificate", "private_key"}
+			for _, field := range fields {
+				if _, ok := secret.Data[field]; !ok {
+					return fmt.Errorf("expected secret at secret_path to have field %s", field)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func findSecret(path string) (*api.Secret, error) {
+	client := testProvider.Meta().(*api.Client)
+
+	return client.Logical().Read(path)
+}


### PR DESCRIPTION
Adds a new resource, `vault_pki_generate`, which calls one of the generate endpoints depending on the `type` argument: [root](https://www.vaultproject.io/api/secret/pki/index.html#generate-root) [intermediate](https://www.vaultproject.io/api/secret/pki/index.html#generate-intermediate).

The resource generates a key/certificate pair, and _optionally_ stores the private key / certificate material into a secret path.