### PR TITLE
Adding provider support for SSH key signing

### DIFF
--- a/vault/data_source_ssh_signed_key.go
+++ b/vault/data_source_ssh_signed_key.go
@@ -1,0 +1,133 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func sshSignCertificateDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: sshSignCertificateRead,
+
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "SSH Secret Engine to read credentials from.",
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the name of the role to sign. This is part of the request URL.",
+			},
+			"cert_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "user",
+				Description: "Specifies the type of certificate to be created; either 'user' or 'host'.",
+			},
+			"public_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "SSH Public Key to Sign.",
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1800,
+				Description: "Number of seconds that the signature will be valid for (defaults to 30 minutes). Cannot be greater than the role's max_ttl value. If not provided, the role's ttl value will be used.",
+			},
+			"valid_principals": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "*",
+				Description: "Specifies valid principals, either usernames or hostnames, that the certificate should be signed for.",
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Specifies the key id that the created certificate should have. If not specified, the display name of the token will be used.",
+			},
+			"lease_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Lease identifier assigned by vault.",
+			},
+			"serial_number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Serial number of the signed certificate.",
+			},
+			"signed_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Signed certificate key.",
+			},
+
+			"lease_duration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Lease duration in seconds relative to the time in lease_start_time.",
+			},
+
+			"lease_start_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time at which the lease was read, using the clock of the system where Terraform was running",
+			},
+
+			"lease_renewable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if the duration of this lease can be extended through renewal.",
+			},
+		},
+	}
+}
+
+func sshSignCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+	certType := d.Get("cert_type").(string)
+	role := d.Get("role").(string)
+	publicKey := d.Get("public_key").(string)
+	ttl := d.Get("ttl").(int)
+	validPrincipals := d.Get("valid_principals").(string)
+	keyId := d.Get("key_id").(string)
+	path := backend + "/sign/" + role
+
+	data := map[string]interface{}{
+		"cert_type":        certType,
+		"public_key":       publicKey,
+		"ttl":              ttl,
+		"key_id":           keyId,
+		"valid_principals": validPrincipals,
+	}
+
+	log.Printf("[DEBUG] Writing %q to Vault", path)
+	secret, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("Error writing to Vault: %s", err)
+	}
+	log.Printf("[DEBUG] Write %q to Vault", path)
+
+	if secret == nil {
+		return fmt.Errorf("No role found at %q; are you sure you're using the right backend and role?", path)
+	}
+
+	d.SetId(secret.RequestID)
+	d.Set("signed_key", secret.Data["signed_key"])
+	d.Set("serial_number", secret.Data["serial_number"])
+	d.Set("lease_id", secret.LeaseID)
+	d.Set("lease_duration", secret.LeaseDuration)
+	d.Set("lease_start_time", time.Now().Format("RFC3339"))
+	d.Set("lease_renewable", secret.Renewable)
+
+	return nil
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -86,6 +86,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"vault_approle_auth_backend_role_id": approleAuthBackendRoleIDDataSource(),
 			"vault_aws_access_credentials":       awsAccessCredentialsDataSource(),
+			"vault_ssh_signed_key":               sshSignCertificateDataSource(),
 			"vault_generic_secret":               genericSecretDataSource(),
 		},
 

--- a/website/docs/d/ssh_signed_key.html.md
+++ b/website/docs/d/ssh_signed_key.html.md
@@ -1,0 +1,74 @@
+---
+layout: "vault"
+page_title: "Vault: SSH Signed Key data source"
+sidebar_current: "docs-vault-datasource-ssh-signed_key"
+description: |-
+  Sign a key for SSH access to a system
+---
+
+# vault\_ssh\_signed\_key
+
+Signs an SSH public key for access to a system
+
+This resource is intended to be used with
+[Vault's "ssh" secret engine](https://www.vaultproject.io/api/secret/ssh/index.html),
+configured with a CA.
+
+## Example Usage
+
+```hcl
+resource "tls_private_key" "key" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
+data "vault_ssh_signed_key" "key" {
+  backend = "ssh"
+  role = "test-ca"
+  valid_principals = "*"
+  ttl = "1800"
+  public_key = "${tls_private_key.key.public_key_openssh}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `backend` - (Required) Mount point for the SSH backend in Vault.
+* `role` - (Required) Role used to sign in
+* `cert_type` - (Required) Specifies the type of certificate to be created; either 'user' or 'host'.
+* `public_key` - (Required) SSH Key to sign.
+* `ttl` - (Optional) Time to live for the signature, defaults to 30 minutes.
+* `valid_principals` - (Optional) Specifies valid principals, either usernames or hostnames, that the certificate should be signed for..
+* `key_id` - (Optional) Specifies the key id that the created certificate should have. If not specified, the display name of the token will be used.
+
+
+## Required Vault Capabilities
+
+Use of this resource requires the `write` capability on the relevant paths (backend/sign/role).
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `serial_number` - Serial of the signed certificate.
+
+* `signed_key` - Key to use for logging into a system.
+
+* `lease_id` - The lease identifier assigned by Vault, if any.
+
+* `lease_duration` - The duration of the secret lease, in seconds relative
+to the time the data was requested. Once this time has passed any plan
+generated with this data may fail to apply.
+
+* `lease_start_time` - As a convenience, this records the current time
+on the computer where Terraform is running when the data is requested.
+This can be used to approximate the absolute time represented by
+`lease_duration`, though users must allow for any clock drift and response
+latency relative to to the Vault server.
+
+* `lease_renewable` - `true` if the lease can be renewed using Vault's
+`sys/renew/{lease-id}` endpoint. Terraform does not currently support lease
+renewal, and so it will request a new lease each time this data source is
+refreshed.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -22,6 +22,10 @@
                             <a href="/docs/providers/vault/d/aws_access_credentials.html">vault_aws_access_credentials</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-datasource-ssh-signed-key") %>>
+                            <a href="/docs/providers/vault/d/ssh_signed_key.html">vault_ssh_signed_key</a>
+                        </li>
+                        
                         <li<%= sidebar_current("docs-vault-datasource-generic-secret") %>>
                             <a href="/docs/providers/vault/d/generic_secret.html">vault_generic_secret</a>
                         </li>


### PR DESCRIPTION
Adding a data source for ssh signed keys. Useful in conjunction with a remote-exec ssh provisioner.