### PR TITLE
"max_connection_lifetime" parameter type changed to "Duration"

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/vault/api"
@@ -379,7 +380,7 @@ func getConnectionDetailsFromResponse(resp *api.Secret) []map[string]interface{}
 		}
 	}
 	if v, ok := data["max_connection_lifetime"]; ok {
-		i, err := v.(json.Number).Int64()
+		i, err := time.ParseDuration(v.(string))
 		if err != nil {
 			log.Printf("[WARN] Non-number %s returned from Vault server: %s", v, err)
 		} else {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -382,7 +382,7 @@ func getConnectionDetailsFromResponse(resp *api.Secret) []map[string]interface{}
 	if v, ok := data["max_connection_lifetime"]; ok {
 		i, err := time.ParseDuration(v.(string))
 		if err != nil {
-			log.Printf("[WARN] Non-number %s returned from Vault server: %s", v, err)
+			log.Printf("[WARN] Non-duration %s returned from Vault server: %s", v, err)
 		} else {
 			result["max_connection_lifetime"] = i
 		}


### PR DESCRIPTION
Field type fix, see https://github.com/hashicorp/vault/blame/df18871704fe869e9be45b542a6b1eb2fe46c293/website/source/api/secret/databases/mysql-maria.html.md#L39

Before this fix I got an error:
```
$ /Users/vladlenfedosov/go/bin/terraform apply
vault_mount.db: Refreshing state... (ID: mysuper_db_0)
vault_database_secret_backend_connection.test: Refreshing state... (ID: mysuper_db_0/config/mysql)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ vault_database_secret_backend_connection.test
      mysql.0.password: "my-secret-pw2" => "my-secret-pw"


Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

vault_database_secret_backend_connection.test: Modifying... (ID: mysuper_db_0/config/mysql)
  mysql.0.password: "my-secret-pw2" => "my-secret-pw"

Error: Error applying plan:

1 error(s) occurred:

* vault_database_secret_backend_connection.test: 1 error(s) occurred:

* vault_database_secret_backend_connection.test: unexpected EOF

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.


panic: interface conversion: interface {} is string, not json.Number
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: 
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: goroutine 137 [running]:
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: github.com/terraform-providers/terraform-provider-vault/vault.getConnectionDetailsFromResponse(0xc0000a1e00, 0xc0003bb080, 0x18e21e5, 0x8)
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: 	/Users/vladlenfedosov/go/src/github.com/terraform-providers/terraform-provider-vault/vault/resource_database_secret_backend_connection.go:398 +0x94e
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: github.com/terraform-providers/terraform-provider-vault/vault.databaseSecretBackendConnectionRead(0xc0000e5650, 0x18c4680, 0xc0001f5dc0, 0x1, 0x1)
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: 	/Users/vladlenfedosov/go/src/github.com/terraform-providers/terraform-provider-vault/vault/resource_database_secret_backend_connection.go:567 +0xe80
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: github.com/terraform-providers/terraform-provider-vault/vault.databaseSecretBackendConnectionUpdate(0xc0000e5650, 0x18c4680, 0xc0001f5dc0, 0x24, 0x2060320)
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: 	/Users/vladlenfedosov/go/src/github.com/terraform-providers/terraform-provider-vault/vault/resource_database_secret_backend_connection.go:632 +0x649
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: github.com/terraform-providers/terraform-provider-vault/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc0002d80c0, 0xc00030ac30, 0xc00000c8a0, 0x18c4680, 0xc0001f5dc0, 0x100d701, 0xc0002d6b80, 0x10bd0dc)
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: 	/Users/vladlenfedosov/go/src/github.com/terraform-providers/terraform-provider-vault/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:199 +0x257
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: github.com/terraform-providers/terraform-provider-vault/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc0000e5110, 0xc00030abe0, 0xc00030ac30, 0xc00000c8a0, 0xc000090000, 0x18, 0x27006c0)
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: 	/Users/vladlenfedosov/go/src/github.com/terraform-providers/terraform-provider-vault/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:259 +0x9c
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: github.com/terraform-providers/terraform-provider-vault/vendor/github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Apply(0xc0004a9da0, 0xc00000c480, 0xc0003b0a10, 0x0, 0x0)
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: 	/Users/vladlenfedosov/go/src/github.com/terraform-providers/terraform-provider-vault/vendor/github.com/hashicorp/terraform/plugin/resource_provider.go:488 +0x57
2018-10-07T18:58:45.922+0300 [DEBUG] plugin.terraform-provider-vault: reflect.Value.call(0xc0002ef500, 0xc000150a18, 0x13, 0x18ddda4, 0x4, 0xc0002d6f18, 0x3, 0x3, 0xc0000c7cc0, 0x2045680, ...)
2018-10-07T18:58:45.923+0300 [DEBUG] plugin.terraform-provider-vault: 	/opt/local/lib/go/src/reflect/value.go:447 +0x449
2018-10-07T18:58:45.923+0300 [DEBUG] plugin.terraform-provider-vault: reflect.Value.Call(0xc0002ef500, 0xc000150a18, 0x13, 0xc000141f18, 0x3, 0x3, 0x12b8a76, 0xc00046cff0, 0xc000141f01)
2018-10-07T18:58:45.923+0300 [DEBUG] plugin.terraform-provider-vault: 	/opt/local/lib/go/src/reflect/value.go:308 +0xa4
2018-10-07T18:58:45.923+0300 [DEBUG] plugin.terraform-provider-vault: net/rpc.(*service).call(0xc000148cc0, 0xc00046ce60, 0xc00047cf40, 0xc00047cf50, 0xc000167480, 0xc000161220, 0x1769c60, 0xc00000c480, 0x16, 0x1769ca0, ...)
2018-10-07T18:58:45.923+0300 [DEBUG] plugin.terraform-provider-vault: 	/opt/local/lib/go/src/net/rpc/server.go:384 +0x14e
2018-10-07T18:58:45.923+0300 [DEBUG] plugin.terraform-provider-vault: created by net/rpc.(*Server).ServeCodec
2018-10-07T18:58:45.923+0300 [DEBUG] plugin.terraform-provider-vault: 	/opt/local/lib/go/src/net/rpc/server.go:481 +0x47e
2018/10/07 18:58:45 [TRACE] root: eval: *terraform.EvalWriteState
2018/10/07 18:58:45 [TRACE] root: eval: *terraform.EvalApplyProvisioners
2018/10/07 18:58:45 [TRACE] root: eval: *terraform.EvalIf
2018/10/07 18:58:45 [TRACE] root: eval: *terraform.EvalWriteState
2018/10/07 18:58:45 [TRACE] root: eval: *terraform.EvalWriteDiff
2018/10/07 18:58:45 [TRACE] root: eval: *terraform.EvalApplyPost
2018/10/07 18:58:45 [ERROR] root: eval: *terraform.EvalApplyPost, err: 1 error(s) occurred:

* vault_database_secret_backend_connection.test: unexpected EOF
2018/10/07 18:58:45 [ERROR] root: eval: *terraform.EvalSequence, err: 1 error(s) occurred:

* vault_database_secret_backend_connection.test: unexpected EOF
2018/10/07 18:58:45 [TRACE] [walkApply] Exiting eval tree: vault_database_secret_backend_connection.test
2018/10/07 18:58:45 [TRACE] dag/walk: upstream errored, not walking "meta.count-boundary (count boundary fixup)"
2018/10/07 18:58:45 [TRACE] dag/walk: upstream errored, not walking "provider.vault (close)"
2018/10/07 18:58:45 [TRACE] dag/walk: upstream errored, not walking "root"
2018-10-07T18:58:45.925+0300 [DEBUG] plugin: plugin process exited: path=/Users/vladlenfedosov/go/bin/terraform-provider-vault
2018/10/07 18:58:45 [TRACE] Preserving existing state lineage "14cec0ae-4617-cee5-f388-716bdc902de5"
2018/10/07 18:58:45 [TRACE] Preserving existing state lineage "14cec0ae-4617-cee5-f388-716bdc902de5"
2018/10/07 18:58:45 [TRACE] Preserving existing state lineage "14cec0ae-4617-cee5-f388-716bdc902de5"
2018/10/07 18:58:45 [TRACE] Preserving existing state lineage "14cec0ae-4617-cee5-f388-716bdc902de5"
2018/10/07 18:58:45 [DEBUG] plugin: waiting for all plugin processes to complete...
2018-10-07T18:58:45.927+0300 [WARN ] plugin: error closing client during Kill: err="connection is shut down"



!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Terraform crashed! This is always indicative of a bug within Terraform.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Terraform[1] so that we can fix this.

When reporting bugs, please include your terraform version. That
information is available on the first line of crash.log. You can also
get it by running 'terraform --version' on the command line.

[1]: https://github.com/hashicorp/terraform/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

```