### PR TITLE
vault_aws_auth_backend_role: Add bound_ec2_instance_id parameter

### DIFF
--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -76,6 +76,11 @@ func awsAuthBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "Only EC2 instances associated with an IAM instance profile ARN that matches this value will be permitted to log in.",
 			},
+			"bound_ec2_instance_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Only EC2 instances that match this instance ID will be permitted to log in.",
+			},
 			"role_tag": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -206,6 +211,9 @@ func awsAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("bound_iam_instance_profile_arn"); ok {
 			data["bound_iam_instance_profile_arn"] = v.(string)
 		}
+		if v, ok := d.GetOk("bound_ec2_instance_id"); ok {
+			data["bound_ec2_instance_id"] = v.(string)
+		}
 	}
 	if authType == "ec2" {
 		if v, ok := d.GetOk("role_tag"); ok {
@@ -301,6 +309,7 @@ func awsAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("bound_subnet_id", resp.Data["bound_subnet_id"])
 	d.Set("bound_iam_role_arn", resp.Data["bound_iam_role_arn"])
 	d.Set("bound_iam_instance_profile_arn", resp.Data["bound_iam_instance_profile_arn"])
+	d.Set("bound_ec2_instance_id", resp.Data["bound_ec2_instance_id"])
 	d.Set("role_tag", resp.Data["role_tag"])
 	d.Set("bound_iam_principal_arn", resp.Data["bound_iam_principal_arn"])
 	d.Set("inferred_entity_type", resp.Data["inferred_entity_type"])
@@ -364,6 +373,9 @@ func awsAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		if v, ok := d.GetOk("bound_iam_instance_profile_arn"); ok {
 			data["bound_iam_instance_profile_arn"] = v.(string)
+		}
+		if v, ok := d.GetOk("bound_ec2_instance_id"); ok {
+			data["bound_ec2_instance_id"] = v.(string)
 		}
 	}
 	if authType == "ec2" {

--- a/vault/resource_aws_auth_backend_role_test.go
+++ b/vault/resource_aws_auth_backend_role_test.go
@@ -212,6 +212,7 @@ func testAccAWSAuthBackendRoleCheck_attrs(backend, role string) resource.TestChe
 			"bound_subnet_id":                "bound_subnet_id",
 			"bound_iam_role_arn":             "bound_iam_role_arn",
 			"bound_iam_instance_profile_arn": "bound_iam_instance_profile_arn",
+			"bound_ec2_instance_id":          "bound_ec2_instance_id",
 			"role_tag":                       "role_tag",
 			"bound_iam_principal_arn":        "bound_iam_principal_arn",
 			"inferred_entity_type":           "inferred_entity_type",
@@ -302,6 +303,7 @@ resource "vault_aws_auth_backend_role" "role" {
   bound_subnet_id = "vpc-a33128f1"
   bound_iam_role_arn = "arn:aws:iam::123456789012:role/S3Access"
   bound_iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/Webserver"
+  bound_ec2_instance_id = "i-06bb291939760ba66"
   inferred_entity_type = "ec2_instance"
   inferred_aws_region = "us-east-1"
   ttl = 60
@@ -366,6 +368,7 @@ resource "vault_aws_auth_backend_role" "role" {
   bound_subnet_id = "vpc-a33128f1"
   bound_iam_role_arn = "arn:aws:iam::123456789012:role/S3Access"
   bound_iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/Webserver"
+  bound_ec2_instance_id = "i-06bb291939760ba66"
   role_tag = "VaultRoleTag"
   allow_instance_migration = true
   disallow_reauthentication = true


### PR DESCRIPTION
Fixes GH-134

I've left the parameter as a string instead of a list, so that the fix for GH-92 can come after this and handle all the bind parameters at once.