### PR TITLE
Add resources for the Kubernetes auth backend

### DIFF
--- a/vault/kubernetes.go
+++ b/vault/kubernetes.go
@@ -1,0 +1,125 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/vault/api"
+)
+
+type kubernetesConfig struct {
+	Host             string
+	CACert           string
+	TokenReviewerJWT string
+	PEMKeys          []string
+}
+
+func kubernetesConfigEndpoint(path string) string {
+	return fmt.Sprintf("/auth/%s/config", path)
+}
+
+func readKubernetesConfig(client *api.Client, path string) (*kubernetesConfig, error) {
+	response, err := client.Logical().Read(kubernetesConfigEndpoint(path))
+	if err != nil {
+		return nil, err
+	}
+
+	if response != nil && response.Data != nil {
+		host, _ := response.Data["kubernetes_host"].(string)
+		caCert, _ := response.Data["kubernetes_ca_cert"].(string)
+		tokenReviewerJWT, _ := response.Data["token_reviewer_jwt"].(string)
+		pemKeys, _ := response.Data["pem_keys"].([]interface{})
+		pemKeyArray := make([]string, len(pemKeys))
+		for i, v := range pemKeys {
+			pemKeyArray[i] = v.(string)
+		}
+
+		return &kubernetesConfig{
+			Host:             host,
+			CACert:           caCert,
+			TokenReviewerJWT: tokenReviewerJWT,
+			PEMKeys:          pemKeyArray,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func updateKubernetesConfig(client *api.Client, path string, config kubernetesConfig) error {
+	_, err := client.Logical().Write(kubernetesConfigEndpoint(path), map[string]interface{}{
+		"kubernetes_host":    config.Host,
+		"kubernetes_ca_cert": config.CACert,
+		"token_reviewer_jwt": config.TokenReviewerJWT,
+		"pem_keys":           config.PEMKeys,
+	})
+
+	return err
+}
+
+type kubernetesRole struct {
+	Name            string
+	ServiceAccounts []string
+	Namespaces      []string
+	TTL             string
+	MaxTTL          string
+	Period          string
+	Policies        []string
+}
+
+func kubernetesRoleEndpoint(path, role string) string {
+	return fmt.Sprintf("/auth/%s/role/%s", path, role)
+}
+
+func readKubernetesRole(client *api.Client, path string, role string) (*kubernetesRole, error) {
+	response, err := client.Logical().Read(kubernetesRoleEndpoint(path, role))
+	if err != nil {
+		return nil, err
+	}
+
+	if response != nil && response.Data != nil {
+		log.Printf("[DEBUG] %+v\n", response)
+		serviceAccounts, _ := response.Data["bound_service_account_names"].([]interface{})
+		serviceAccountArray := make([]string, len(serviceAccounts))
+		for i, v := range serviceAccounts {
+			serviceAccountArray[i] = v.(string)
+		}
+		namespaces, _ := response.Data["bound_service_account_namespaces"].([]interface{})
+		namespaceArray := make([]string, len(namespaces))
+		for i, v := range namespaces {
+			namespaceArray[i] = v.(string)
+		}
+		ttl, _ := response.Data["ttl"].(string)
+		maxTTL, _ := response.Data["max_ttl"].(string)
+		period, _ := response.Data["period"].(string)
+		policies, _ := response.Data["policies"].([]interface{})
+		policyArray := make([]string, len(policies))
+		for i, v := range policies {
+			policyArray[i] = v.(string)
+		}
+
+		return &kubernetesRole{
+			Name:            role,
+			ServiceAccounts: serviceAccountArray,
+			Namespaces:      namespaceArray,
+			TTL:             ttl,
+			MaxTTL:          maxTTL,
+			Period:          period,
+			Policies:        policyArray,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func updateKubernetesRole(client *api.Client, path string, role kubernetesRole) error {
+	_, err := client.Logical().Write(kubernetesRoleEndpoint(path, role.Name), map[string]interface{}{
+		"bound_service_account_names":      role.ServiceAccounts,
+		"bound_service_account_namespaces": role.Namespaces,
+		"ttl":      role.TTL,
+		"max_ttl":  role.MaxTTL,
+		"period":   role.Period,
+		"policies": role.Policies,
+	})
+
+	return err
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -106,6 +106,8 @@ func Provider() terraform.ResourceProvider {
 			"vault_database_secret_backend_connection":  databaseSecretBackendConnectionResource(),
 			"vault_database_secret_backend_role":        databaseSecretBackendRoleResource(),
 			"vault_generic_secret":                      genericSecretResource(),
+			"vault_kubernetes_auth_backend":             kubernetesAuthBackendResource(),
+			"vault_kubernetes_auth_backend_role":        kubernetesAuthBackendRoleResource(),
 			"vault_okta_auth_backend":                   oktaAuthBackendResource(),
 			"vault_okta_auth_backend_user":              oktaAuthBackendUserResource(),
 			"vault_okta_auth_backend_group":             oktaAuthBackendGroupResource(),

--- a/vault/resource_kubernetes_auth_backend.go
+++ b/vault/resource_kubernetes_auth_backend.go
@@ -1,0 +1,183 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func kubernetesAuthBackendResource() *schema.Resource {
+	return &schema.Resource{
+		Create: kubernetesAuthBackendCreate,
+		Read:   kubernetesAuthBackendRead,
+		Update: kubernetesAuthBackendUpdate,
+		Delete: kubernetesAuthBackendDelete,
+		Exists: kubernetesAuthBackendExists,
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Path to mount the backend",
+				Default:     "kubernetes",
+				ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
+					value := v.(string)
+					if strings.HasSuffix(value, "/") {
+						errs = append(errs, errors.New("cannot write to a path ending in '/'"))
+					}
+					return
+				},
+			},
+
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The description of the auth backend",
+			},
+
+			"host": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "URL for the Kubernetes API server",
+			},
+
+			"ca_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "PEM encoded CA cert for use by the TLS client.",
+			},
+
+			"token_reviewer_jwt": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A service account JWT used to access the TokenReview API.",
+			},
+
+			"pem_keys": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "PEM encoded public keys or certificates to verify service account JWTs.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func kubernetesAuthBackendCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+	desc := d.Get("description").(string)
+
+	log.Printf("[DEBUG] Writing Kubernetes auth backend %q", path)
+	err := client.Sys().EnableAuth(path, "kubernetes", desc)
+	if err != nil {
+		return fmt.Errorf("Error writing Kubernetes auth backend %q: %s", path, err)
+	}
+
+	d.SetId(path)
+
+	return kubernetesAuthBackendUpdate(d, meta)
+}
+
+func kubernetesAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Reading Kubernetes auth backend %q", path)
+	config, err := readKubernetesConfig(client, path)
+	if err != nil {
+		return fmt.Errorf("Error reading Kubernetes auth backend %q: %s", path, err)
+	}
+
+	if config != nil {
+		if err := d.Set("host", config.Host); err != nil {
+			return err
+		}
+		if err := d.Set("ca_cert", config.CACert); err != nil {
+			return err
+		}
+		if err := d.Set("token_reviewer_jwt", config.TokenReviewerJWT); err != nil {
+			return err
+		}
+		if err := d.Set("pem_keys", config.PEMKeys); err != nil {
+			return err
+		}
+	} else {
+		// Resource does not exist, so clear ID
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func kubernetesAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	host := d.Get("host").(string)
+	caCert := d.Get("ca_cert").(string)
+	tokenReviewerJWT := d.Get("token_reviewer_jwt").(string)
+
+	var pemKeysArray []string
+	if pemKeys, ok := d.GetOk("pem_keys"); ok {
+		pemKeysArray = toStringArray(pemKeys.(*schema.Set).List())
+	} else {
+		pemKeysArray = []string{}
+	}
+
+	log.Printf("[DEBUG] Updating Kubernetes auth backend %q", path)
+	if err := updateKubernetesConfig(client, path, kubernetesConfig{
+		Host:             host,
+		CACert:           caCert,
+		TokenReviewerJWT: tokenReviewerJWT,
+		PEMKeys:          pemKeysArray,
+	}); err != nil {
+		return fmt.Errorf("Error updating Kubernetes auth backend %q: %s", path, err)
+	}
+
+	return kubernetesAuthBackendRead(d, meta)
+}
+
+func kubernetesAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Disabling Kubernetes auth backend %q", path)
+	err := client.Sys().DisableAuth(path)
+	if err != nil {
+		return fmt.Errorf("Error disabling Kubernetes auth backend %q: %s", path, err)
+	}
+
+	return nil
+}
+
+func kubernetesAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Checking if Kubernetes auth backend %q exists", path)
+	auths, err := client.Sys().ListAuth()
+	if err != nil {
+		return true, fmt.Errorf("Error checking if Kubernetes auth backend %q exists: %s", path, err)
+	}
+
+	for authPath, auth := range auths {
+		if auth.Type == "kubernetes" && authPath == fmt.Sprintf("%s/", path) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -1,0 +1,210 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func kubernetesAuthBackendRoleResource() *schema.Resource {
+	return &schema.Resource{
+		Create: kubernetesAuthBackendRoleWrite,
+		Read:   kubernetesAuthBackendRoleRead,
+		Update: kubernetesAuthBackendRoleWrite,
+		Delete: kubernetesAuthBackendRoleDelete,
+		Exists: kubernetesAuthBackendRoleExists,
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Path to the Kubernetes auth backend",
+			},
+
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the role",
+				ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
+					value := v.(string)
+					if strings.Contains(value, "/") {
+						errs = append(errs, errors.New("role name cannot contain '/'"))
+					}
+					return
+				},
+			},
+
+			"service_accounts": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "Service accounts able to access this role",
+				Set:         schema.HashString,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"namespaces": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "Namespaces able to access this role",
+				Set:         schema.HashString,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Lifetime of tokens issued by this role by default",
+			},
+
+			"max_ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Maximum lifetime of tokens issued by this role",
+			},
+
+			"period": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Indicates that the token issued by this role should never expire; on renewal the TTL of the token will be set to this value",
+			},
+
+			"policies": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Policies assigned to tokens issued by this role",
+				Set:         schema.HashString,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func kubernetesAuthBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+	name := d.Get("name").(string)
+	ttl := d.Get("ttl").(string)
+	maxTTL := d.Get("max_ttl").(string)
+	period := d.Get("period").(string)
+
+	var serviceAccountsArray []string
+	if serviceAccounts, ok := d.GetOk("service_accounts"); ok {
+		serviceAccountsArray = toStringArray(serviceAccounts.(*schema.Set).List())
+	} else {
+		serviceAccountsArray = []string{}
+	}
+
+	var namespacesArray []string
+	if namespaces, ok := d.GetOk("namespaces"); ok {
+		namespacesArray = toStringArray(namespaces.(*schema.Set).List())
+	} else {
+		namespacesArray = []string{}
+	}
+
+	var policiesArray []string
+	if policies, ok := d.GetOk("policies"); ok {
+		policiesArray = toStringArray(policies.(*schema.Set).List())
+	} else {
+		policiesArray = []string{}
+	}
+
+	log.Printf("[DEBUG] Writing Kubernetes auth backend %q role %q", path, name)
+	if err := updateKubernetesRole(client, path, kubernetesRole{
+		Name:            name,
+		ServiceAccounts: serviceAccountsArray,
+		Namespaces:      namespacesArray,
+		TTL:             ttl,
+		MaxTTL:          maxTTL,
+		Period:          period,
+		Policies:        policiesArray,
+	}); err != nil {
+		return fmt.Errorf("Error writing Kubernetes auth backend %q role %q: %s", path, name, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", path, name))
+
+	return kubernetesAuthBackendRoleRead(d, meta)
+}
+
+func kubernetesAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+	name := d.Get("name").(string)
+
+	log.Printf("[DEBUG] Reading Kubernetes auth backend %q role %q", path, name)
+	role, err := readKubernetesRole(client, path, name)
+	if err != nil {
+		return fmt.Errorf("Error reading Kubernetes auth backend %q role %q: %s", path, name, err)
+	}
+
+	if role != nil {
+		if err := d.Set("service_accounts", role.ServiceAccounts); err != nil {
+			return err
+		}
+		if err := d.Set("namespaces", role.Namespaces); err != nil {
+			return err
+		}
+		if err := d.Set("ttl", role.TTL); err != nil {
+			return err
+		}
+		if err := d.Set("max_ttl", role.MaxTTL); err != nil {
+			return err
+		}
+		if err := d.Set("period", role.Period); err != nil {
+			return err
+		}
+		if err := d.Set("policies", role.Policies); err != nil {
+			return err
+		}
+	} else {
+		// Resource does not exist, so clear ID
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func kubernetesAuthBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+	name := d.Get("name").(string)
+
+	log.Printf("[DEBUG] Removing Kubernetes auth backend %q role %q", path, name)
+	if _, err := client.Logical().Delete(kubernetesRoleEndpoint(path, name)); err != nil {
+		return fmt.Errorf("Error removing Kubernetes auth backend %q role %q: %s", path, name, err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func kubernetesAuthBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+	name := d.Get("name").(string)
+
+	log.Printf("[DEBUG] Checking if Kubernetes auth backend %q role %q exists", path, name)
+	resp, err := client.Logical().Read(fmt.Sprintf("auth/%s/role/%s", path, name))
+	if err != nil {
+		return true, fmt.Errorf("Error checking if Kubernetes auth backend %q role %q exists: %s", path, name, err)
+	}
+
+	return resp != nil, nil
+}

--- a/vault/resource_kubernetes_auth_backend_role_test.go
+++ b/vault/resource_kubernetes_auth_backend_role_test.go
@@ -1,0 +1,125 @@
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestKubernetesAuthRoleBackend(t *testing.T) {
+	path := "kubernetes-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testKubernetesAuthRoleCheckDestroy(path, "test"),
+		Steps: []resource.TestStep{
+			{
+				Config: initialKubernetesAuthRoleConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "path", path),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "name", "test"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test.service_accounts", "0", "test_1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test.namespaces", "0", "test_1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "ttl", "3600"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "max_ttl", "86400"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "period", "1800"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test.policies", "0", "test_1"),
+				),
+			},
+			{
+				Config: updatedKubernetesAuthRoleConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "path", path),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "name", "test"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test.service_accounts", "0", "test_1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test.service_accounts", "1", "test_2"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test.namespaces", "0", "test_2"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "ttl", "1800"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "max_ttl", "43200"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test", "period", "900"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_role.test.policies", "0", ""),
+				),
+			},
+		},
+	})
+}
+
+func initialKubernetesAuthRoleConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_kubernetes_auth_backend" "test" {
+    path = "%s"
+    host = "test host"
+}
+
+resource "vault_kubernetes_auth_backend_role" "test" {
+    path = "${vault_kubernetes_auth_backend.test.path}"
+    name = "test"
+    ttl = "3600"
+    max_ttl = "86400"
+    period = "1800"
+
+    service_accounts = [
+        "test_1",
+    ]
+
+    namespaces = [
+        "test_1",
+    ]
+
+    policies = [
+        "test_1"
+    ]
+}
+`, path)
+}
+
+func updatedKubernetesAuthRoleConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_kubernetes_auth_backend" "test" {
+    path = "%s"
+    host = "test host"
+}
+
+resource "vault_kubernetes_auth_backend_role" "test" {
+    path = "${vault_kubernetes_auth_backend.test.path}"
+    name = "test"
+    ttl = "1800"
+    max_ttl = "43200"
+    period = "900"
+
+    service_accounts = [
+        "test_1",
+        "test_2",
+    ]
+
+    namespaces = [
+        "test_2",
+    ]
+
+    policies = [
+    ]
+}
+`, path)
+}
+
+func testKubernetesAuthRoleCheckDestroy(path string, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testProvider.Meta().(*api.Client)
+
+		role, err := client.Logical().Read(fmt.Sprintf("/auth/%s/role/%s", path, name))
+		if err != nil {
+			return fmt.Errorf("Error reading Kubernetes role: %s", err)
+		}
+		if role != nil {
+			return fmt.Errorf("Kubernetes role still exists")
+		}
+
+		return nil
+	}
+}

