### PR TITLE
Fix link in database_secret_backend_connection resource

### DIFF
--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -142,7 +142,7 @@ Exactly one of the nested blocks of configuration options must be supplied.
 
 * `connection_url` - (Required) A URL containing connection information. See
   the [Vault
-  docs](https://www.vaultproject.io/api/secret/databases/mysql.html#sample-payload)
+  docs](https://www.vaultproject.io/api/secret/databases/mysql-maria.html#sample-payload)
   for an example.
 
 * `max_open_connections` - (Optional) The maximum number of open connections to


### PR DESCRIPTION
Link in database_secret_backend_connection resource regarding the mysql documentation is outdated. This PR fixes the link.