### PR TITLE
remove wrong references in cert_auth_backend_role to gcp resources

### DIFF
--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -209,8 +209,6 @@ func certAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("display_name", resp.Data["display_name"])
 	d.Set("ttl", resp.Data["ttl"])
 	d.Set("max_ttl", resp.Data["max_ttl"])
-	d.Set("type", resp.Data["role_type"])
-	d.Set("project_id", resp.Data["project_id"])
 	d.Set("period", resp.Data["period"])
 
 	// Vault sometimes returns these as null instead of an empty list.


### PR DESCRIPTION
In the cert_auth_backend_role resource there are references to values which are not existent. I suppose, they are a copy & paste error.

This pull request just removes these references.