### PR TITLE
Typo in approle login resource name

### DIFF
--- a/website/docs/r/approle_auth_backend_login.md
+++ b/website/docs/r/approle_auth_backend_login.md
@@ -1,12 +1,12 @@
 ---
 layout: "vault"
-page_title: "Vault: vault_approle_auth_backend_role_login resource"
-sidebar_current: "docs-vault-approle-auth-backend-role-login"
+page_title: "Vault: vault_approle_auth_backend_login resource"
+sidebar_current: "docs-vault-approle-auth-backend-login"
 description: |-
   Log into Vault using the AppRole auth backend.
 ---
 
-# vault\_approle\_auth\_backend\_role\_login
+# vault\_approle\_auth\_backend\_login
 
 Logs into Vault using the AppRole auth backend. See the [Vault
 documentation](https://www.vaultproject.io/docs/auth/approle.html) for more
@@ -30,7 +30,7 @@ resource "vault_approle_auth_backend_role_secret_id" "id" {
   role_name = "${vault_approle_auth_backend_role.example.role_name}"
 }
 
-resource "vault_approle_auth_backend_role_login" "login" {
+resource "vault_approle_auth_backend_login" "login" {
   backend   = "${vault_auth_backend.approle.path}"
   role_id   = "${vault_approle_auth_backend_role.example.role_id}"
   secret_id = "${vault_approle_auth_backend_role_secret_id.id.secret_id}"


### PR DESCRIPTION
As of now resource name is [vault_approle_auth_backend_login](https://github.com/terraform-providers/terraform-provider-vault/blob/d5e4b2baf17cf94648ccf0c74392d447c34fc059/vault/resource_approle_auth_backend_login.go) [declaration](
https://github.com/terraform-providers/terraform-provider-vault/commit/baddbbf0c9ab01155bdfc7d19acfafc4846108c4#diff-ec6b668213758f85da277cfc634daef9R92) not `vault_approle_auth_backend_role_login` it contains extra word `_role_`.
