### PR TITLE
Added new vault_token_auth_backend_role resource

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -94,6 +94,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_approle_auth_backend_role":           approleAuthBackendRoleResource(),
 			"vault_approle_auth_backend_role_secret_id": approleAuthBackendRoleSecretIDResource(),
 			"vault_auth_backend":                        authBackendResource(),
+			"vault_token_auth_backend_role":             tokenAuthBackendRoleResource(),
 			"vault_aws_auth_backend_cert":               awsAuthBackendCertResource(),
 			"vault_aws_auth_backend_client":             awsAuthBackendClientResource(),
 			"vault_aws_auth_backend_identity_whitelist": awsAuthBackendIdentityWhitelistResource(),

--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -1,0 +1,280 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	tokenAuthBackendRoleNameFromPathRegex = regexp.MustCompile("^auth/token/roles/(.+)$")
+)
+
+func tokenAuthBackendRoleResource() *schema.Resource {
+	return &schema.Resource{
+		Create: tokenAuthBackendRoleCreate,
+		Read:   tokenAuthBackendRoleRead,
+		Update: tokenAuthBackendRoleUpdate,
+		Delete: tokenAuthBackendRoleDelete,
+		Exists: tokenAuthBackendRoleExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"role_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the role.",
+			},
+			"allowed_policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "List of allowed policies for given role.",
+			},
+			"disallowed_policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "List of disallowed policies for given role.",
+			},
+			"orphan": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true, tokens created against this policy will be orphan tokens.",
+			},
+			"period": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The duration in which a token should be renewed. At each renewal, the token's TTL will be set to the value of this parameter.",
+			},
+			"renewable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Wether to disable the ability of the token to be renewed past its initial TTL.",
+			},
+			"explicit_max_ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "If set, the token will have an explicit max TTL set upon it.",
+			},
+			"path_suffix": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "Tokens created against this role will have the given suffix as part of their path in addition to the role name.",
+			},
+			"ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The TTL period of tokens issued using this role, provided as the number of minutes.",
+			},
+			"max_ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The maximum allowed lifetime of tokens issued using this role.",
+			},
+		},
+	}
+}
+
+func tokenAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	role := d.Get("role_name").(string)
+
+	path := tokenAuthBackendRolePath(role)
+
+	log.Printf("[DEBUG] Writing Token auth backend role %q", path)
+
+	iAllowedPolicies := d.Get("allowed_policies").([]interface{})
+	allowedPolicies := make([]string, 0, len(iAllowedPolicies))
+	for _, iPolicy := range iAllowedPolicies {
+		allowedPolicies = append(allowedPolicies, iPolicy.(string))
+	}
+
+	iDisallowedPolicies := d.Get("disallowed_policies").([]interface{})
+	disallowedPolicies := make([]string, 0, len(iDisallowedPolicies))
+	for _, iPolicy := range iDisallowedPolicies {
+		disallowedPolicies = append(disallowedPolicies, iPolicy.(string))
+	}
+
+	data := map[string]interface{}{}
+
+	if len(allowedPolicies) > 0 {
+		data["allowed_policies"] = allowedPolicies
+	}
+
+	if len(disallowedPolicies) > 0 {
+		data["disallowed_policies"] = disallowedPolicies
+	}
+
+	data["explicit_max_ttl"] = d.Get("explicit_max_ttl").(string)
+	data["ttl"] = d.Get("ttl").(string)
+	data["max_ttl"] = d.Get("max_ttl").(string)
+	data["orphan"] = d.Get("orphan").(bool)
+	data["renewable"] = d.Get("renewable").(bool)
+	data["path_suffix"] = d.Get("path_suffix").(string)
+
+	_, err := client.Logical().Write(path, data)
+
+	d.SetId(path)
+
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error writing Token auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Wrote Token auth backend role %q", path)
+
+	return tokenAuthBackendRoleRead(d, meta)
+}
+
+func tokenAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	roleName, err := tokenAuthBackendRoleNameFromPath(path)
+	if err != nil {
+		return fmt.Errorf("Invalid path %q for Token auth backend role: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading Token auth backend role %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("Error reading Token auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read Token auth backend role %q", path)
+	if resp == nil {
+		log.Printf("[WARN] Token auth backend role %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	iAllowedPolicies := resp.Data["allowed_policies"].([]interface{})
+	allowedPolicies := make([]string, 0, len(iAllowedPolicies))
+	for _, iAllowedPolicy := range iAllowedPolicies {
+		allowedPolicies = append(allowedPolicies, iAllowedPolicy.(string))
+	}
+
+	iDisallowedPolicies := resp.Data["disallowed_policies"].([]interface{})
+	disallowedPolicies := make([]string, 0, len(iDisallowedPolicies))
+	for _, iDisallowedPolicy := range iDisallowedPolicies {
+		disallowedPolicies = append(disallowedPolicies, iDisallowedPolicy.(string))
+	}
+
+	d.Set("role_name", roleName)
+	d.Set("allowed_policies", allowedPolicies)
+	d.Set("disallowed_policies", disallowedPolicies)
+	d.Set("orphan", resp.Data["orphan"])
+	d.Set("period", resp.Data["period"])
+	d.Set("renewable", resp.Data["renewable"])
+	d.Set("explicit_max_ttl", resp.Data["explicit_max_ttl"])
+	d.Set("path_suffix", resp.Data["path_suffix"])
+	d.Set("ttl", resp.Data["ttl"])
+	d.Set("max_ttl", resp.Data["max_ttl"])
+
+	return nil
+}
+
+func tokenAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Updating Token auth backend role %q", path)
+
+	iAllowedPolicies := d.Get("allowed_policies").([]interface{})
+	allowedPolicies := make([]string, 0, len(iAllowedPolicies))
+	for _, iPolicy := range iAllowedPolicies {
+		allowedPolicies = append(allowedPolicies, iPolicy.(string))
+	}
+
+	iDisallowedPolicies := d.Get("disallowed_policies").([]interface{})
+	disallowedPolicies := make([]string, 0, len(iDisallowedPolicies))
+	for _, iPolicy := range iDisallowedPolicies {
+		disallowedPolicies = append(disallowedPolicies, iPolicy.(string))
+	}
+
+	data := map[string]interface{}{}
+
+	if len(allowedPolicies) > 0 {
+		data["allowed_policies"] = allowedPolicies
+	}
+	if len(disallowedPolicies) > 0 {
+		data["disallowed_policies"] = disallowedPolicies
+	}
+
+	data["orphan"] = d.Get("orphan").(bool)
+	data["period"] = d.Get("period").(string)
+	data["renewable"] = d.Get("renewable").(bool)
+	data["explicit_max_ttl"] = d.Get("explicit_max_ttl").(string)
+	data["path_suffix"] = d.Get("path_suffix").(string)
+	data["ttl"] = d.Get("ttl").(string)
+	data["max_ttl"] = d.Get("max_ttl").(string)
+
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("Error updating Token auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated Token auth backend role %q", path)
+
+	return tokenAuthBackendRoleRead(d, meta)
+}
+
+func tokenAuthBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting Token auth backend role %q", path)
+	_, err := client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("Error deleting Token auth backend role %q", path)
+	}
+	log.Printf("[DEBUG] Deleted Token auth backend role %q", path)
+
+	return nil
+}
+
+func tokenAuthBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	log.Printf("[DEBUG] Checking if Token auth backend role %q exists", path)
+
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("Error checking if Token auth backend role %q exists: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if Token auth backend role %q exists", path)
+
+	return resp != nil, nil
+}
+
+func tokenAuthBackendRolePath(role string) string {
+	return "auth/token/roles/" + strings.Trim(role, "/")
+}
+
+func tokenAuthBackendRoleNameFromPath(path string) (string, error) {
+	if !tokenAuthBackendRoleNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no role found")
+	}
+	res := tokenAuthBackendRoleNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}

