### PR TITLE
[GH-93] Add kubernetetes_auth_backend_* resources

### DIFF
--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -1,0 +1,80 @@
+package vault
+
+import (
+	"strings"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"log"
+)
+
+func kubernetesAuthBackendConfigDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: kubernetesAuthBackendConfigDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the kubernetes backend to configure.",
+				ForceNew:    true,
+				Default:     "kubernetes",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"kubernetes_host": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.",
+			},
+			"kubernetes_ca_cert": {
+				Type:        schema.TypeString,
+				Description: "PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.",
+				Computed:    true,
+				Optional:    true,
+			},
+			"pem_keys": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: "Optional list of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := kubernetesAuthBackendConfigPath(d.Get("backend").(string))
+
+	log.Printf("[DEBUG] Reading Kubernetes auth backend config %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading Kubernetes auth backend config %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read Kubernetes auth backend config %q", path)
+
+	if resp == nil {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(path)
+	d.Set("kubernetes_ca_cert", resp.Data["kubernetes_ca_cert"])
+	d.Set("kubernetes_host", resp.Data["kubernetes_host"])
+
+	iPemKeys := resp.Data["pem_keys"].([]interface{})
+	pemKeys := make([]string, 0, len(iPemKeys))
+
+	for _, iPemKey := range iPemKeys {
+		pemKeys = append(pemKeys, iPemKey.(string))
+	}
+
+	d.Set("pem_keys", pemKeys)
+
+	return nil
+}

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -1,0 +1,114 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccKubernetesAuthBackendConfigDataSource_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	jwt := kubernetesJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", jwt),
+				),
+			},
+			{
+				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_basic(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckNoResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	jwt := kubernetesJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", jwt),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.0", kubernetesPEMfile)),
+			},
+			{
+				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckNoResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "1"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
+						"pem_keys.0", kubernetesPEMfile),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesAuthBackendConfigDataSourceConfig_basic(backend, jwt string) string {
+	return fmt.Sprintf(`
+%s
+
+data "vault_kubernetes_auth_backend_config" "config" {
+  backend = %q
+}`, testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt), backend)
+}
+
+func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string) string {
+	return fmt.Sprintf(`
+%s
+
+data "vault_kubernetes_auth_backend_config" "config" {
+  backend = "%s"
+}`, testAccKubernetesAuthBackendConfigConfig_full(backend, jwt), backend)
+}

--- a/vault/data_source_kubernetes_auth_backend_role.go
+++ b/vault/data_source_kubernetes_auth_backend_role.go
@@ -1,0 +1,152 @@
+package vault
+
+import (
+	"strings"
+
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"log"
+)
+
+func kubernetesAuthBackendRoleDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: kubernetesAuthBackendRoleDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the kubernetes backend to configure.",
+				ForceNew:    true,
+				Default:     "kubernetes",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"role_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the role.",
+			},
+			"bound_service_account_names": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of service account names able to access this role. If set to \"*\" all names are allowed, both this and bound_service_account_namespaces can not be \"*\".",
+				Computed:    true,
+			},
+			"bound_service_account_namespaces": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of namespaces allowed to access this role. If set to \"*\" all namespaces are allowed, both this and bound_service_account_names can not be set to \"*\".",
+				Computed:    true,
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Description: "The TTL period of tokens issued using this role in seconds.",
+				Computed:    true,
+				Optional:    true,
+			},
+			"max_ttl": {
+				Type:        schema.TypeInt,
+				Description: "The maximum allowed lifetime of tokens issued in seconds using this role.",
+				Computed:    true,
+				Optional:    true,
+			},
+			"num_uses": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Number of times issued tokens can be used. Setting this to 0 or leaving it unset means unlimited uses.",
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Description: "If set, indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this parameter.",
+				Computed:    true,
+				Optional:    true,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Policies to be set on tokens issued using this role.",
+				Computed:    true,
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func kubernetesAuthBackendRoleDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+	role := d.Get("role_name").(string)
+	path := kubernetesAuthBackendRolePath(backend, role)
+
+	log.Printf("[DEBUG] Reading Kubernetes auth backend role %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading Kubernetes auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read Kubernetes auth backend role %q", path)
+
+	if resp == nil {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(path)
+
+	iBoundServiceAccountNames := resp.Data["bound_service_account_names"].([]interface{})
+	boundServiceAccountNames := make([]string, 0, len(iBoundServiceAccountNames))
+
+	for _, iBoundServiceAccountName := range iBoundServiceAccountNames {
+		boundServiceAccountNames = append(boundServiceAccountNames, iBoundServiceAccountName.(string))
+	}
+
+	d.Set("bound_service_account_names", boundServiceAccountNames)
+
+	iBoundServiceAccountNamespaces := resp.Data["bound_service_account_namespaces"].([]interface{})
+	boundServiceAccountNamespaces := make([]string, 0, len(iBoundServiceAccountNamespaces))
+
+	for _, iBoundServiceAccountNamespace := range iBoundServiceAccountNamespaces {
+		boundServiceAccountNamespaces = append(boundServiceAccountNamespaces, iBoundServiceAccountNamespace.(string))
+	}
+
+	d.Set("bound_service_account_namespaces", boundServiceAccountNamespaces)
+
+	iPolicies := resp.Data["policies"].([]interface{})
+	policies := make([]string, 0, len(iPolicies))
+
+	for _, iPolicy := range iPolicies {
+		policies = append(policies, iPolicy.(string))
+	}
+
+	d.Set("policies", policies)
+
+	ttl, err := resp.Data["ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected `ttl` %q to be a number, isn't", resp.Data["ttl"])
+	}
+	d.Set("ttl", ttl)
+
+	maxTTL, err := resp.Data["max_ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected `max_ttl` %q to be a number, isn't", resp.Data["max_ttl"])
+	}
+	d.Set("max_ttl", maxTTL)
+
+	numUses, err := resp.Data["num_uses"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected `num_uses` %q to be a number, isn't", resp.Data["num_uses"])
+	}
+	d.Set("num_uses", numUses)
+
+	period, err := resp.Data["period"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected `period` %q to be a number, isn't", resp.Data["period"])
+	}
+	d.Set("period", period)
+	return nil
+}

