### PR TITLE
Support v2 KV mount

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 script:
   - docker run -d -e VAULT_DEV_ROOT_TOKEN_ID=TEST -p 8200:8200 --name vault vault:0.11.1
   - sleep 10
-  - docker exec -e VAULT_TOKEN=TEST -e VAULT_ADDR="http://localhost:8200" vault vault secrets enable --version=1 -path=secretsv1 kv
   - make test
   - VAULT_ADDR=http://localhost:8200 VAULT_TOKEN=TEST make testacc
   - make vendor-status

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,12 @@ install:
 
 script:
   - docker run -d -e VAULT_DEV_ROOT_TOKEN_ID=TEST -p 8200:8200 --name vault vault:0.11.1
-  - sleep 10
+  - |
+    until $(curl --output /dev/null --silent --head --fail http://localhost:8200)
+    do
+        printf '.'
+        sleep 1
+    done
   - make test
   - VAULT_ADDR=http://localhost:8200 VAULT_TOKEN=TEST make testacc
   - make vendor-status

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -22,6 +22,13 @@ func genericSecretDataSource() *schema.Resource {
 				Description: "Full path from which a secret will be read.",
 			},
 
+			"version": {
+				Type:     schema.TypeInt,
+				Required: false,
+				Optional: true,
+				Default:  -1,
+			},
+
 			"data_json": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -66,8 +73,10 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 
 	path := d.Get("path").(string)
 
-	log.Printf("[DEBUG] Reading %s from Vault", path)
-	secret, err := client.Logical().Read(path)
+	secretVersion := d.Get("version").(int)
+	log.Printf("[DEBUG] Reading %s %d from Vault", path, secretVersion)
+
+	secret, err := versionedSecret(secretVersion, path, client)
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -26,7 +26,7 @@ func genericSecretDataSource() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: false,
 				Optional: true,
-				Default:  -1,
+				Default:  latestSecretVersion,
 			},
 
 			"data_json": {

--- a/vault/kv_helpers.go
+++ b/vault/kv_helpers.go
@@ -1,0 +1,147 @@
+package vault
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func versionedSecret(requestedVersion int, path string, client *api.Client) (*api.Secret, error) {
+	mountPath, v2, err := isKVv2(path, client)
+	if err != nil {
+		return nil, err
+	}
+
+	var versionParam map[string]string
+
+	if v2 {
+		path = addPrefixToVKVPath(path, mountPath, "data")
+		if err != nil {
+			return nil, err
+		}
+
+		if requestedVersion > 0 {
+			versionParam = map[string]string{
+				"version": fmt.Sprintf("%d", requestedVersion),
+			}
+		}
+	}
+
+	secret, err := kvReadRequest(client, path, versionParam)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if v2 && secret != nil {
+		// This is a v2, grab the data field
+		if data, ok := secret.Data["data"]; ok && data != nil {
+			if dataMap, ok := data.(map[string]interface{}); ok {
+				secret.Data = dataMap
+			}
+		}
+	}
+
+	return secret, nil
+}
+
+func kvReadRequest(client *api.Client, path string, params map[string]string) (*api.Secret, error) {
+	r := client.NewRequest("GET", "/v1/"+path)
+	for k, v := range params {
+		r.Params.Set(k, v)
+	}
+	resp, err := client.RawRequest(r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if resp != nil && resp.StatusCode == 404 {
+		secret, parseErr := api.ParseSecret(resp.Body)
+		switch parseErr {
+		case nil:
+		case io.EOF:
+			return nil, nil
+		default:
+			return nil, err
+		}
+		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
+			return secret, nil
+		}
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return api.ParseSecret(resp.Body)
+}
+
+func kvPreflightVersionRequest(client *api.Client, path string) (string, int, error) {
+	// We don't want to use a wrapping call here so save any custom value and
+	// restore after
+	currentWrappingLookupFunc := client.CurrentWrappingLookupFunc()
+	client.SetWrappingLookupFunc(nil)
+	defer client.SetWrappingLookupFunc(currentWrappingLookupFunc)
+
+	r := client.NewRequest("GET", "/v1/sys/internal/ui/mounts/"+path)
+	resp, err := client.RawRequest(r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		// If we get a 404 we are using an older version of vault, default to
+		// version 1
+		if resp != nil && resp.StatusCode == 404 {
+			return "", 1, nil
+		}
+
+		return "", 0, err
+	}
+
+	secret, err := api.ParseSecret(resp.Body)
+	if err != nil {
+		return "", 0, err
+	}
+	var mountPath string
+	if mountPathRaw, ok := secret.Data["path"]; ok {
+		mountPath = mountPathRaw.(string)
+	}
+	options := secret.Data["options"]
+	if options == nil {
+		return mountPath, 1, nil
+	}
+	versionRaw := options.(map[string]interface{})["version"]
+	if versionRaw == nil {
+		return mountPath, 1, nil
+	}
+	version := versionRaw.(string)
+	switch version {
+	case "", "1":
+		return mountPath, 1, nil
+	case "2":
+		return mountPath, 2, nil
+	}
+
+	return mountPath, 1, nil
+}
+
+func isKVv2(path string, client *api.Client) (string, bool, error) {
+	mountPath, version, err := kvPreflightVersionRequest(client, path)
+	if err != nil {
+		return "", false, err
+	}
+
+	return mountPath, version == 2, nil
+}
+
+func addPrefixToVKVPath(p, mountPath, apiPrefix string) string {
+	switch {
+	case p == mountPath, p == strings.TrimSuffix(mountPath, "/"):
+		return path.Join(mountPath, apiPrefix)
+	default:
+		p = strings.TrimPrefix(p, mountPath)
+		return path.Join(mountPath, apiPrefix, p)
+	}
+}

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
+const latestSecretVersion = -1
+
 func genericSecretResource() *schema.Resource {
 	return &schema.Resource{
 		SchemaVersion: 1,
@@ -166,7 +168,7 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 		client := meta.(*api.Client)
 
 		log.Printf("[DEBUG] Reading %s from Vault", path)
-		secret, err := versionedSecret(-1, path, client)
+		secret, err := versionedSecret(latestSecretVersion, path, client)
 
 		if err != nil {
 			return fmt.Errorf("error reading from Vault: %s", err)

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -96,12 +96,26 @@ func NormalizeDataJSON(configI interface{}) string {
 func genericSecretResourceWrite(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
-	path := d.Get("path").(string)
-
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(d.Get("data_json").(string)), &data)
 	if err != nil {
 		return fmt.Errorf("data_json %#v syntax error: %s", d.Get("data_json"), err)
+	}
+
+	path := d.Get("path").(string)
+	originalPath := path // if the path belongs to a v2 endpoint, it will be modified
+	mountPath, v2, err := isKVv2(path, client)
+	if err != nil {
+		return fmt.Errorf("error determining if it's a v2 path: %s", err)
+	}
+
+	if v2 {
+		path = addPrefixToVKVPath(path, mountPath, "data")
+		data = map[string]interface{}{
+			"data":    data,
+			"options": map[string]interface{}{},
+		}
+
 	}
 
 	log.Printf("[DEBUG] Writing generic Vault secret to %s", path)
@@ -110,7 +124,7 @@ func genericSecretResourceWrite(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}
 
-	d.SetId(path)
+	d.SetId(originalPath)
 
 	return genericSecretResourceRead(d, meta)
 }
@@ -120,8 +134,17 @@ func genericSecretResourceDelete(d *schema.ResourceData, meta interface{}) error
 
 	path := d.Id()
 
+	mountPath, v2, err := isKVv2(path, client)
+	if err != nil {
+		return fmt.Errorf("error determining if it's a v2 path: %s", err)
+	}
+
+	if v2 {
+		path = addPrefixToVKVPath(path, mountPath, "data")
+	}
+
 	log.Printf("[DEBUG] Deleting vault_generic_secret from %q", path)
-	_, err := client.Logical().Delete(path)
+	_, err = client.Logical().Delete(path)
 	if err != nil {
 		return fmt.Errorf("error deleting %q from Vault: %q", path, err)
 	}
@@ -143,7 +166,8 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 		client := meta.(*api.Client)
 
 		log.Printf("[DEBUG] Reading %s from Vault", path)
-		secret, err := client.Logical().Read(path)
+		secret, err := versionedSecret(-1, path, client)
+
 		if err != nil {
 			return fmt.Errorf("error reading from Vault: %s", err)
 		}
@@ -155,11 +179,12 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 
 		log.Printf("[DEBUG] secret: %#v", secret)
 
-		jsonDataBytes, err := json.Marshal(secret.Data)
+		jsonData, err := json.Marshal(secret.Data)
 		if err != nil {
 			return fmt.Errorf("error marshaling JSON for %q: %s", path, err)
 		}
-		d.Set("data_json", string(jsonDataBytes))
+
+		d.Set("data_json", string(jsonData))
 		d.Set("path", path)
 	} else {
 		log.Printf("[WARN] vault_generic_secret does not refresh when disable_read is set to true")

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -55,7 +55,16 @@ func TestResourceGenericSecret_deleted(t *testing.T) {
 
 func testResourceGenericSecret_initialConfig(path string) string {
 	return fmt.Sprintf(`
+resource "vault_mount" "v1" {
+	path = "secretsv1"
+	type = "kv"
+	options = {
+		version = "1"
+	}
+}
+
 resource "vault_generic_secret" "test" {
+    depends_on = ["vault_mount.v1"]
     path = "%s"
     data_json = <<EOT
 {
@@ -102,8 +111,16 @@ func testResourceGenericSecret_initialCheck(expectedPath string) resource.TestCh
 
 var testResourceGenericSecret_updateConfig = `
 
+resource "vault_mount" "v1" {
+	path = "secretsv1"
+	type = "kv"
+	options = {
+		version = "1"
+	}
+}
+
 resource "vault_generic_secret" "test" {
-    path = "secretsv1/foo"
+    path = "${vault_mount.v1.path}/foo"
     disable_read = false
     data_json = <<EOT
 {


### PR DESCRIPTION
Should address #140

Borrows a lot of code from the cli, `kv get` in `hashicorp/vault/command`, since it's not public api.
