### PR TITLE
Allow for templated database backends

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -49,6 +49,12 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"data": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "A map of sensitive data to pass to the endpoint. Usefule for templated connection strings.",
+				Sensitive:   true,
+			},
 
 			"cassandra": {
 				Type:        schema.TypeList,
@@ -391,6 +397,12 @@ func databaseSecretBackendConnectionCreate(d *schema.ResourceData, meta interfac
 			roles = append(roles, role.(string))
 		}
 		data["allowed_roles"] = strings.Join(roles, ",")
+	}
+
+	if m, ok := d.GetOkExists("data"); ok {
+		for k, v := range m.(map[string]interface{}) {
+			data[k] = v.(string)
+		}
 	}
 
 	log.Printf("[DEBUG] Writing connection config to %q", path)


### PR DESCRIPTION
Allows for something like this, so you don't display the username and passwords in plans. 
```hcl
resource "vault_mount" "postgres" {
  path = "postgres"
  type = "database"
}

locals {
  db_name             = "my-db"
  postgres_connection = "postgres://{{username}}:{{password}}@postgres.service.consul:5432/${local.db_name}"
}

variable "postgres_user" {}
variable "postgres_password" {}

resource "vault_database_secret_backend_connection" "postgres" {
  backend       = "${vault_mount.postgres.path}"
  name          = "${local.db_name}"
  allowed_roles = ["*"]

  postgresql {
    connection_url          = "${local.postgres_connection}"
    max_connection_lifetime = "100"
  }

  data = {
    username = "${var.postgres_user}"
    password = "${var.postgres_password}"
  }
}
```