### PR TITLE
Mistake in documentation - connection_url

### DIFF
--- a/website/docs/r/database_secret_backend_role.md
+++ b/website/docs/r/database_secret_backend_role.md
@@ -32,7 +32,7 @@ resource "vault_database_secret_backend_connection" "postgres" {
   allowed_roles = ["dev", "prod"]
 
   postgresql {
-    role_url = "postgres://username:password@host:port/database"
+    connection_url = "postgres://username:password@host:port/database"
   }
 }
 


### PR DESCRIPTION
Incorrectly using role_url instead of connection_url for postgresql parameter.