### PR TITLE
Deprecate KV V1, update to KV V2

### DIFF
--- a/vault/data_source_generic_secret_test.go
+++ b/vault/data_source_generic_secret_test.go
@@ -13,7 +13,7 @@ func TestDataSourceGenericSecret(t *testing.T) {
 		Providers: testProviders,
 		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []r.TestStep{
-			r.TestStep{
+			{
 				Config: testDataSourceGenericSecret_config,
 				Check:  testDataSourceGenericSecret_check,
 			},
@@ -24,7 +24,7 @@ func TestDataSourceGenericSecret(t *testing.T) {
 var testDataSourceGenericSecret_config = `
 
 resource "vault_generic_secret" "test" {
-    path = "secret/foo"
+    path = "secret/data/foo"
     data_json = <<EOT
 {
     "zip": "zap"

--- a/vault/resource_generic_secret_migrate.go
+++ b/vault/resource_generic_secret_migrate.go
@@ -19,7 +19,7 @@ func resourceGenericSecretMigrateState(v int, s *terraform.InstanceState, meta i
 		s, err := migrateGenericSecretStateV0toV1(s)
 		return s, err
 	default:
-		return s, fmt.Errorf("Unexpected schema version: %d", v)
+		return s, fmt.Errorf("unexpected schema version: %d", v)
 	}
 }
 


### PR DESCRIPTION
`TestDataSourceGenericSecret` was failing for me and it was because of an incompatibility between KV V1, which the code was written for, and KV V2, the current version of KV.

This PR:
- Fixes the failing test
- Adds support for KV V2
- Removes support for KV V1
- Lower-cases a couple of error strings I encountered along the way