--- a/vault/resource_kubernetes_auth_backend_test.go
+++ b/vault/resource_kubernetes_auth_backend_test.go
@@ -1,0 +1,89 @@
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestKubernetesAuthBackend(t *testing.T) {
+	path := "kubernetes-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testKubernetesAuthCheckDestroy(path),
+		Steps: []resource.TestStep{
+			{
+				Config: initialKubernetesAuthConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "path", path),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "description", "test description"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "host", "test.host"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "ca_cert", "test cert"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "token_reviewer_jwt", "test jwt"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "pem_keys", "test keys"),
+				),
+			},
+			{
+				Config: updatedKubernetesAuthConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "path", path),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "description", "test updated description"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "host", "test updated host"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "ca_cert", "test updated cert"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "token_reviewer_jwt", "test updated jwt"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend.test", "pem_keys", "test updated keys"),
+				),
+			},
+		},
+	})
+}
+
+func initialKubernetesAuthConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_kubernetes_auth_backend" "test" {
+    path = "%s"
+    description = "test description"
+    host = "test host"
+    ca_cert = "test cert"
+    token_reviewer_jwt = "test jwt"
+    pem_keys = "test keys"
+}
+`, path)
+}
+
+func updatedKubernetesAuthConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_okta_auth_backend" "test" {
+    path = "%s"
+    description = "test updated description"
+    host = "test updated host"
+    ca_cert = "test updated cert"
+    token_reviewer_jwt = "test updated jwt"
+    pem_keys = "test updated keys"
+}
+`, path)
+}
+
+func testKubernetesAuthCheckDestroy(path string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testProvider.Meta().(*api.Client)
+
+		authMounts, err := client.Sys().ListAuth()
+		if err != nil {
+			return err
+		}
+
+		if _, ok := authMounts[fmt.Sprintf("%s/", path)]; ok {
+			return fmt.Errorf("auth mount not destroyed")
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Defines resources for the backend itself, as well as the roles associated with Kubernetes auth backends. I have tried to imitate the structure of the Okta auth backend resources as close as I could; please let me know if any changes are required.