### PR TITLE
Fix path check on secret role read

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -85,7 +85,7 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	path := d.Id()
 	pathPieces := strings.Split(path, "/")
-	if len(pathPieces) != 3 || pathPieces[1] != "roles" {
+	if len(pathPieces) < 3 || pathPieces[len(pathPieces)-2] != "roles" {
 		return fmt.Errorf("Invalid id %q; must be {backend}/roles/{name}", path)
 	}
 

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -102,8 +102,8 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("policy", secret.Data["policy"])
 	d.Set("policy_arn", secret.Data["arn"])
-	d.Set("backend", pathPieces[0])
-	d.Set("name", pathPieces[2])
+	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
+	d.Set("name", pathPieces[len(pathPieces)-1])
 	return nil
 }
 

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -16,7 +16,7 @@ const testAccAWSSecretBackendRolePolicyArn_basic = "arn:aws:iam::123456789123:po
 const testAccAWSSecretBackendRolePolicyArn_updated = "arn:aws:iam::123456789123:policy/bar"
 
 func TestAccAWSSecretBackendRole_basic(t *testing.T) {
-	backend := acctest.RandomWithPrefix("tf-test-aws/nested")
+	backend := acctest.RandomWithPrefix("tf-test-aws")
 	name := acctest.RandomWithPrefix("tf-test-aws")
 	accessKey, secretKey := getTestAWSCreds(t)
 	resource.Test(t, resource.TestCase{
@@ -79,6 +79,41 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 				ResourceName:      "vault_aws_secret_backend_role.test_policy_arn",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSecretBackendRole_nested(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-aws/nested")
+	name := acctest.RandomWithPrefix("tf-test-aws")
+	accessKey, secretKey := getTestAWSCreds(t)
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccAWSSecretBackendRoleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
+					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+				),
+			},
+			{
+				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
+					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
+				),
 			},
 		},
 	})

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -16,7 +16,7 @@ const testAccAWSSecretBackendRolePolicyArn_basic = "arn:aws:iam::123456789123:po
 const testAccAWSSecretBackendRolePolicyArn_updated = "arn:aws:iam::123456789123:policy/bar"
 
 func TestAccAWSSecretBackendRole_basic(t *testing.T) {
-	backend := acctest.RandomWithPrefix("tf-test-aws")
+	backend := acctest.RandomWithPrefix("tf-test-aws/nested")
 	name := acctest.RandomWithPrefix("tf-test-aws")
 	accessKey, secretKey := getTestAWSCreds(t)
 	resource.Test(t, resource.TestCase{

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -27,10 +27,10 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
@@ -38,10 +38,10 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
 				),
@@ -62,10 +62,10 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
@@ -96,10 +96,10 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
@@ -107,10 +107,10 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
 				),
@@ -145,7 +145,7 @@ resource "vault_aws_secret_backend" "test" {
   secret_key = "%s"
 }
 
-resource "vault_aws_secret_backend_role" "test_inline_policy" {
+resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
   policy = %q
   backend = "${vault_aws_secret_backend.test.path}"


### PR DESCRIPTION
This is to address #78 

The code currently forces a `backend/roles/name` format when it should be able to take a nested path as the backend such as `backend/path/roles/name`.  This PR changes the check to ensure it is at least as large as it should be and that `roles` is the second to last of the slice.