### PR TITLE
Fix test for cassandra not being skipped

### DIFF
--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -50,6 +50,10 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 	host := os.Getenv("CASSANDRA_HOST")
+	if host == "" {
+		t.Skip("CASSANDRA_HOST not set")
+	}
+
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")


### PR DESCRIPTION
Without a set `CASSANDRA_HOST`, the `TestAccDatabaseSecretBackendConnection_cassandra` would always fail.

I've implemented the same skip behavior as seen in tests for other external resources. 


Just a small nitpick I had when running the test suite.

@paddycarver 