### PR TITLE
Update `bindpass` in `vault_ldap_auth_backend`

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -58,9 +58,10 @@ func ldapAuthBackendResource() *schema.Resource {
 				Computed: true,
 			},
 			"bindpass": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"userdn": {
 				Type:     schema.TypeString,
@@ -254,7 +255,6 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("insecure_tls", resp.Data["insecure_tls"])
 	d.Set("certificate", resp.Data["certificate"])
 	d.Set("binddn", resp.Data["binddn"])
-	d.Set("bindpass", resp.Data["bindpass"])
 	d.Set("userdn", resp.Data["userdn"])
 	d.Set("userattr", resp.Data["userattr"])
 	d.Set("discoverdn", resp.Data["discoverdn"])
@@ -263,6 +263,9 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("groupfilter", resp.Data["groupfilter"])
 	d.Set("groupdn", resp.Data["groupdn"])
 	d.Set("groupattr", resp.Data["groupattr"])
+
+	// `bindpass` cannot be read out from the API
+	// So... if they drift, they drift.
 
 	return nil
 }

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -86,6 +86,11 @@ func testLDAPAuthBackendCheck_attrs(path string) resource.TestCheckFunc {
 			return err
 		}
 
+		// Check that `bindpass`, if present in the state, is not returned by the API
+		if instanceState.Attributes["bindpass"] != "" && resp.Data["bindpass"] != nil {
+			return fmt.Errorf("expected api field bindpass to not be returned, but was %q", resp.Data["bindpass"])
+		}
+
 		attrs := map[string]string{
 			"url":             "url",
 			"starttls":        "starttls",
@@ -94,7 +99,6 @@ func testLDAPAuthBackendCheck_attrs(path string) resource.TestCheckFunc {
 			"insecure_tls":    "insecure_tls",
 			"certificate":     "certificate",
 			"binddn":          "binddn",
-			"bindpass":        "bindpass",
 			"userdn":          "userdn",
 			"userattr":        "userattr",
 			"discoverdn":      "discoverdn",
@@ -180,6 +184,10 @@ resource "vault_ldap_auth_backend" "test" {
     tls_min_version        = "tls11"
     tls_max_version        = "tls12"
     insecure_tls           = false
+    binddn                 = "cn=example.com"
+    bindpass               = "supersecurepassword"
+    discoverdn             = false
+    deny_null_bind         = true
 }
 `, path)
 

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -69,6 +69,11 @@ The following arguments are supported:
 
 For more details on the usage of each argument consult the [Vault LDAP API documentation](https://www.vaultproject.io/api/auth/ldap/index.html).
 
+~> **Important** Because Vault does not support reading the configured
+credentials back from the API, Terraform cannot detect and correct drift
+on `bindpass`. Changing the values, however, _will_ overwrite the
+previously stored values.
+
 ## Attribute Reference
 
 No additional attributes are exposed by this resource.


### PR DESCRIPTION
- Set the attribute to sensitive
- Do not read back from the API since the API does not return it

I am not sure if this is the right way to handle it. I tried to mimic how this is done in the `vault_aws_secret_backend` resource.