### PR TITLE
Update database_secret_backend_role.md

### DIFF
--- a/website/docs/r/database_secret_backend_role.md
+++ b/website/docs/r/database_secret_backend_role.md
@@ -40,7 +40,7 @@ resource "vault_database_secret_backend_role" "role" {
   backend             = "${vault_mount.db.path}"
   name                = "my-role"
   db_name             = "${vault_database_secret_backend_connection.postgres.name}"
-  creation_statements = "CREATE ROLE {{name}} WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';"
+  creation_statements = "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';"
 }
 ```
 


### PR DESCRIPTION
This change is needed for current versions of Postgresql, which don't allow dashes in the username unless it is encapsulated in double  quotes. Encountered the error using postgres 10.4