### PR TITLE
add vault_jwt_auth_backend_role resource

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -110,6 +110,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_gcp_auth_backend_role":               gcpAuthBackendRoleResource(),
 			"vault_cert_auth_backend_role":              certAuthBackendRoleResource(),
 			"vault_generic_secret":                      genericSecretResource(),
+			"vault_jwt_auth_backend_role":               jwtAuthBackendRoleResource(),
 			"vault_okta_auth_backend":                   oktaAuthBackendResource(),
 			"vault_okta_auth_backend_user":              oktaAuthBackendUserResource(),
 			"vault_okta_auth_backend_group":             oktaAuthBackendGroupResource(),

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -1,0 +1,352 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	jwtAuthBackendRoleBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/role/.+$")
+	jwtAuthBackendRoleNameFromPathRegex    = regexp.MustCompile("^auth/.+/role/(.+)$")
+)
+
+func jwtAuthBackendRoleResource() *schema.Resource {
+	return &schema.Resource{
+		Create: jwtAuthBackendRoleCreate,
+		Read:   jwtAuthBackendRoleRead,
+		Update: jwtAuthBackendRoleUpdate,
+		Delete: jwtAuthBackendRoleDelete,
+		Exists: jwtAuthBackendRoleExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"role_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the role.",
+				ForceNew:    true,
+			},
+			"bound_audiences": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "List of aud claims to match against. Any match is sufficient.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"user_claim": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The claim to use to uniquely identify the user; this will be used as the name for the Identity entity alias created due to a successful login.",
+			},
+			"policies": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Policies to be set on tokens issued using this role.",
+			},
+			"ttl": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Description:   "Default number of seconds to set as the TTL for issued tokens and at renewal time.",
+				ConflictsWith: []string{"period"},
+			},
+			"max_ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Number of seconds after which issued tokens can no longer be renewed.",
+			},
+			"period": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Description:   "Number of seconds to set the TTL to for issued tokens upon renewal. Makes the token a periodic token, which will never expire as long as it is renewed before the TTL each period.",
+				ConflictsWith: []string{"ttl"},
+			},
+			"num_uses": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Number of times issued tokens can be used. Setting this to 0 or leaving it unset means unlimited uses.",
+			},
+			"bound_subject": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If set, requires that the sub claim matches this value.",
+			},
+			"bound_cidrs": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of CIDRs valid as the source address for login requests. This value is also encoded into any resulting token.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"groups_claim": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The claim to use to uniquely identify the set of groups to which the user belongs; this will be used as the names for the Identity group aliases created due to a successful login. The claim value must be a list of strings.",
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the auth backend to configure.",
+				ForceNew:    true,
+				Default:     "jwt",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+		},
+	}
+}
+
+func jwtAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+	role := d.Get("role_name").(string)
+	path := jwtAuthBackendRolePath(backend, role)
+
+	log.Printf("[DEBUG] Writing JWT auth backend role %q", path)
+	data := jwtAuthBackendRoleDataToWrite(d)
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error writing JWT auth backend role %q: %s", path, err)
+	}
+	d.SetId(path)
+	log.Printf("[DEBUG] Wrote JWT auth backend role %q", path)
+
+	if v, ok := d.GetOk("role_id"); ok {
+		log.Printf("[DEBUG] Writing JWT auth backend role %q RoleID", path)
+		_, err := client.Logical().Write(path+"/role-id", map[string]interface{}{
+			"role_id": v.(string),
+		})
+		if err != nil {
+			return fmt.Errorf("error writing JWT auth backend role %q's RoleID: %s", path, err)
+		}
+		log.Printf("[DEBUG] Wrote JWT auth backend role %q RoleID", path)
+	}
+
+	return jwtAuthBackendRoleRead(d, meta)
+}
+
+func jwtAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	backend, err := jwtAuthBackendRoleBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for JWT auth backend role: %s", path, err)
+	}
+
+	role, err := jwtAuthBackendRoleNameFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for JWT auth backend role: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading JWT auth backend role %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading JWT auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read JWT auth backend role %q", path)
+	if resp == nil {
+		log.Printf("[WARN] JWT auth backend role %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	boundAuds := jsonStringArrayToStringArray(resp.Data["bound_audiences"].([]interface{}))
+	err = d.Set("bound_audiences", boundAuds)
+	if err != nil {
+		return fmt.Errorf("error setting bound_audiences in state: %s", err)
+	}
+
+	d.Set("user_claim", resp.Data["user_claim"].(string))
+
+	policies := jsonStringArrayToStringArray(resp.Data["policies"].([]interface{}))
+	err = d.Set("policies", policies)
+	if err != nil {
+		return fmt.Errorf("error setting policies in state: %s", err)
+	}
+
+	tokenTTL, err := resp.Data["ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected ttl %q to be a number, isn't", resp.Data["ttl"])
+	}
+	d.Set("ttl", tokenTTL)
+
+	tokenMaxTTL, err := resp.Data["max_ttl"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected max_ttl %q to be a number, isn't", resp.Data["max_ttl"])
+	}
+	d.Set("max_ttl", tokenMaxTTL)
+
+	period, err := resp.Data["period"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected period %q to be a number, isn't", resp.Data["period"])
+	}
+	d.Set("period", period)
+
+	tokenNumUses, err := resp.Data["num_uses"].(json.Number).Int64()
+	if err != nil {
+		return fmt.Errorf("expected token_num_uses %q to be a number, isn't", resp.Data["num_uses"])
+	}
+	d.Set("num_uses", tokenNumUses)
+
+	d.Set("bound_subject", resp.Data["bound_subject"].(string))
+
+	if resp.Data["bound_cidrs"] != nil {
+		cidrs := jsonStringArrayToStringArray(resp.Data["bound_cidrs"].([]interface{}))
+		err = d.Set("bound_cidrs", cidrs)
+		if err != nil {
+			return fmt.Errorf("error setting bound_cidrs in state: %s", err)
+		}
+	} else {
+		d.Set("bound_cidrs", make([]string, 0))
+	}
+
+	d.Set("groups_claim", resp.Data["groups_claim"].(string))
+
+	d.Set("backend", backend)
+	d.Set("role_name", role)
+
+	return nil
+}
+
+func jwtAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Updating JWT auth backend role %q", path)
+	data := jwtAuthBackendRoleDataToWrite(d)
+	_, err := client.Logical().Write(path, data)
+
+	d.SetId(path)
+
+	if err != nil {
+		return fmt.Errorf("error updating JWT auth backend role %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated JWT auth backend role %q", path)
+
+	if d.HasChange("role_id") {
+		log.Printf("[DEBUG] Updating JWT auth backend role %q RoleID", path)
+		_, err := client.Logical().Write(path+"/role-id", map[string]interface{}{
+			"role_id": d.Get("role_id").(string),
+		})
+		if err != nil {
+			return fmt.Errorf("error updating JWT auth backend role %q's RoleID: %s", path, err)
+		}
+		log.Printf("[DEBUG] Updated JWT auth backend role %q RoleID", path)
+	}
+
+	return jwtAuthBackendRoleRead(d, meta)
+
+}
+
+func jwtAuthBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting JWT auth backend role %q", path)
+	_, err := client.Logical().Delete(path)
+	if err != nil && !is404(err) {
+		return fmt.Errorf("error deleting JWT auth backend role %q", path)
+	} else if err != nil {
+		log.Printf("[DEBUG] JWT auth backend role %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+	log.Printf("[DEBUG] Deleted JWT auth backend role %q", path)
+
+	return nil
+}
+
+func jwtAuthBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	log.Printf("[DEBUG] Checking if JWT auth backend role %q exists", path)
+
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("error checking if JWT auth backend role %q exists: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if JWT auth backend role %q exists", path)
+
+	return resp != nil, nil
+}
+
+func jwtAuthBackendRolePath(backend, role string) string {
+	return "auth/" + strings.Trim(backend, "/") + "/role/" + strings.Trim(role, "/")
+}
+
+func jwtAuthBackendRoleNameFromPath(path string) (string, error) {
+	if !jwtAuthBackendRoleNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no role found")
+	}
+	res := jwtAuthBackendRoleNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}
+
+func jwtAuthBackendRoleBackendFromPath(path string) (string, error) {
+	if !jwtAuthBackendRoleBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := jwtAuthBackendRoleBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}
+
+func jwtAuthBackendRoleDataToWrite(d *schema.ResourceData) map[string]interface{} {
+	data := map[string]interface{}{}
+
+	data["bound_audiences"] = terraformSetToStringArray(d.Get("bound_audiences"))
+	data["user_claim"] = d.Get("user_claim").(string)
+
+	if dataList := terraformSetToStringArray(d.Get("policies")); len(dataList) > 0 {
+		data["policies"] = dataList
+	}
+
+	if v, ok := d.GetOk("ttl"); ok {
+		data["ttl"] = v.(int)
+	}
+	if v, ok := d.GetOk("max_ttl"); ok {
+		data["max_ttl"] = v.(int)
+	}
+	if v, ok := d.GetOk("period"); ok {
+		data["period"] = v.(int)
+	}
+	if v, ok := d.GetOk("num_uses"); ok {
+		data["num_uses"] = v.(int)
+	}
+
+	if v, ok := d.GetOkExists("bound_subject"); ok {
+		data["bound_subject"] = v.(string)
+	}
+
+	if dataList := terraformSetToStringArray(d.Get("bound_cidrs")); len(dataList) > 0 {
+		data["bound_cidrs"] = dataList
+	}
+
+	if v, ok := d.GetOkExists("groups_claim"); ok {
+		data["groups_claim"] = v.(string)
+	}
+
+	return data
+}

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -1,0 +1,435 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestAccJWTAuthBackendRole_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("jwt")
+	role := acctest.RandomWithPrefix("test-role")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendRoleConfig_full(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.1971754988", "default"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.232240223", "prod"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"ttl", "3600"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_ttl", "7200"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"num_uses", "12"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"period", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.#", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.1709552943", "10.148.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.838827017", "10.150.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_subject", "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@client"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.2478800941", "https://myco.test"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/user"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"groups_claim", "https://vault/groups"),
+				),
+			},
+			{
+				ResourceName:      "vault_jwt_auth_backend_role.role",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccJWTAuthBackendRole_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("jwt")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendRoleConfig_basic(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.1971754988", "default"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.232240223", "prod"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"ttl", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_ttl", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"num_uses", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"period", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.#", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.2478800941", "https://myco.test"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/user"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJWTAuthBackendRole_update(t *testing.T) {
+	backend := acctest.RandomWithPrefix("jwt")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendRoleConfig_basic(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.1971754988", "default"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.232240223", "prod"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"ttl", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_ttl", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"period", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.#", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.2478800941", "https://myco.test"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/user"),
+				),
+			},
+			{
+				Config: testAccJWTAuthBackendRoleConfig_update(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.#", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.1971754988", "default"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"ttl", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_ttl", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"num_uses", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"period", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.#", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.2478800941", "https://myco.test"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/user"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJWTAuthBackendRole_full(t *testing.T) {
+	backend := acctest.RandomWithPrefix("jwt")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendRoleConfig_full(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.1971754988", "default"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.232240223", "prod"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"ttl", "3600"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_ttl", "7200"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"num_uses", "12"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"period", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.#", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.1709552943", "10.148.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.838827017", "10.150.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_subject", "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@client"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.2478800941", "https://myco.test"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/user"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"groups_claim", "https://vault/groups"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
+	backend := acctest.RandomWithPrefix("jwt")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendRoleConfig_full(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.#", "3"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.1971754988", "default"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.232240223", "prod"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"ttl", "3600"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_ttl", "7200"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"num_uses", "12"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"period", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.#", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.1709552943", "10.148.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.838827017", "10.150.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_subject", "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@client"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.2478800941", "https://myco.test"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/user"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"groups_claim", "https://vault/groups"),
+				),
+			},
+			{
+				Config: testAccJWTAuthBackendRoleConfig_fullUpdate(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.#", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.1971754988", "default"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"ttl", "7200"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_ttl", "10800"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"num_uses", "24"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"period", "0"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.#", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.838827017", "10.150.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_cidrs.520705167", "10.152.0.0/20"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_subject", "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@update"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_audiences.510103575", "https://myco.update"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/updateuser"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"groups_claim", "https://vault/updategroups"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckJWTAuthBackendRoleDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_jwt_auth_backend_role" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for JWT auth backend role %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("JWT auth backend role %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccJWTAuthBackendRoleConfig_basic(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "jwt" {
+  type = "jwt"
+  path = "%s"
+}
+
+resource "vault_jwt_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.jwt.path}"
+  role_name = "%s"
+
+  bound_audiences = ["https://myco.test"]
+  user_claim = "https://vault/user"
+  policies = ["default", "dev", "prod"]
+}`, backend, role)
+}
+
+func testAccJWTAuthBackendRoleConfig_update(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "jwt" {
+  type = "jwt"
+  path = "%s"
+}
+
+resource "vault_jwt_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.jwt.path}"
+  role_name = "%s"
+
+  bound_audiences = ["https://myco.test"]
+  user_claim = "https://vault/user"
+  policies = ["default", "dev"]
+}`, backend, role)
+}
+
+func testAccJWTAuthBackendRoleConfig_full(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "jwt" {
+  type = "jwt"
+  path = "%s"
+}
+
+resource "vault_jwt_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.jwt.path}"
+  role_name = "%s"
+
+  bound_subject = "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@client"
+  bound_cidrs = ["10.148.0.0/20", "10.150.0.0/20"]
+  bound_audiences = ["https://myco.test"]
+  user_claim = "https://vault/user"
+  groups_claim = "https://vault/groups"
+  policies = ["default", "dev", "prod"]
+  ttl = 3600
+  num_uses = 12
+  max_ttl = 7200
+}`, backend, role)
+}
+
+func testAccJWTAuthBackendRoleConfig_fullUpdate(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "jwt" {
+  type = "jwt"
+  path = "%s"
+}
+
+resource "vault_jwt_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.jwt.path}"
+  role_name = "%s"
+
+  bound_subject = "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@update"
+  bound_cidrs = ["10.150.0.0/20", "10.152.0.0/20"]
+  bound_audiences = ["https://myco.update",]
+  user_claim = "https://vault/updateuser"
+  groups_claim = "https://vault/updategroups"
+  policies = ["default", "dev"]
+  ttl = 7200
+  num_uses = 24
+  max_ttl = 10800
+}`, backend, role)
+}