--- a/vault/data_source_kubernetes_auth_backend_role_test.go
+++ b/vault/data_source_kubernetes_auth_backend_role_test.go
@@ -1,0 +1,183 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"strconv"
+)
+
+func TestAccKubernetesAuthBackendRoleDataSource_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	role := acctest.RandomWithPrefix("test-role")
+	ttl := 3600
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_basic(backend, role, ttl),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", "3600"),
+				),
+			},
+			{
+				Config: testAccKubernetesAuthBackendRoleDataSourceConfig_basic(backend, role, ttl),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(ttl)),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"max_ttl", "0"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"num_uses", "0"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"period", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendRoleDataSource_full(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	role := acctest.RandomWithPrefix("test-role")
+	ttl := 3600
+	maxTTL := 3600
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_full(backend, role, ttl, maxTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(ttl)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"max_ttl", strconv.Itoa(maxTTL)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"period", "900"),
+				),
+			},
+			{
+				Config: testAccKubernetesAuthBackendRoleDataSourceConfig_full(backend, role, ttl, maxTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(ttl)),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"max_ttl", strconv.Itoa(ttl)),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"num_uses", "0"),
+					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_role.role",
+						"period", "900"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesAuthBackendRoleDataSourceConfig_basic(backend, role string, ttl int) string {
+	return fmt.Sprintf(`
+%s
+
+data "vault_kubernetes_auth_backend_role" "role" {
+  backend = %q
+  role_name = %q
+}`, testAccKubernetesAuthBackendRoleConfig_basic(backend, role, ttl), backend, role)
+}
+
+func testAccKubernetesAuthBackendRoleDataSourceConfig_full(backend, role string, ttl, maxTTL int) string {
+	return fmt.Sprintf(`
+%s
+
+data "vault_kubernetes_auth_backend_role" "role" {
+  backend = %q
+  role_name = %q
+}`, testAccKubernetesAuthBackendRoleConfig_full(backend, role, ttl, maxTTL), backend, role)
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -84,9 +84,11 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: providerConfigure,
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"vault_approle_auth_backend_role_id": approleAuthBackendRoleIDDataSource(),
-			"vault_aws_access_credentials":       awsAccessCredentialsDataSource(),
-			"vault_generic_secret":               genericSecretDataSource(),
+			"vault_approle_auth_backend_role_id":   approleAuthBackendRoleIDDataSource(),
+			"vault_kubernetes_auth_backend_config": kubernetesAuthBackendConfigDataSource(),
+			"vault_kubernetes_auth_backend_role":   kubernetesAuthBackendRoleDataSource(),
+			"vault_aws_access_credentials":         awsAccessCredentialsDataSource(),
+			"vault_generic_secret":                 genericSecretDataSource(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -106,6 +108,8 @@ func Provider() terraform.ResourceProvider {
 			"vault_database_secret_backend_connection":  databaseSecretBackendConnectionResource(),
 			"vault_database_secret_backend_role":        databaseSecretBackendRoleResource(),
 			"vault_generic_secret":                      genericSecretResource(),
+			"vault_kubernetes_auth_backend_config":      kubernetesAuthBackendConfigResource(),
+			"vault_kubernetes_auth_backend_role":        kubernetesAuthBackendRoleResource(),
 			"vault_okta_auth_backend":                   oktaAuthBackendResource(),
 			"vault_okta_auth_backend_user":              oktaAuthBackendUserResource(),
 			"vault_okta_auth_backend_group":             oktaAuthBackendGroupResource(),

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -1,0 +1,218 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	kubernetesAuthBackendConfigFromPathRegex = regexp.MustCompile("^auth/(.+)/config$")
+)
+
+func kubernetesAuthBackendConfigResource() *schema.Resource {
+	return &schema.Resource{
+		Create: kubernetesAuthBackendConfigCreate,
+		Read:   kubernetesAuthBackendConfigRead,
+		Update: kubernetesAuthBackendConfigUpdate,
+		Delete: kubernetesAuthBackendConfigDelete,
+		Exists: kubernetesAuthBackendConfigExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"kubernetes_host": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.",
+			},
+			"kubernetes_ca_cert": {
+				Type:        schema.TypeString,
+				Description: "PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.",
+				Optional:    true,
+				Default:     "",
+			},
+			"token_reviewer_jwt": {
+				Type:        schema.TypeString,
+				Description: "A service account JWT used to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API.",
+				Default:     "",
+				Optional:    true,
+			},
+			"pem_keys": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Optional list of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.",
+				Optional:    true,
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the kubernetes backend to configure.",
+				ForceNew:    true,
+				Default:     "kubernetes",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+		},
+	}
+}
+
+func kubernetesAuthBackendConfigPath(backend string) string {
+	return "auth/" + strings.Trim(backend, "/") + "/config"
+}
+
+func kubernetesAuthBackendConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+
+	path := kubernetesAuthBackendConfigPath(backend)
+	log.Printf("[DEBUG] Writing Kubernetes auth backend config %q", path)
+
+	data := map[string]interface{}{}
+
+	if v, ok := d.GetOk("kubernetes_ca_cert"); ok {
+		data["kubernetes_ca_cert"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("token_reviewer_jwt"); ok {
+		data["token_reviewer_jwt"] = v.(string)
+	}
+
+	if v, ok := d.GetOkExists("pem_keys"); ok {
+		var pemKeys []string
+		for _, pemKey := range v.([]interface{}) {
+			pemKeys = append(pemKeys, pemKey.(string))
+		}
+		data["pem_keys"] = strings.Join(pemKeys, ",")
+	}
+	data["kubernetes_host"] = d.Get("kubernetes_host").(string)
+
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error writing Kubernetes auth backend config %q: %s", path, err)
+	}
+
+	d.SetId(path)
+	// NOTE: Since reading the auth/<backend>/config does
+	// not return the `token_reviewer_jwt`,
+	// set it from data after successfully storing it in Vault.
+	d.Set("token_reviewer_jwt", data["token_reviewer_jwt"])
+	log.Printf("[DEBUG] Wrote Kubernetes auth backend config %q", path)
+
+	return kubernetesAuthBackendConfigRead(d, meta)
+}
+
+func kubernetesAuthBackendConfigBackendFromPath(path string) (string, error) {
+	if !kubernetesAuthBackendConfigFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := kubernetesAuthBackendConfigFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}
+
+func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	backend, err := kubernetesAuthBackendConfigBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for Kubernetes auth backend config: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading Kubernetes auth backend config %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading Kubernetes auth backend config %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read Kubernetes auth backend config %q", path)
+	if resp == nil {
+		log.Printf("[WARN] Kubernetes auth backend config %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("backend", backend)
+	d.Set("kubernetes_host", resp.Data["kubernetes_host"])
+	d.Set("kubernetes_ca_cert", resp.Data["kubernetes_ca_cert"])
+
+	iPemKeys := resp.Data["pem_keys"].([]interface{})
+	pemKeys := make([]string, 0, len(iPemKeys))
+
+	for _, iPemKey := range iPemKeys {
+		pemKeys = append(pemKeys, iPemKey.(string))
+	}
+
+	d.Set("pem_keys", pemKeys)
+
+	return nil
+}
+
+func kubernetesAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Updating Kubernetes auth backend config %q", path)
+
+	data := map[string]interface{}{}
+
+	if v, ok := d.GetOk("kubernetes_ca_cert"); ok {
+		data["kubernetes_ca_cert"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("token_reviewer_jwt"); ok {
+		data["token_reviewer_jwt"] = v.(string)
+	}
+
+	if v, ok := d.GetOkExists("pem_keys"); ok {
+		var pemKeys []string
+		for _, pemKey := range v.([]interface{}) {
+			pemKeys = append(pemKeys, pemKey.(string))
+		}
+		data["pem_keys"] = strings.Join(pemKeys, ",")
+	}
+	data["kubernetes_host"] = d.Get("kubernetes_host").(string)
+
+	_, err := client.Logical().Write(path, data)
+
+	d.SetId(path)
+
+	if err != nil {
+		return fmt.Errorf("error updating Kubernetes auth backend config %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated Kubernetes auth backend config %q", path)
+
+	return kubernetesAuthBackendConfigRead(d, meta)
+}
+
+func kubernetesAuthBackendConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	path := d.Id()
+	log.Printf("[DEBUG] Deleted Kubernetes auth backend config %q", path)
+	d.SetId("")
+	return nil
+}
+
+func kubernetesAuthBackendConfigExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	log.Printf("[DEBUG] Checking if Kubernetes auth backend config %q exists", path)
+
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("error checking if Kubernetes auth backend config %q exists: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if Kubernetes auth backend config %q exists", path)
+
+	return resp != nil, nil
+}

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -1,0 +1,291 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+const kubernetesJWT = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlcm5ldGVzLWF1dGgtdmF1bHQtb3BlcmF0b3IiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlY3JldC5uYW1lIjoia3ViZXJuZXRlcy1hdXRoLXZhdWx0LW9wZXJhdG9yLXRva2VuLWZycmc3Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmVybmV0ZXMtYXV0aC12YXVsdC1vcGVyYXRvciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjMwYzRiZjdkLTMwZmYtMTFlOC04ODdkLTA4MDAyNzZhYmI4OCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDprdWJlcm5ldGVzLWF1dGgtdmF1bHQtb3BlcmF0b3I6a3ViZXJuZXRlcy1hdXRoLXZhdWx0LW9wZXJhdG9yIn0.V6lWrH6rgNfghn5Qc9IdPwxrAV0E8cdVNvGh3KmVCZpZVwOnL4eCQ3R6V37pO7ssTs-0aYYWc2NYcGnLiXvUPah89uK2wkE_Eod3NgWDqlutcM-LJuIK6xubuH0y2Bpb7ZddZmtc5MOa8e88iwiZmQ_zKhifwESdwFWaA5Nn1QNzwIPu2kOZU0Wz9sVN4i_NETUGqaEQYVU6DF--gErCLeloUDERW-QyrCRZ-ymTFt7UWRiPi3zAZ0-BG8j4TsjNYLiifGiMiaD6Ss-pd0brVMzQylpVlnZ7Of6ywIv-BWVa278ki3cd1RMqQj8tzHNg2tlbBSLMn92Gxh16jBW90w"
+const kubernetesAnotherJWT = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImRlZmF1bHQtdG9rZW4tNzhsNXAiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoiZGVmYXVsdCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjUzZjZhY2Y5LTMwZmEtMTFlOC04ODdkLTA4MDAyNzZhYmI4OCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0OmRlZmF1bHQifQ.pM5ugxaTX22vBsb4IOUz-pgwKM_ZfhgFhS1PKfpcSJYs4h-C4OujjKpF8j-Lw5oxaHOIxbROUxurlh-9eqvYqKREQOVxZvhoqxiflWCuAtu4RxHI-x4COSqV0H7pc_JNnDbgEqBhbFW1UiKfoye3QiqiqwYBaxvdpyH3uarv5yi26FT2lNvy6rHWMaMg3VZLzbZPOPY-v1C0RUbiyCz100A2UvaU5QbdHfwFab18vqgB_FN4aFXP9TKrcDUPyFyAhoC6h4Tb_ounuQ1u8UWtLL_KwDK7KEAgwg-FfayzHtw41PneS9nNtNm7bZJsLtzsvSzuMJpwehnN1GtUCMvDzA"
+
+const kubernetesCAcert = `-----BEGIN CERTIFICATE-----
+MIIFXTCCA0WgAwIBAgIJAOLBeuu/P2O6MA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTgwNDExMTEwNDE5WhcNMTkwNDExMTEwNDE5WjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC
+CgKCAgEAx8AtbNS5rSO8ZlHE+s7yzJI2qBNnOZsfyWApfw4rie0u3lXm2aHYMK4B
+gg1vBVeUe/LbrnRDMMkZ5cKU24CnUNa+2A6ITQPnyHXEJxzR/O6fPgxW88itCha1
+ZWOlTe8dhcNWh95Id+4m5H9RztdCpI7hwvo8HuCdlWSP/HsceI6nAOyw2dPBKZ1B
+Z9FaqA6r+ET/kGs/iU9a7ZJtNlPBmAHm54hj+eNVmroP5JALpf8zcoPGIVhvv9Mu
+GeveSg7CPMVpnjVnjQfI5ZnJmmLI6wqgpvuvhycMbpvbOvsJ6JIfudwIQv/Suk10
+R+K4booiFs0yPkrZ+NjbmdwRMqV7R3cPqTOzzHtG+HC+AJB4t4ecAULWOzqH/KY7
+ICpNQZm3o2sT0ZeL5p1v/up3cncASgJBGMapLB5rrBdxykMifeioZHt+U55O0bq3
+X0tRmaVSLMwWVa8UQQNK6pEKFsDYCC+knYUmT7Fyt6xOstE0Zwrpbda33BULVLlM
+jGtY4ZqMEmxRd6iwuX+XziPJ+kSjyBi8SBTeP3bVh4OXkLnddNL45fwIrb7VB8EJ
+C5RYUNH+nCJS3NW16ZFM/TSvn+r5K/iRFIMy+YUHloL4hiVKkA4bF17zEXfqynpA
+Xw7wxwEOGnNnE1rz4XhQp5LqZgRZlRWEdZ9naFNIj9WsUcKHqRECAwEAAaNQME4w
+HQYDVR0OBBYEFFSgoZGl4H8Y3/pb2aDAWopCW/nvMB8GA1UdIwQYMBaAFFSgoZGl
+4H8Y3/pb2aDAWopCW/nvMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIB
+AFwauMwjtDSLxt4LvzTE/7Zz9vZ1iavGisRFQmAH3pK/RAB4830b3Y5C98abZRbt
+7qS+J1xia7MSPQr2ex7EHK6eE1U3apuOgcckFrR4DiieZEjRxOlqHRUXnrtHHNsi
+v3fx6IeoB5/685lwAWyS65R5lJsggnLiG4gwl3t0uN50/pjegN+iAzn3krnLC85c
+u1dQAhY9XiiBy1jcX+zDQBVi+YRp5gk4KiBipwE0gB0aUJIlODdSqe5Tl0DqD7/6
+W95ABX9ksuaREoFDVWMEgsPQlXj5cD7nQsX6Ghnrb60m9s60/Wnftjw+UHcm/QK3
+28QlfcBvA4cfjAW+8WCuhKMjyUPEdD8tHG9C/PN/i+c5MOkmCGMIGbay6AN0nQM6
+TlrjK0wHk1eBIs+u5GqL1Cg+GKddeqFP9slMCyuSKyDJzn4uZB8j+NwrdM9Ma3UY
+dwWpxrJOJY5k2f/GFMmOgk4qite+PZT5nCT8YLiO5nN6nCxQyEtOwRIbDrZjJSeH
+g+ra+LRtnP6DGO9r/2EO5XLUgLp8hPZbq3+xd8TWMpv5TnuqPGJ5gM4rQzH3+H75
+2K27ycqQbqM7ceOoihM6hb2VhEeoq8nYxWKZ4OGONpoaHA0tdYFGyVRYBBMUK/DB
+1B4wS06RrGt6oud4fLHZpuvspPQTlLRjHvuXDi/cbIIE
+-----END CERTIFICATE-----`
+
+const kubernetesPEMfile = `-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAx8AtbNS5rSO8ZlHE+s7y
+zJI2qBNnOZsfyWApfw4rie0u3lXm2aHYMK4Bgg1vBVeUe/LbrnRDMMkZ5cKU24Cn
+UNa+2A6ITQPnyHXEJxzR/O6fPgxW88itCha1ZWOlTe8dhcNWh95Id+4m5H9RztdC
+pI7hwvo8HuCdlWSP/HsceI6nAOyw2dPBKZ1BZ9FaqA6r+ET/kGs/iU9a7ZJtNlPB
+mAHm54hj+eNVmroP5JALpf8zcoPGIVhvv9MuGeveSg7CPMVpnjVnjQfI5ZnJmmLI
+6wqgpvuvhycMbpvbOvsJ6JIfudwIQv/Suk10R+K4booiFs0yPkrZ+NjbmdwRMqV7
+R3cPqTOzzHtG+HC+AJB4t4ecAULWOzqH/KY7ICpNQZm3o2sT0ZeL5p1v/up3cncA
+SgJBGMapLB5rrBdxykMifeioZHt+U55O0bq3X0tRmaVSLMwWVa8UQQNK6pEKFsDY
+CC+knYUmT7Fyt6xOstE0Zwrpbda33BULVLlMjGtY4ZqMEmxRd6iwuX+XziPJ+kSj
+yBi8SBTeP3bVh4OXkLnddNL45fwIrb7VB8EJC5RYUNH+nCJS3NW16ZFM/TSvn+r5
+K/iRFIMy+YUHloL4hiVKkA4bF17zEXfqynpAXw7wxwEOGnNnE1rz4XhQp5LqZgRZ
+lRWEdZ9naFNIj9WsUcKHqRECAwEAAQ==
+-----END PUBLIC KEY-----`
+
+func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	jwt := kubernetesJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", jwt),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.0", kubernetesPEMfile),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "1"),
+				),
+			},
+			{
+				ResourceName:      "vault_kubernetes_auth_backend_config.config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// NOTE: The API can't serve these fields, so ignore them.
+				ImportStateVerifyIgnore: []string{"backend", "token_reviewer_jwt"},
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendConfig_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	jwt := kubernetesJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", jwt),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKubernetesAuthBackendConfigDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_kubernetes_auth_backend_config" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for Kubernetes auth backend config %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("Kubernetes auth backend config %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func TestAccKubernetesAuthBackendConfig_update(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	oldJWT := kubernetesJWT
+	newJWT := kubernetesAnotherJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, oldJWT),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", oldJWT),
+				),
+			},
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, newJWT),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", newJWT),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	jwt := kubernetesJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", jwt),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.0", kubernetesPEMfile),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	oldJWT := kubernetesJWT
+	newJWT := kubernetesAnotherJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, oldJWT),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", oldJWT),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.0", kubernetesPEMfile),
+				),
+			},
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", newJWT),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.0", kubernetesPEMfile),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+  path = "%s"
+}
+
+resource "vault_kubernetes_auth_backend_config" "config" {
+  backend = "${vault_auth_backend.kubernetes.path}"
+  kubernetes_host = "http://example.com:443"
+  kubernetes_ca_cert = %q
+  token_reviewer_jwt = %q
+}`, backend, kubernetesCAcert, jwt)
+}
+
+func testAccKubernetesAuthBackendConfigConfig_full(backend, jwt string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+  path = "%s"
+}
+
+resource "vault_kubernetes_auth_backend_config" "config" {
+  backend = "${vault_auth_backend.kubernetes.path}"
+  kubernetes_host = "http://example.com:443"
+  kubernetes_ca_cert = %q
+  token_reviewer_jwt = %q
+  pem_keys = [%q]
+}`, backend, kubernetesCAcert, jwt, kubernetesPEMfile)
+}

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -1,0 +1,338 @@
+package vault
+
+import (
+	"regexp"
+	"strings"
+
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"log"
+)
+
+var (
+	kubernetesAuthBackendRoleBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/role/.+$")
+	kubernetesAuthBackendRoleNameFromPathRegex    = regexp.MustCompile("^auth/.+/role/(.+)$")
+)
+
+func kubernetesAuthBackendRoleResource() *schema.Resource {
+	return &schema.Resource{
+		Create: kubernetesAuthBackendRoleCreate,
+		Read:   kubernetesAuthBackendRoleRead,
+		Update: kubernetesAuthBackendRoleUpdate,
+		Delete: kubernetesAuthBackendRoleDelete,
+		Exists: kubernetesAuthBackendRoleExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"role_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the role.",
+			},
+			"bound_service_account_names": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of service account names able to access this role. If set to \"*\" all names are allowed, both this and bound_service_account_namespaces can not be \"*\".",
+				Required:    true,
+			},
+			"bound_service_account_namespaces": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of namespaces allowed to access this role. If set to \"*\" all namespaces are allowed, both this and bound_service_account_names can not be set to \"*\".",
+				Required:    true,
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Description: "The TTL period of tokens issued using this role in seconds.",
+				Optional:    true,
+			},
+			"max_ttl": {
+				Type:        schema.TypeInt,
+				Description: "The maximum allowed lifetime of tokens issued in seconds using this role.",
+				Optional:    true,
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Description: "If set, indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this parameter.",
+				Optional:    true,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Policies to be set on tokens issued using this role.",
+				Optional:    true,
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the kubernetes backend to configure.",
+				ForceNew:    true,
+				Default:     "kubernetes",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+		},
+	}
+}
+
+func kubernetesAuthBackendRolePath(backend, role string) string {
+	return "auth/" + strings.Trim(backend, "/") + "/role/" + strings.Trim(role, "/")
+}
+
+func kubernetesAuthBackendRoleNameFromPath(path string) (string, error) {
+	if !kubernetesAuthBackendRoleNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no role found")
+	}
+	res := kubernetesAuthBackendRoleNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}
+
+func kubernetesAuthBackendRoleBackendFromPath(path string) (string, error) {
+	if !kubernetesAuthBackendRoleBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := kubernetesAuthBackendRoleBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}
+
+func kubernetesAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+	role := d.Get("role_name").(string)
+
+	path := kubernetesAuthBackendRolePath(backend, role)
+
+	log.Printf("[DEBUG] Writing Kubernetes auth backend role %q", path)
+
+	iBoundServiceAccountNames := d.Get("bound_service_account_names").([]interface{})
+	boundServiceAccountNames := make([]string, 0, len(iBoundServiceAccountNames))
+	for _, iBoundServiceAccountName := range iBoundServiceAccountNames {
+		boundServiceAccountNames = append(boundServiceAccountNames, iBoundServiceAccountName.(string))
+	}
+
+	iBoundServiceAccountNamespaces := d.Get("bound_service_account_namespaces").([]interface{})
+	boundServiceAccountNamespaces := make([]string, 0, len(iBoundServiceAccountNamespaces))
+	for _, iBoundServiceAccountNamespace := range iBoundServiceAccountNamespaces {
+		boundServiceAccountNamespaces = append(boundServiceAccountNamespaces, iBoundServiceAccountNamespace.(string))
+	}
+
+	data := map[string]interface{}{}
+
+	if len(boundServiceAccountNames) > 0 {
+		data["bound_service_account_names"] = boundServiceAccountNames
+	}
+	if len(boundServiceAccountNamespaces) > 0 {
+		data["bound_service_account_namespaces"] = boundServiceAccountNamespaces
+	}
+
+	if v, ok := d.GetOk("policies"); ok {
+		iPolicies := v.([]interface{})
+		policies := make([]string, 0, len(iPolicies))
+		for _, iPolicy := range iPolicies {
+			policies = append(policies, iPolicy.(string))
+		}
+
+		if len(policies) > 0 {
+			data["policies"] = policies
+		}
+	}
+
+	if v, ok := d.GetOk("ttl"); ok {
+		data["ttl"] = v.(int)
+	}
+
+	if v, ok := d.GetOk("max_ttl"); ok {
+		data["max_ttl"] = v.(int)
+	}
+
+	if v, ok := d.GetOk("period"); ok {
+		data["period"] = v.(int)
+	}
+
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error writing Kubernetes auth backend role %q: %s", path, err)
+	}
+	d.SetId(path)
+	log.Printf("[DEBUG] Wrote Kubernetes auth backend role %q", path)
+
+	return kubernetesAuthBackendRoleRead(d, meta)
+}
+
+func kubernetesAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	backend, err := kubernetesAuthBackendRoleBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for Kubernetes auth backend role: %s", path, err)
+	}
+
+	role, err := kubernetesAuthBackendRoleNameFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for Kubernetes auth backend role: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading Kubernetes auth backend role: %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading Kubernetes auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read Kubernetes auth backend role: %q", path)
+	if resp == nil {
+		log.Printf("[WARN] Kubernetes auth backend role %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("backend", backend)
+	d.Set("role_name", role)
+
+	iBoundServiceAccountNames := resp.Data["bound_service_account_names"].([]interface{})
+	boundServiceAccountNames := make([]string, 0, len(iBoundServiceAccountNames))
+
+	for _, iBoundServiceAccountName := range iBoundServiceAccountNames {
+		boundServiceAccountNames = append(boundServiceAccountNames, iBoundServiceAccountName.(string))
+	}
+
+	d.Set("bound_service_account_names", boundServiceAccountNames)
+
+	iBoundServiceAccountNamespaces := resp.Data["bound_service_account_namespaces"].([]interface{})
+	boundServiceAccountNamespaces := make([]string, 0, len(iBoundServiceAccountNamespaces))
+
+	for _, iBoundServiceAccountNamespace := range iBoundServiceAccountNamespaces {
+		boundServiceAccountNamespaces = append(boundServiceAccountNamespaces, iBoundServiceAccountNamespace.(string))
+	}
+
+	d.Set("bound_service_account_namespaces", boundServiceAccountNamespaces)
+
+	iPolicies := resp.Data["policies"].([]interface{})
+	policies := make([]string, 0, len(iPolicies))
+
+	for _, iPolicy := range iPolicies {
+		policies = append(policies, iPolicy.(string))
+	}
+
+	d.Set("policies", policies)
+
+	ttl, err := resp.Data["ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected `ttl` %q to be a number, isn't", resp.Data["ttl"])
+	}
+	d.Set("ttl", ttl)
+
+	maxTTL, err := resp.Data["max_ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected `max_ttl` %q to be a number, isn't", resp.Data["max_ttl"])
+	}
+	d.Set("max_ttl", maxTTL)
+
+	period, err := resp.Data["period"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected `period` %q to be a number, isn't", resp.Data["period"])
+	}
+	d.Set("period", period)
+
+	return nil
+}
+
+func kubernetesAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Updating Kubernetes auth backend role %q", path)
+
+	iBoundServiceAccountNames := d.Get("bound_service_account_names").([]interface{})
+	boundServiceAccountNames := make([]string, 0, len(iBoundServiceAccountNames))
+	for _, iBoundServiceAccountName := range iBoundServiceAccountNames {
+		boundServiceAccountNames = append(boundServiceAccountNames, iBoundServiceAccountName.(string))
+	}
+
+	iBoundServiceAccountNamespaces := d.Get("bound_service_account_namespaces").([]interface{})
+	boundServiceAccountNamespaces := make([]string, 0, len(iBoundServiceAccountNamespaces))
+	for _, iBoundServiceAccountNamespace := range iBoundServiceAccountNamespaces {
+		boundServiceAccountNamespaces = append(boundServiceAccountNamespaces, iBoundServiceAccountNamespace.(string))
+	}
+
+	iPolicies := d.Get("policies").([]interface{})
+	policies := make([]string, 0, len(iPolicies))
+	for _, iPolicy := range iPolicies {
+		policies = append(policies, iPolicy.(string))
+	}
+
+	data := map[string]interface{}{
+		"bound_service_account_names":      strings.Join(boundServiceAccountNames, ","),
+		"bound_service_account_namespaces": strings.Join(boundServiceAccountNamespaces, ","),
+		"policies":                         strings.Join(policies, ","),
+	}
+
+	if v, ok := d.GetOk("ttl"); ok {
+		data["ttl"] = v.(int)
+	}
+
+	if v, ok := d.GetOk("max_ttl"); ok {
+		data["max_ttl"] = v.(int)
+	}
+
+	if v, ok := d.GetOk("period"); ok {
+		data["period"] = v.(int)
+	}
+
+	_, err := client.Logical().Write(path, data)
+
+	d.SetId(path)
+
+	if err != nil {
+		return fmt.Errorf("error updating Kubernetes auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated Kubernetes auth backend role %q", path)
+
+	return kubernetesAuthBackendRoleRead(d, meta)
+}
+
+func kubernetesAuthBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting Kubernetes auth backend role %q", path)
+	_, err := client.Logical().Delete(path)
+	if err != nil && !is404(err) {
+		return fmt.Errorf("error deleting Kubernetes auth backend role %q", path)
+	} else if err != nil {
+		log.Printf("[DEBUG] Kubernetes auth backend role %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+	log.Printf("[DEBUG] Deleted Kubernetes auth backend role %q", path)
+
+	return nil
+}
+
+func kubernetesAuthBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	log.Printf("[DEBUG] Checking if Kubernetes auth backend role %q exists", path)
+
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("error checking if Kubernetes auth backend role %q exists: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if Kubernetes auth backend role %q exists", path)
+
+	return resp != nil, nil
+}

