### PR TITLE
Remove duplicate navigation in docs for `vault_generic_secret`

### DIFF
--- a/website/vault.erb
+++ b/website/vault.erb
@@ -148,10 +148,6 @@
                             <a href="/docs/providers/vault/r/okta_auth_backend.html">vault_okta_auth_backend</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-vault-resource-generic-secret") %>>
-                            <a href="/docs/providers/vault/r/generic_secret.html">vault_generic_secret</a>
-                        </li>
-
                         <li<%= sidebar_current("docs-vault-resource-mount") %>>
                             <a href="/docs/providers/vault/r/mount.html">vault_mount</a>
                         </li>


### PR DESCRIPTION
Simple update to remove the same resource appearing twice in the navigation at <https://www.terraform.io/docs/providers/vault/>.
