### PR TITLE
Improved example

### DIFF
--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -31,6 +31,9 @@ data "vault_generic_secret" "rundeck_auth" {
 }
 
 # Rundeck Provider, for example
+# For this example, in Vault there is a key named "auth_token" and the value is the token we need to keep secret.
+# In general usage, replace "auth_token" with the key you wish to extract from Vault. 
+
 provider "rundeck" {
   url        = "http://rundeck.example.com/"
   auth_token = "${data.vault_generic_secret.rundeck_auth.data["auth_token"]}"


### PR DESCRIPTION
A colleague was very confused about where "auth_token" came from, as it is not in the example. Provided a little more detail for clarity.