--- a/vault/resource_token_auth_backend_role_test.go
+++ b/vault/resource_token_auth_backend_role_test.go
@@ -1,0 +1,215 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestAccTokenAuthBackendRoleImport(t *testing.T) {
+	role := acctest.RandomWithPrefix("test-role")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckTokenAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTokenAuthBackendRoleConfig(role),
+				Check:  testAccTokenAuthBackendRoleCheck_attrs(role),
+			},
+			{
+				ResourceName:      "vault_token_auth_backend_role.role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTokenAuthBackendRole(t *testing.T) {
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckTokenAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTokenAuthBackendRoleConfig(role),
+				Check:  testAccTokenAuthBackendRoleCheck_attrs(role),
+			},
+		},
+	})
+}
+
+func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckTokenAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTokenAuthBackendRoleConfig(role),
+				Check:  testAccTokenAuthBackendRoleCheck_attrs(role),
+			},
+			{
+				Config: testAccTokenAuthBackendRoleConfigUpdate(role),
+				Check: resource.ComposeTestCheckFunc(
+					testAccTokenAuthBackendRoleCheck_attrs(role),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.0", "dev"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.1", "test"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "orphan", "true"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "period", "86400"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "renewable", "true"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "explicit_max_ttl", "115200"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "path_suffix", "parth-suffix"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTokenAuthBackendRoleDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_token_auth_backend_role" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error checking for Token auth backend role %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("Token auth backend role %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccTokenAuthBackendRoleCheck_attrs(role string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_token_auth_backend_role.role"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		endpoint := instanceState.ID
+
+		if endpoint != "auth/token/roles/"+role {
+			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/token/roles/"+role, endpoint)
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		resp, err := client.Logical().Read(endpoint)
+		if err != nil {
+			return fmt.Errorf("%q doesn't exist", endpoint)
+		}
+
+		attrs := map[string]string{
+			"role_name":           "name",
+			"allowed_policies":    "allowed_policies",
+			"disallowed_policies": "disallowed_policies",
+			"orphan":              "orphan",
+			"period":              "period",
+			"renewable":           "renewable",
+			"explicit_max_ttl":    "explicit_max_ttl",
+			"path_suffix":         "path_suffix",
+			"ttl":                 "ttl",
+			"max_ttl":             "max_ttl",
+		}
+		for stateAttr, apiAttr := range attrs {
+			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+				continue
+			}
+			var match bool
+			switch resp.Data[apiAttr].(type) {
+			case json.Number:
+				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
+				if err != nil {
+					return fmt.Errorf("Expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
+				}
+				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
+				if err != nil {
+					return fmt.Errorf("Expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
+				}
+				match = apiData == stateData
+			case bool:
+				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
+					match = true
+				} else {
+					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
+					if err != nil {
+						return fmt.Errorf("Expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
+					}
+					match = resp.Data[apiAttr] == stateData
+				}
+			case []interface{}:
+				apiData := resp.Data[apiAttr].([]interface{})
+				length := instanceState.Attributes[stateAttr+".#"]
+				if length == "" {
+					if len(resp.Data[apiAttr].([]interface{})) != 0 {
+						return fmt.Errorf("Expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
+					}
+					match = true
+				} else {
+					count, err := strconv.Atoi(length)
+					if err != nil {
+						return fmt.Errorf("Expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
+					}
+					if count != len(apiData) {
+						return fmt.Errorf("Expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
+					}
+					for i := 0; i < count; i++ {
+						stateData := instanceState.Attributes[stateAttr+"."+strconv.Itoa(i)]
+						if stateData != apiData[i] {
+							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be %q, got %q", i, apiAttr, stateAttr, endpoint, stateData, apiData[i])
+						}
+					}
+					match = true
+				}
+			default:
+				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+			}
+			if !match {
+				return fmt.Errorf("Expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
+			}
+		}
+		return nil
+	}
+}
+
+func testAccTokenAuthBackendRoleConfig(roleName string) string {
+	return fmt.Sprintf(`
+resource "vault_token_auth_backend_role" "role" {
+  role_name = "%s"
+}`, roleName)
+}
+
+func testAccTokenAuthBackendRoleConfigUpdate(role string) string {
+	return fmt.Sprintf(`
+resource "vault_token_auth_backend_role" "role" {
+  role_name = "%s"
+  allowed_policies = ["dev", "test"]
+  disallowed_policies = ["default"]
+  orphan = true
+  period = "86400"
+  renewable = true
+  explicit_max_ttl = "115200"
+  path_suffix = "parth-suffix"
+}`, role)
+}


### PR DESCRIPTION
This PR adds new resource `vault_token_auth_backend_role`, arguments taken from [Vault docs](https://www.vaultproject.io/api/auth/token/index.html#create-token).