### PR TITLE
Added functionality to capture response from vault generic secret resources.

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -133,7 +133,6 @@ func genericSecretResourceWrite(d *schema.ResourceData, meta interface{}) error 
 			return nil
 		}
 		jsonDataBytes, err := json.Marshal(secret.Data)
-		log.Printf("[DEBUG] Secret is %s", jsonDataBytes)
 		if err != nil {
 			return fmt.Errorf("Error marshaling JSON for %q: %s", path, err)
 		}
@@ -148,20 +147,20 @@ func genericSecretResourceWrite(d *schema.ResourceData, meta interface{}) error 
 		for k, v := range secret.Data {
 			if vs, ok := v.(string); ok {
 				dataMap[k] = vs
-			} else {
-				// Again ignoring error because we know this value
-				// came from JSON in the first place and so must be valid.
-				vBytes, _ := json.Marshal(v)
-				dataMap[k] = string(vBytes)
+				continue
 			}
+			// Again ignoring error because we know this value
+			// came from JSON in the first place and so must be valid.
+			vBytes, _ := json.Marshal(v)
+			dataMap[k] = string(vBytes)
 		}
 		d.Set("data", dataMap)
 
 		d.Set("path", path)
 		return nil
-	} else {
-		return genericSecretResourceRead(d, meta)
 	}
+
+	return genericSecretResourceRead(d, meta)
 }
 
 func genericSecretResourceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -45,10 +45,10 @@ func genericSecretResource() *schema.Resource {
 			},
 
 			"data": &schema.Schema{
-				Type:		  schema.TypeMap,
-				Required:	  false,
-				Description:  "Data returned from the resource.  Should be a map containing the content from data_json.",
-				Computed:	  true,
+				Type:        schema.TypeMap,
+				Required:    false,
+				Description: "Data returned from the resource.  Should be a map containing the content from data_json.",
+				Computed:    true,
 			},
 
 			"allow_read": &schema.Schema{

--- a/website/docs/r/generic_secret.html.md
+++ b/website/docs/r/generic_secret.html.md
@@ -50,6 +50,10 @@ The following arguments are supported:
 
 * `data_json` - (Required) String containing a JSON-encoded object that will be
   written as the secret data at the given path.
+  
+* `capture_response` - (Optional) True/false.  Set this to true for writes which return data
+  as part of their response (i.e. CSRs generated with the pki backend).  The data will be 
+  available in the data_json and data attributes.
 
 * `allow_read` - (Optional, Deprecated) True/false. Set this to true if your
   vault authentication is able to read the data, this allows the resource to be


### PR DESCRIPTION
This adds a "capture_response" setting to vault_generic_secret resources, which allows data that is only returned in a response to a Create/Write call to be accessed in the resultant data_json and data attributes.  (i.e. CSRs returned from pki endpoints and certificates returned from signing requests). This should provide a workable solution for #67 and #111  .  

[Note that this is my first foray into Go programming and has only been lightly tested.]. 