### PR TITLE
Fix #128: vault_aws_auth_backend_role.resolve_aws_unique_ids setting not detected

### DIFF
--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -211,7 +211,7 @@ func awsAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("role_tag"); ok {
 			data["role_tag"] = v.(string)
 		}
-		if v, ok := d.GetOk("allow_instance_migration"); ok {
+		if v, ok := d.GetOkExists("allow_instance_migration"); ok {
 			data["allow_instance_migration"] = v.(bool)
 		}
 		if v, ok := d.GetOk("disallow_reauthentication"); ok {
@@ -228,7 +228,7 @@ func awsAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("inferred_aws_region"); ok {
 			data["inferred_aws_region"] = v.(string)
 		}
-		if v, ok := d.GetOk("resolve_aws_unique_ids"); ok {
+		if v, ok := d.GetOkExists("resolve_aws_unique_ids"); ok {
 			data["resolve_aws_unique_ids"] = v.(bool)
 		}
 	}
@@ -370,7 +370,7 @@ func awsAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("role_tag"); ok {
 			data["role_tag"] = v.(string)
 		}
-		if v, ok := d.GetOk("allow_instance_migration"); ok {
+		if v, ok := d.GetOkExists("allow_instance_migration"); ok {
 			data["allow_instance_migration"] = v.(bool)
 		}
 		if v, ok := d.GetOk("disallow_reauthentication"); ok {
@@ -387,7 +387,7 @@ func awsAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("inferred_aws_region"); ok {
 			data["inferred_aws_region"] = v.(string)
 		}
-		if v, ok := d.GetOk("resolve_aws_unique_ids"); ok {
+		if v, ok := d.GetOkExists("resolve_aws_unique_ids"); ok {
 			data["resolve_aws_unique_ids"] = v.(bool)
 		}
 	}


### PR DESCRIPTION
Per the schema.ResourceData docs[0], GetOkExists is needed for properly detecting whether optional boolean values have been set.

[0] https://godoc.org/github.com/hashicorp/terraform/helper/schema#ResourceData.GetOkExists