### PR TITLE
Run vault and mysql in docker-compose for travis acceptance tests

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,0 +1,3 @@
+export VAULT_ADDR="http://localhost:8200"
+export VAULT_TOKEN="TEST"
+export MYSQL_URL="vault:vault@tcp(mysql:3306)/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,16 @@ install:
   - go get github.com/kardianos/govendor
 
 script:
-  - docker run -d -e VAULT_DEV_ROOT_TOKEN_ID=TEST -p 8200:8200 --name vault vault:0.11.1
+  - docker-compose up -d
   - |
     until $(curl --output /dev/null --silent --head --fail http://localhost:8200)
     do
         printf '.'
         sleep 1
     done
+  - source .test-env
   - make test
-  - VAULT_ADDR=http://localhost:8200 VAULT_TOKEN=TEST make testacc
+  - make testacc
   - make vendor-status
   - make vet
   - make website-test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "2.2"
+
+services:
+  vault:
+    image: vault:0.11.1
+    cap_add:
+    - "IPC_LOCK"
+    ports:
+    - "8200:8200"
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: "TEST"
+      VAULT_ADDR: "http://localhost:8200"
+      VAULT_TOKEN: "TEST"
+      MYSQL_URL: "vault:vault@tcp(mysql:3306)/"
+
+  mysql:
+    image: mysql:5.7
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: "root"
+      MYSQL_DATABASE: "main"
+      MYSQL_USER: "vault"
+      MYSQL_PASSWORD: "vault"


### PR DESCRIPTION
In order to run the acceptance tests locally one has to manually startup mysql, or similar. And travis isn't executing all the tests either. Some of those could be simplified with docker-compose.

For example running vault and mysql in docker-compose means both, developers and the CI, can use the same spec to run the tests. Which also improves test coverage from the CI.
