### PR TITLE
[WIP] Update `aws_secret_backend_role` with changes from Vault 0.11

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -168,9 +168,14 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 		if _, ok := d.GetOk("credential_type"); ok {
 			d.Set("credential_type", credentialTypes[0])
-			d.Set("policy_arns", secret.Data["policy_arns"])
-			d.Set("role_arns", secret.Data["role_arns"])
 			d.Set("policy_document", secret.Data["policy_document"])
+
+			if err := d.Set("role_arns", secret.Data["role_arns"]); err != nil {
+				return fmt.Errorf("error setting role_arns for role %q: %s", path, err)
+			}
+			if err := d.Set("policy_arns", secret.Data["policy_arns"]); err != nil {
+				return fmt.Errorf("error setting policy_arns for role %q: %s", path, err)
+			}
 
 		} else {
 			// Deprecated style

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -33,17 +33,54 @@ func awsSecretBackendRoleResource() *schema.Resource {
 				ForceNew:    true,
 				Description: "The path of the AWS Secret Backend the role belongs to.",
 			},
+			"credential_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Specifies the type of credential to be used when retrieving credentials from the role.",
+				// DefaultFunc: ??,
+			},
+			"role_arns": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"policy", "policy_arn", "policy_arns", "policy_document"},
+				Description:   "Specifies the ARNs of the AWS roles this Vault role is allowed to assume.",
+			},
+			"policy_arns": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"policy", "policy_arn", "role_arns"},
+				Description:   "Specifies the ARNs of the AWS managed policies to be attached to IAM users when they are requested.",
+			},
+			"policy_document": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ConflictsWith:    []string{"policy", "policy_arn", "role_arns"},
+				Description:      "Specifies the ARNs of the AWS managed policies to be attached to IAM users when they are requested.",
+				DiffSuppressFunc: jsonDiffSuppress,
+			},
 			"policy_arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"policy"},
+				ConflictsWith: []string{"policy", "credential_type", "role_arns", "policy_arns", "policy_document"},
 				Description:   "ARN for an existing IAM policy the role should use.",
+				Deprecated:    "Deprecated from Vault 0.11.",
 			},
 			"policy": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ConflictsWith:    []string{"policy_arn"},
+				ConflictsWith:    []string{"policy_arn", "credential_type", "role_arns", "policy_arns", "policy_document"},
 				Description:      "IAM policy the role should use in JSON format.",
+				Deprecated:       "Deprecated from Vault 0.11.",
 				DiffSuppressFunc: jsonDiffSuppress,
 			},
 		},
@@ -55,20 +92,37 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
+
+	credentialType := d.Get("credential_type").(string)
+	roleARNs := d.Get("role_arns").([]interface{})
+	policyARNs := d.Get("policy_arns").([]interface{})
+	policyDocument := d.Get("policy_document").(string)
+
 	policyARN := d.Get("policy_arn").(string)
 	policy := d.Get("policy").(string)
 
