### PR TITLE
Support of the backends mounted to the path with "/"

### DIFF
--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -120,7 +120,7 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	idPieces := strings.Split(d.Id(), "/")
-	d.Set("backend", idPieces[1:len(idPieces) - 2])
+	d.Set("backend", idPieces[1:len(idPieces)-2])
 	d.Set("access_key", secret.Data["access_key"])
 	d.Set("ec2_endpoint", secret.Data["endpoint"])
 	d.Set("iam_endpoint", secret.Data["iam_endpoint"])

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -120,7 +120,7 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	idPieces := strings.Split(d.Id(), "/")
-	d.Set("backend", idPieces[1:len(idPieces)-2])
+	d.Set("backend", strings.Join(idPieces[1:len(idPieces)-2], ""))
 	d.Set("access_key", secret.Data["access_key"])
 	d.Set("ec2_endpoint", secret.Data["endpoint"])
 	d.Set("iam_endpoint", secret.Data["iam_endpoint"])

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -120,10 +120,7 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	idPieces := strings.Split(d.Id(), "/")
-	if len(idPieces) != 4 {
-		return fmt.Errorf("expected %q to have 4 pieces, has %d", d.Id(), len(idPieces))
-	}
-	d.Set("backend", idPieces[1])
+	d.Set("backend", idPieces[1:len(idPieces) - 2])
 	d.Set("access_key", secret.Data["access_key"])
 	d.Set("ec2_endpoint", secret.Data["endpoint"])
 	d.Set("iam_endpoint", secret.Data["iam_endpoint"])


### PR DESCRIPTION
Currently Terraform returns an error if you try to write the following:

```hcl
resource "vault_auth_backend" "this" {
  type = "aws"
  path = "team_name/aws"
}

resource "vault_aws_auth_backend_client" "this" {
  backend = "${vault_auth_backend.this.path}"
  iam_server_id_header_value = "https://vault.devops.net"
}
```