### PR TITLE
vault_auth_backend: Add plugin parameter

### DIFF
--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -68,16 +68,20 @@ func authBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
 	name := d.Get("type").(string)
-	desc := d.Get("description").(string)
 	path := d.Get("path").(string)
 
 	if path == "" {
 		path = name
 	}
 
+	options := &api.EnableAuthOptions{
+		Type:        name,
+		Description: d.Get("description").(string),
+	}
+
 	log.Printf("[DEBUG] Writing auth %q to Vault", path)
 
-	err := client.Sys().EnableAuth(path, name, desc)
+	err := client.Sys().EnableAuthWithOptions(path, options)
 
 	if err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)

--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -60,6 +60,13 @@ func authBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "The accessor of the auth backend",
 			},
+
+			"plugin": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "The name of the auth plugin to use",
+			},
 		},
 	}
 }
@@ -77,6 +84,7 @@ func authBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	options := &api.EnableAuthOptions{
 		Type:        name,
 		Description: d.Get("description").(string),
+		PluginName:  d.Get("plugin").(string),
 	}
 
 	log.Printf("[DEBUG] Writing auth %q to Vault", path)
@@ -125,6 +133,7 @@ func authBackendRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("path", path)
 			d.Set("description", auth.Description)
 			d.Set("accessor", auth.Accessor)
+			d.Set("plugin", auth.Config.PluginName)
 			return nil
 		}
 	}

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -82,6 +82,13 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 			return fmt.Errorf("unexpected auth path %q, expected %q", path, expectedPath)
 		}
 
+		if instanceState.Attributes["type"] != "github" {
+			return fmt.Errorf("unexpected auth type")
+		}
+		if instanceState.Attributes["description"] != "Test auth backend" {
+			return fmt.Errorf("unexpected auth description")
+		}
+
 		client := testProvider.Meta().(*api.Client)
 		auths, err := client.Sys().ListAuth()
 
@@ -90,9 +97,15 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 		}
 
 		found := false
-		for serverPath := range auths {
+		for serverPath, serverAuth := range auths {
 			if serverPath == expectedPath+"/" {
 				found = true
+				if serverAuth.Type != "github" {
+					return fmt.Errorf("unexpected auth type")
+				}
+				if serverAuth.Description != "Test auth backend" {
+					return fmt.Errorf("unexpected auth description")
+				}
 				break
 			}
 		}


### PR DESCRIPTION
Fixes #54.

In order to implement this I needed to switch from the [`EnableAuth`](https://github.com/hashicorp/vault/blob/v0.11.3/api/sys_auth.go#L39-L40) call to [`EnableAuthWithOptions`](https://github.com/hashicorp/vault/blob/v0.11.3/api/sys_auth.go#L47). The first commit is implementing that as well as some extra assertions in the tests.

I'm not actually sure how to write a test for the `plugin` parameter as it would require setting up a Vault auth plugin which is fairly complicated.

Related: #203 