### PR TITLE
Update some resource documentation to mention importability

### DIFF
--- a/website/docs/r/approle_auth_backend_role.md
+++ b/website/docs/r/approle_auth_backend_role.md
@@ -69,3 +69,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+AppRole authentication backend roles can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_approle_auth_backend_role.example auth/approle/role/test-role
+```

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -30,3 +30,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+Authentication backends can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_auth_backend.example github
+```

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -58,3 +58,11 @@ for credentials issued by this backend.
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+AWS secret backends can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_aws_secret_backend.aws aws
+```

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -64,3 +64,11 @@ with this role. Either `policy` or `policy_arn` must be specified.
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+AWS secret backend roles can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_aws_secret_backend_role.role aws/roles/deploy
+```


### PR DESCRIPTION
This covers the following resources:

* vault_approle_auth_backend
* vault_auth_backend
* vault_aws_secret_backend
* vault_aws_secret_backend_role

This is obviously not exhaustive, but these were the only resources that I have direct experience in managing via Terraform, and I was able to read through the respective source code to validate the proper ID to use when importing.