### PR TITLE
token needs to be able to create child tokens

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -87,7 +87,9 @@ variables in order to keep credential information out of the configuration.
   If none is otherwise supplied, Terraform will attempt to read it from
   `~/.vault-token` (where the vault command stores its current token).
   Terraform will issue itself a new token that is a child of the one given,
-  with a short TTL to limit the exposure of any requested secrets.
+  with a short TTL to limit the exposure of any requested secrets. Note that
+  the given token must have the update capability on the auth/token/create
+  path in Vault in order to create child tokens.
 
 * `ca_cert_file` - (Optional) Path to a file on local disk that will be
   used to validate the certificate presented by the Vault server.


### PR DESCRIPTION
The Vault token passed to Terraform needs to have a policy associated with it that gives it the capability to create child tokens. Specifically, it needs the update capability on the Vault path auth/token/create.  See https://www.vaultproject.io/api/auth/token/index.html#create-token.  A Vault policy that would give the given token the ability to do that is:

```
path "auth/token/create" {
   capabilities = ["update"]
}
```