### PR TITLE
Use set connection_url when available instead of value read for API response

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -352,15 +352,19 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 	return data, nil
 }
 
-func getConnectionDetailsFromResponse(resp *api.Secret) []map[string]interface{} {
+func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) []map[string]interface{} {
 	details := resp.Data["connection_details"]
 	data, ok := details.(map[string]interface{})
 	if !ok {
 		return nil
 	}
 	result := map[string]interface{}{}
-	if v, ok := data["connection_url"]; ok {
+	if v, ok := d.GetOk(prefix + "connection_url"); ok {
 		result["connection_url"] = v.(string)
+	} else {
+		if v, ok := data["connection_url"]; ok {
+			result["connection_url"] = v.(string)
+		}
 	}
 	if v, ok := data["max_open_connections"]; ok {
 		n, err := v.(json.Number).Int64()
@@ -520,7 +524,7 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 			d.Set("cassandra", []map[string]interface{}{result})
 		}
 	case "hana-database-plugin":
-		d.Set("hana", getConnectionDetailsFromResponse(resp))
+		d.Set("hana", getConnectionDetailsFromResponse(d, "hana.0.", resp))
 	case "mongodb-database-plugin":
 		details := resp.Data["connection_details"]
 		data, ok := details.(map[string]interface{})
@@ -532,19 +536,19 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 			d.Set("mongodb", []map[string]interface{}{result})
 		}
 	case "mssql-database-plugin":
-		d.Set("mssql", getConnectionDetailsFromResponse(resp))
+		d.Set("mssql", getConnectionDetailsFromResponse(d, "mssql.0.", resp))
 	case "mysql-database-plugin":
-		d.Set("mysql", getConnectionDetailsFromResponse(resp))
+		d.Set("mysql", getConnectionDetailsFromResponse(d, "mysql.0.", resp))
 	case "mysql-rds-database-plugin":
-		d.Set("mysql_rds", getConnectionDetailsFromResponse(resp))
+		d.Set("mysql_rds", getConnectionDetailsFromResponse(d, "mysql_rds.0.", resp))
 	case "mysql-aurora-database-plugin":
-		d.Set("mysql_aurora", getConnectionDetailsFromResponse(resp))
+		d.Set("mysql_aurora", getConnectionDetailsFromResponse(d, "mysql_aurora.0.", resp))
 	case "mysql-legacy-database-plugin":
-		d.Set("mysql_legacy", getConnectionDetailsFromResponse(resp))
+		d.Set("mysql_legacy", getConnectionDetailsFromResponse(d, "mysql_legacy.0.", resp))
 	case "oracle-database-plugin":
-		d.Set("oracle", getConnectionDetailsFromResponse(resp))
+		d.Set("oracle", getConnectionDetailsFromResponse(d, "oracle.0.", resp))
 	case "postgresql-database-plugin":
-		d.Set("postgresql", getConnectionDetailsFromResponse(resp))
+		d.Set("postgresql", getConnectionDetailsFromResponse(d, "postgresql.0.", resp))
 	}
 
 	if err != nil {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -42,7 +42,7 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 				ResourceName:            "vault_database_secret_backend_connection.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"verify_connection"},
+				ImportStateVerifyIgnore: []string{"verify_connection", "postgresql.0.connection_url"},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #215. The value in the API response will be masked if it contains credentials. This leads to the resource always appears to be out of sync.

Fixes the following acceptance tests:
- TestAccDatabaseSecretBackendConnection_import
- TestAccDatabaseSecretBackendConnection_postgresql
- TestAccDatabaseSecretBackendRole_basic

Note: TestAccDatabaseSecretBackendRole_import still fails, but not for `connect_url` mismatch anymore. I didn't have a chance to dig into the issues causing the current failures.