### PR TITLE
[GH-47] Fix documentation for aws_auth_backend_role

### DIFF
--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -105,17 +105,17 @@ func awsAuthBackendRoleResource() *schema.Resource {
 			"ttl": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The TTL period of tokens issued using this role, provided as the number of minutes.",
+				Description: "The TTL period of tokens issued using this role, provided as the number of seconds.",
 			},
 			"max_ttl": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The maximum allowed lifetime of tokens issued using this role.",
+				Description: "The maximum allowed lifetime of tokens issued using this role, provided as the number of seconds.",
 			},
 			"period": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The duration in which a token should be renewed. At each renewal, the token's TTL will be set to the value of this parameter.",
+				Description: "If set, indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this field. The maximum allowed lifetime of token issued using this role. Specified as a number of seconds.",
 			},
 			"policies": {
 				Type:     schema.TypeList,

--- a/website/docs/r/aws_auth_backend_role.html.md
+++ b/website/docs/r/aws_auth_backend_role.html.md
@@ -120,16 +120,16 @@ The following arguments are supported:
   the value set to `true`.
 
 * `ttl` - (Optional) The TTL period of tokens issued using this role, provided
-  as a number of minutes.
+  as a number of seconds.
 
 * `max_ttl` - (Optional) The maximum allowed lifetime of tokens issued using
-  this role, provided as a number of minutes.
+  this role, provided as a number of seconds.
 
 * `period` - (Optional) If set, indicates that the token generated using this
   role should never expire. The token should be renewed within the duration
   specified by this value. At each renewal, the token's TTL will be set to the
   value of this field. The maximum allowed lifetime of token issued using this
-  role. Specified as a number of minutes.
+  role. Specified as a number of seconds.
 
 * `policies` - (Optional) An array of strings specifying the policies to be set
   on tokens issued using this role.


### PR DESCRIPTION
Replace misleading `minutes` unit with the actual `seconds` unit.

Reference Vault commit and line-numbers that seconds is actually the unit of choice:

* https://github.com/hashicorp/vault/blob/e2bb2ec3b93a242a167f763684f93df867bb253d/builtin/credential/aws/path_role.go#L733
* https://github.com/hashicorp/vault/blob/e2bb2ec3b93a242a167f763684f93df867bb253d/builtin/credential/aws/path_role.go#L745
* https://github.com/hashicorp/vault/blob/e2bb2ec3b93a242a167f763684f93df867bb253d/builtin/credential/aws/path_role.go#L766


Fixes https://github.com/terraform-providers/terraform-provider-vault/issues/47

Ready for review @paddycarver 