### PR TITLE
Adding bypass_okta_mfa flag to vault_okta_auth_backend resource.

### DIFF
--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -80,6 +80,14 @@ func oktaAuthBackendResource() *schema.Resource {
 				Description: "Maximum duration after which authentication will be expired",
 			},
 
+			"bypass_okta_mfa": {
+				Type:        schema.TypeBool,
+				Required:    false,
+				Optional:    true,
+				Description: "Whether to bypass an Okta MFA request. Useful if using one of Vault's built-in MFA mechanisms, but this will also cause certain other statuses to be ignored, such as PASSWORD_EXPIRED.",
+				Default:     false,
+			},
+
 			"group": {
 				Type:     schema.TypeSet,
 				Required: false,
@@ -281,6 +289,10 @@ func oktaAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if maxTtl, ok := d.GetOk("max_ttl"); ok {
 		configuration["max_ttl"] = maxTtl
+	}
+
+	if bypassOktaMFA, ok := d.GetOk("bypass_okta_mfa"); ok {
+		configuration["bypass_okta_mfa"] = bypassOktaMFA
 	}
 
 	_, err := client.Logical().Write(oktaConfigEndpoint(path), configuration)

--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -50,6 +50,8 @@ If this is not supplied only locally configured groups will be enabled.
 * `max_ttl` - (Optional) Maximum duration after which authentication will be expired
 [See the documentation for info on valid duration formats](https://golang.org/pkg/time/#ParseDuration).
 
+* `bypass_okta_mfa` - (Optional) Whether to bypass an Okta MFA request. Useful if using one of Vault's built-in MFA mechanisms, but this will also cause certain other statuses to be ignored, such as PASSWORD_EXPIRED.
+
 * `group` - (Optional) Associate Okta groups with policies within Vault.
 [See below for more details](#okta-group). 
 


### PR DESCRIPTION
I took a stab at this.  I am noticing that the acceptance tests are failing (and were failing before these changes).

=== RUN   TestOktaAuthBackend
--- FAIL: TestOktaAuthBackend (7.98s)
	testing.go:434: Step 0 error: Check failed: Check 1/3 error: incorrect ttl: 3600

I am running them against Vault v0.10.0.

In my testing, this will properly set bypass_okta_mfa to true, but will not set it back to false.  Anyone have any idea why this is?

Thanks,
Ben

https://github.com/terraform-providers/terraform-provider-vault/issues/105