### PR TITLE
Changing role in aws_auth_backend_role must force new resource

### DIFF
--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -32,6 +32,7 @@ func awsAuthBackendRoleResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of the role.",
+				ForceNew:    true,
 			},
 			"auth_type": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Currently role_name is not updated after `terraform apply` because changing role_name changes vault path but ForceNew is not specified in schema. Adding ForceNew fixes this.