--- a/vault/resource_kubernetes_auth_backend_role_test.go
+++ b/vault/resource_kubernetes_auth_backend_role_test.go
@@ -1,0 +1,351 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+	"strconv"
+)
+
+func TestAccKubernetesAuthBackendRole_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	role := acctest.RandomWithPrefix("test-role")
+	ttl := 3600
+	maxTTL := 3600
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_full(backend, role, ttl, maxTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(ttl)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"max_ttl", strconv.Itoa(maxTTL)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"period", "900"),
+				),
+			},
+			{
+				ResourceName:      "vault_kubernetes_auth_backend_role.role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendRole_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	role := acctest.RandomWithPrefix("test-role")
+	ttl := 3600
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_basic(backend, role, ttl),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", "3600"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendRole_update(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	role := acctest.RandomWithPrefix("test-role")
+	oldTTL := 3600
+	newTTL := oldTTL * 2
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_basic(backend, role, oldTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(oldTTL)),
+				),
+			},
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_basic(backend, role, newTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(newTTL)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendRole_full(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	role := acctest.RandomWithPrefix("test-role")
+	ttl := 3600
+	maxTTL := 3600
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_full(backend, role, ttl, maxTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(ttl)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"max_ttl", strconv.Itoa(maxTTL)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"period", "900"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesAuthBackendRole_fullUpdate(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	role := acctest.RandomWithPrefix("test-role")
+	oldTTL := 3600
+	newTTL := oldTTL * 2
+	oldMaxTTL := 3600
+	newMaxTTL := oldMaxTTL * 2
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_full(backend, role, oldTTL, oldMaxTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(oldTTL)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"max_ttl", strconv.Itoa(oldMaxTTL)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"period", "900"),
+				),
+			},
+			{
+				Config: testAccKubernetesAuthBackendRoleConfig_full(backend, role, newTTL, newMaxTTL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_names.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.0", "example"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"bound_service_account_namespaces.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.1", "dev"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.2", "prod"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"ttl", strconv.Itoa(newTTL)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"max_ttl", strconv.Itoa(newMaxTTL)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.role",
+						"period", "900"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKubernetesAuthBackendRoleDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_kubernetes_auth_backend_role" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for Kubernetes auth backend role %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("Kubernetes auth backend role %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccKubernetesAuthBackendRoleConfig_basic(backend, role string, ttl int) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+  path = %q
+}
+
+resource "vault_kubernetes_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.kubernetes.path}"
+  role_name = %q
+  bound_service_account_names = ["example"]
+  bound_service_account_namespaces = ["example"]
+  ttl = %d
+  policies = ["default", "dev", "prod"]
+}`, backend, role, ttl)
+}
+
+func testAccKubernetesAuthBackendRoleConfig_full(backend, role string, ttl, maxTTL int) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+  path = %q
+}
+
+resource "vault_kubernetes_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.kubernetes.path}"
+  role_name = %q
+  bound_service_account_names = ["example"]
+  bound_service_account_namespaces = ["example"]
+  ttl = %d
+  max_ttl = %d
+  period = 900
+  policies = ["default", "dev", "prod"]
+}`, backend, role, ttl, maxTTL)
+}