-	if policy == "" && policyARN == "" {
-		return fmt.Errorf("either policy or policy_arn must be set.")
+	data := map[string]interface{}{}
+
+	if credentialType != "" {
+		data["credential_type"] = credentialType
+		if len(roleARNs) > 0 {
+			data["role_arns"] = roleARNs
+		}
+		if len(policyARNs) > 0 {
+			data["policy_arns"] = policyARNs
+		}
+		if policyDocument != "" {
+			data["policy_document"] = policyDocument
+		}
+	} else {
+		if policy != "" {
+			data["policy"] = policy
+		}
+		if policyARN != "" {
+			data["arn"] = policyARN
+		}
 	}
 
-	data := map[string]interface{}{}
-	if policy != "" {
-		data["policy"] = policy
-	}
-	if policyARN != "" {
-		data["arn"] = policyARN
-	}
 	log.Printf("[DEBUG] Creating role %q on AWS backend %q", name, backend)
 	_, err := client.Logical().Write(backend+"/roles/"+name, data)
 	if err != nil {
@@ -100,8 +154,47 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	d.Set("policy", secret.Data["policy"])
-	d.Set("policy_arn", secret.Data["arn"])
+
+	if invalidData, ok := secret.Data["invalid_data"]; ok {
+		log.Printf("[WARN] Role %q has Invalid Data from upgrading: %q\nSee https://www.vaultproject.io/guides/upgrading/upgrade-to-0.11.0.html#aws-secret-engine-roles for more details", path, invalidData)
+	}
+
+	if credentialTypes, ok := secret.Data["credential_types"]; ok {
+		credentialTypes := credentialTypes.([]interface{})
+		// Vault >= 0.11
+		if len(credentialTypes) > 1 {
+			log.Printf("[WARN] Role %q has multiple credential types from upgrading: %q\nSee https://www.vaultproject.io/guides/upgrading/upgrade-to-0.11.0.html#aws-secret-engine-roles for more details", path, credentialTypes)
+		}
+
+		if _, ok := d.GetOk("credential_type"); ok {
+			d.Set("credential_type", credentialTypes[0])
+			d.Set("policy_arns", secret.Data["policy_arns"])
+			d.Set("role_arns", secret.Data["role_arns"])
+			d.Set("policy_document", secret.Data["policy_document"])
+
+		} else {
+			// Deprecated style
+			policyARNs, hasPolicy := secret.Data["policy_arns"].([]interface{})
+			roleARNs, hasRole := secret.Data["role_arns"].([]interface{})
+
+			// If both policyARNs and roleARNs are returned
+			if hasPolicy && hasRole && (len(policyARNs)+len(roleARNs)) > 1 {
+				log.Printf("[WARN] Role %q has returned multiple policy or role ARNs but the deprecated `policy_arn` is used.", path)
+			}
+
+			if len(policyARNs) > 0 {
+				d.Set("policy_arn", policyARNs[0])
+			} else if len(roleARNs) > 0 {
+				d.Set("policy_arn", roleARNs[0])
+			}
+			d.Set("policy", secret.Data["policy_document"])
+		}
+	} else {
+		// Vault < 0.11
+		d.Set("policy", secret.Data["policy"])
+		d.Set("policy_arn", secret.Data["arn"])
+	}
+
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
 	d.Set("name", pathPieces[len(pathPieces)-1])
 	return nil


### PR DESCRIPTION
This PR attempts to update the `aws_secret_backend_role` resource to conform to the changes made in  [Vault 0.11](https://www.vaultproject.io/guides/upgrading/upgrade-to-0.11.0.html#aws-secret-engine-roles), namely:

- New parameters for creating a role
- New return values

This should address #176.

This is still a WIP and I haven't updated the tests yet because I have a few questions (and because I am new to Go):

- To what extent should we support `Vault < 0.11`? How much logic should we write in to deal with reading back values from Vault in the "old way".
- Should we validate the parameters in the provider? I feel like the validation logic for Vault 0.11 is more complex than what was before and I don't know if we should replicate Vault's logic here or just let the application error out on Vault's side. Suffice to say some of the logic can be provided for "free" by Terraform in the form of conflicting attributes.
- How do we handle `invalidData`? I am guesing we should warn the user.But seems like all the Warnings are eaten up by Terraform.
- How do we handle more than 1 `credentialsTypes` being returned by Vault? This happened on my Vault instance which was upgraded from 0.10.4. I am guesing we should warn the user.But seems like all the Warnings are eaten up by Terraform.
- Should we attempt to "guess" the `credential_type` if it's not provided? We cannot really make it `Required` because it breaks backwards compatibility. But it's also not supported pre Vault 0.11 (which leads me back to the first question). 

FWIW I tested this with my upgraded Vault cluster (from  0.10.4 to 0.11) and I didn't update my Terraform files and the plans show no diff. So it "kind of works".

Some advice would be appreciated. I'm new to this.