--- a/vault/util.go
+++ b/vault/util.go
@@ -60,3 +60,20 @@ func arrayToTerraformList(values []string) string {
 	}
 	return fmt.Sprintf("[%s]", strings.Join(output, ", "))
 }
+
+func terraformSetToStringArray(set interface{}) []string {
+	list := set.(*schema.Set).List()
+	arr := make([]string, 0, len(list))
+	for _, v := range list {
+		arr = append(arr, v.(string))
+	}
+	return arr
+}
+
+func jsonStringArrayToStringArray(jsonList []interface{}) []string {
+	strList := make([]string, 0, len(jsonList))
+	for _, v := range jsonList {
+		strList = append(strList, v.(string))
+	}
+	return strList
+}

--- a/website/docs/r/jwt_auth_backend_role.md
+++ b/website/docs/r/jwt_auth_backend_role.md
@@ -1,0 +1,85 @@
+---
+layout: "vault"
+page_title: "Vault: vault_jwt_auth_backend_role resource"
+sidebar_current: "docs-vault-jwt-auth-backend-role"
+description: |-
+  Manages JWT auth backend roles in Vault.
+---
+
+# vault\_jwt\_auth\_backend\_role
+
+Manages an JWT auth backend role in a Vault server. See the [Vault
+documentation](https://www.vaultproject.io/docs/auth/jwt.html) for more
+information.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "jwt" {
+  type = "jwt"
+}
+
+resource "vault_jwt_auth_backend_role" "example" {
+  backend   = "${vault_auth_backend.jwt.path}"
+  role_name = "test-role"
+  policies  = ["default", "dev", "prod"]
+
+  bound_audiences = ["https://myco.test"]
+  user_claim      = "https://vault/user"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `role_name` - (Required) The name of the role.
+
+* `bound_audiences` - (Required) List of `aud` claims to match
+  against. Any match is sufficient.
+
+* `user_claim` - (Required) The claim to use to uniquely identify
+  the user; this will be used as the name for the Identity entity alias created
+  due to a successful login.
+
+* `policies` - (Optional) Policies to be set on tokens issued using this role.
+
+* `ttl` - (Optional) The initial/renewal TTL of tokens issued using this role,
+  in seconds.
+
+* `max_ttl` - (Optional) The maximum allowed lifetime of tokens issued using
+  this role, in seconds.
+
+* `period` - (Optional) If set, indicates that the token generated
+  using this role should never expire, but instead always use the value set
+  here as the TTL for every renewal. 
+
+* `num_uses` - (Optional) If set, puts a use-count limitation on the issued
+  token.
+
+* `bound_subject` - (Optional) If set, requires that the `sub` claim matches
+  this value.
+
+* `bound_cidrs` - (Optional) If set, a list of CIDRs valid as the source 
+  address for login requests. This value is also encoded into any resulting
+  token.
+
+* `groups_claim` - (Optional) The claim to use to uniquely identify
+  the set of groups to which the user belongs; this will be used as the names
+  for the Identity group aliases created due to a successful login. The claim
+  value must be a list of strings.
+
+* `backend` - (Optional) The unique name of the auth backend to configure.
+  Defaults to `jwt`.
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.
+
+## Import
+
+JWT authentication backend roles can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_jwt_auth_backend_role.example auth/jwt/role/test-role
+```

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -33,15 +33,15 @@
                     <a href="#">Resources</a>
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-vault-resource-approle-auth-backend-role") %>>
-			    <a href="/docs/providers/vault/r/approle_auth_backend_role.html">vault_approle_auth_backend_role</a>
+                            <a href="/docs/providers/vault/r/approle_auth_backend_role.html">vault_approle_auth_backend_role</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-approle-auth-backend-login") %>>
-			    <a href="/docs/providers/vault/r/approle_auth_backend_login.html">vault_approle_auth_backend_login</a>
+                            <a href="/docs/providers/vault/r/approle_auth_backend_login.html">vault_approle_auth_backend_login</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-approle-auth-backend-role-secret-id") %>>
-			    <a href="/docs/providers/vault/r/approle_auth_backend_role_secret_id.html">vault_approle_auth_backend_role_secret_id</a>
+                            <a href="/docs/providers/vault/r/approle_auth_backend_role_secret_id.html">vault_approle_auth_backend_role_secret_id</a>
                         </li>
                         <li<%= sidebar_current("docs-vault-resource-auth-backend") %>>
                             <a href="/docs/providers/vault/r/auth_backend.html">vault_auth_backend</a>
@@ -104,6 +104,10 @@
 
                         <li<%= sidebar_current("docs-vault-resource-generic-secret") %>>
                             <a href="/docs/providers/vault/r/generic_secret.html">vault_generic_secret</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-jwt-auth-backend-role") %>>
+                            <a href="/docs/providers/vault/r/jwt_auth_backend_role.html">vault_jwt_auth_backend_role</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-ldap-auth-backend") %>>


### PR DESCRIPTION
This new resource adds support for the JWT auth method recently added to Vault.  
The existing vault_approle_auth_backend_role was used as a template and starting point.