--- a/website/docs/d/kubernetes_auth_backend_config.md
+++ b/website/docs/d/kubernetes_auth_backend_config.md
@@ -1,0 +1,43 @@
+---
+layout: "vault"
+page_title: "Vault: vault_kubernetes_auth_backend_config data source"
+sidebar_current: "docs-vault-datasource-kubernetes-auth-backend-config"
+description: |-
+  Manages Kubernetes auth backend configs in Vault.
+---
+
+# vault\_kubernetes\_auth\_backend\_config
+
+Reads the Role of an Kubernetes from a Vault server. See the [Vault
+documentation](https://www.vaultproject.io/api/auth/kubernetes/index.html#read-config) for more
+information.
+
+## Example Usage
+
+```hcl
+data "vault_kubernetes_auth_backend_config" "config" {
+  backend   = "my-kubernetes-backend"
+}
+
+output "token_reviewer_jwt" {
+  value = "${data.vault_kubernetes_auth_backend_config.config.token_reviewer_jwt}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `backend` - (Optional) The unique name for the Kubernetes backend the config to
+  retrieve Role attributes for resides in. Defaults to "kubernetes".
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `kubernetes_host` - Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
+
+* `kubernetes_ca_cert` - PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.
+
+* `pem_keys` - Optional list of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.
+

--- a/website/docs/d/kubernetes_auth_backend_role.md
+++ b/website/docs/d/kubernetes_auth_backend_role.md
@@ -1,0 +1,53 @@
+---
+layout: "vault"
+page_title: "Vault: vault_kubernetes_auth_backend_role data source"
+sidebar_current: "docs-vault-datasource-kubernetes-auth-backend-role"
+description: |-
+  Manages Kubernetes auth backend roles in Vault.
+---
+
+# vault\_kubernetes\_auth\_backend\_role
+
+Reads the Role of an Kubernetes from a Vault server. See the [Vault
+documentation](https://www.vaultproject.io/api/auth/kubernetes/index.html#read-role) for more
+information.
+
+## Example Usage
+
+```hcl
+data "vault_kubernetes_auth_backend_role" "role" {
+  backend   = "my-kubernetes-backend"
+  role_name = "my-role"
+}
+
+output "policies" {
+  value = "${data.vault_kubernetes_auth_backend_role.role.policies}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `role_name` - (Required) The name of the role to retrieve the Role attributes for.
+
+* `backend` - (Optional) The unique name for the Kubernetes backend the role to
+  retrieve Role attributes for resides in. Defaults to "kubernetes".
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `bound_service_account_names` - List of service account names able to access this role. If set to "*" all names are allowed, both this and bound_service_account_namespaces can not be "*".
+
+* `bound_service_account_namespaces` - List of namespaces allowed to access this role. If set to "*" all namespaces are allowed, both this and bound_service_account_names can not be set to "*".
+
+* `ttl` - The TTL period of tokens issued using this role in seconds.
+
+* `max_ttl` - The maximum allowed lifetime of tokens issued in seconds using this role.
+
+* `num_uses` - Number of times issued tokens can be used. Setting this to 0 or leaving it unset means unlimited uses.
+
+* `period` - If set, indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this parameter.
+
+* `policies` - Policies to be set on tokens issued using this role.

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -1,0 +1,44 @@
+---
+layout: "vault"
+page_title: "Vault: vault_kubernetes_auth_backend_config resource"
+sidebar_current: "docs-vault-kubernetes-auth-backend-config"
+description: |-
+  Manages Kubernetes auth backend configs in Vault.
+---
+
+# vault\_kubernetes\_auth\_backend\_config
+
+Manages an Kubernetes auth backend config in a Vault server. See the [Vault
+documentation](https://www.vaultproject.io/docs/auth/kubernetes.html) for more
+information.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+}
+
+resource "vault_kubernetes_auth_backend_config" "example" {
+  backend   = "${vault_auth_backend.kubernetes.path}"
+  kubernetes_host = "http://example.com:443"
+  kubernetes_ca_cert = "-----BEGIN CERTIFICATE-----\nexample\n-----END CERTIFICATE-----"
+  token_reviewer_jwt = "ZXhhbXBsZQo="
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `kubernetes_host` - (Required) Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
+
+* `kubernetes_ca_cert` - (Optional) PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.
+
+* `token_reviewer_jwt` - (Optional) A service account JWT used to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API.
+
+* `pem_keys` - (Optional) List of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys. 
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.

--- a/website/docs/r/kubernetes_auth_backend_role.md
+++ b/website/docs/r/kubernetes_auth_backend_role.md
@@ -1,0 +1,54 @@
+---
+layout: "vault"
+page_title: "Vault: vault_kubernetes_auth_backend_role resource"
+sidebar_current: "docs-vault-kubernetes-auth-backend-role"
+description: |-
+  Manages Kubernetes auth backend roles in Vault.
+---
+
+# vault\_kubernetes\_auth\_backend\_role
+
+Manages an Kubernetes auth backend role in a Vault server. See the [Vault
+documentation](https://www.vaultproject.io/docs/auth/kubernetes.html) for more
+information.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+}
+
+resource "vault_kubernetes_auth_backend_role" "example" {
+  backend   = "${vault_auth_backend.kubernetes.path}"
+  role_name = "example-role"
+  bound_service_account_names = ["example"]
+  bound_service_account_namespaces = ["example"]
+  ttl = 3600
+  policies = ["default", "dev", "prod"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `role_name` - (Required) Name of the role.
+
+* `bound_service_account_names` - (Optional) List of service account names able to access this role. If set to "*" all names are allowed, both this and bound_service_account_namespaces can not be "*".
+
+* `bound_service_account_namespaces` - (Optional) List of namespaces allowed to access this role. If set to "*" all namespaces are allowed, both this and bound_service_account_names can not be set to "*".
+
+* `ttl` - (Optional) The TTL period of tokens issued using this role in seconds.
+
+* `max_ttl` - (Optional) The maximum allowed lifetime of tokens issued in seconds using this role.
+
+* `period` - (Optional) If set, indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this parameter.
+
+* `policies` - (Optional) Policies to be set on tokens issued using this role.
+
+* `backend` - (Optional) Unique name of the kubernetes backend to configure.
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -26,6 +26,14 @@
                             <a href="/docs/providers/vault/d/generic_secret.html">vault_generic_secret</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-datasource-kubernetes-auth-backend-config") %>>
+                            <a href="/docs/providers/vault/d/kubernetes_auth_backend_config.html">vault_kubernetes_auth_backend_config</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-datasource-kubernetes-auth-backend-role") %>>
+                            <a href="/docs/providers/vault/d/kubernetes_auth_backend_role.html">vault_kubernetes_auth_backend_role</a>
+                        </li>
+
                     </ul>
                 </li>
 
@@ -93,6 +101,14 @@
 
                         <li<%= sidebar_current("docs-vault-resource-generic-secret") %>>
                             <a href="/docs/providers/vault/r/generic_secret.html">vault_generic_secret</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-kubernetes-auth-backend-config") %>>
+                            <a href="/docs/providers/vault/r/kubernetes_auth_backend_config.html">vault_kubernetes_auth_backend_config</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-kubernetes-auth-backend-role") %>>
+                            <a href="/docs/providers/vault/r/kubernetes_auth_backend_role.html">vault_kubernetes_auth_backend_role</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-okta-auth-backend") %>>


### PR DESCRIPTION
Work on https://github.com/terraform-providers/terraform-provider-vault/issues/93.

Resources identified and implemented:

* kubernetes_auth_backend_config (create,update,delete,tested and documented)
* kubernetes_auth_backend_role (create,update,delete,tested and documented)

Data sources identified and implemented:

* kubernetes_auth_backend_config (read,tested and documented)
* kubernetes_auth_backend_role (read,tested and documented)

Also included cherry-picked commits from #95 and #103 .