### PR TITLE
new resource: vault_audit

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -111,6 +111,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_okta_auth_backend_group":             oktaAuthBackendGroupResource(),
 			"vault_policy":                              policyResource(),
 			"vault_mount":                               mountResource(),
+			"vault_audit":                               auditResource(),
 		},
 	}
 }

--- a/vault/resource_audit.go
+++ b/vault/resource_audit.go
@@ -1,0 +1,125 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func auditResource() *schema.Resource {
+	return &schema.Resource{
+		Create: auditWrite,
+		Read:   auditRead,
+		Delete: auditDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Path in which to enable the audit device",
+			},
+
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Type of the audit device, such as 'file'",
+			},
+
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Human-friendly description of the audit device",
+			},
+
+			"options": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Required:    true,
+				ForceNew:    true,
+				Description: "Configuration options to pass to the audit device itself",
+			},
+		},
+	}
+}
+
+func auditWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+	optionsRaw := d.Get("options").(map[string]interface{})
+	options := make(map[string]string)
+
+	for k, v := range optionsRaw {
+		options[k] = v.(string)
+	}
+
+	log.Printf("[DEBUG] Enabling audit backend %s in Vault", path)
+
+	if err := client.Sys().EnableAudit(
+		path,
+		d.Get("type").(string),
+		d.Get("description").(string),
+		options,
+	); err != nil {
+		return fmt.Errorf("error enabling audit backend: %s", err)
+	}
+
+	d.SetId(path)
+
+	return nil
+}
+
+func auditDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Unmounting %s from Vault", path)
+
+	if err := client.Sys().DisableAudit(path); err != nil {
+		return fmt.Errorf("error disabling audit backend Vault: %s", err)
+	}
+
+	return nil
+}
+
+func auditRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Reading audit backends %s from Vault", path)
+
+	client.Sys().ListAudit()
+
+	audits, err := client.Sys().ListAudit()
+	if err != nil {
+		return fmt.Errorf("error reading from Vault: %s", err)
+	}
+
+	// path can have a trailing slash, but doesn't need to have one
+	// this standardises on having a trailing slash, which is how the
+	// API always responds.
+	audit, ok := audits[strings.Trim(path, "/")+"/"]
+	if !ok {
+		log.Printf("[WARN] Audit backend %q not found, removing from state.", path)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("path", path)
+	d.Set("type", audit.Type)
+	d.Set("description", audit.Description)
+	d.Set("options", audit.Options)
+
+	return nil
+}

--- a/vault/resource_audit_test.go
+++ b/vault/resource_audit_test.go
@@ -1,0 +1,98 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestResourceAudit(t *testing.T) {
+	path := "example-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceAudit_initialConfig(path),
+				Check:  testResourceAudit_initialCheck(path),
+			},
+		},
+	})
+}
+
+func testResourceAudit_initialConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_audit" "test" {
+	path = "%s"
+	type = "file"
+	description = "Example file audit for vault"
+	options = {
+		path = "stdout"
+	}
+}
+`, path)
+}
+
+func testResourceAudit_initialCheck(expectedPath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_audit.test"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		path := instanceState.ID
+
+		if path != instanceState.Attributes["path"] {
+			return fmt.Errorf("id %q doesn't match path %q", path, instanceState.Attributes["path"])
+		}
+
+		if path != expectedPath {
+			return fmt.Errorf("unexpected path %q, expected %q", path, expectedPath)
+		}
+
+		audit, err := findAudit(path)
+		if err != nil {
+			return fmt.Errorf("error reading back mount %q: %s", path, err)
+		}
+
+		if wanted := "Example file audit for vault"; audit.Description != wanted {
+			return fmt.Errorf("description is %v; wanted %v", audit.Description, wanted)
+		}
+
+		if wanted := "file"; audit.Type != wanted {
+			return fmt.Errorf("type is %v; wanted %v", audit.Type, wanted)
+		}
+
+		if wanted := "stdout"; audit.Options["path"] != wanted {
+			return fmt.Errorf("log path is %v; wanted %v", audit.Options["path"], wanted)
+		}
+
+		return nil
+	}
+}
+
+func findAudit(path string) (*api.Audit, error) {
+	client := testProvider.Meta().(*api.Client)
+
+	path = path + "/"
+
+	audits, err := client.Sys().ListAudit()
+	if err != nil {
+		return nil, err
+	}
+
+	if audits[path] != nil {
+		return audits[path], nil
+	}
+
+	return nil, fmt.Errorf("Unable to find audit %s in Vault; current list: %v", path, audits)
+}


### PR DESCRIPTION
Adds a new resource, `vault_audit`, which manages vault audit backends. This also solves following issue https://github.com/terraform-providers/terraform-provider-vault/issues/53