### PR TITLE
Fix wrong response data from gcp_auth_backend_role read request

### DIFF
--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -252,7 +252,7 @@ func gcpAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("ttl", resp.Data["ttl"])
 	d.Set("max_ttl", resp.Data["max_ttl"])
-	d.Set("type", resp.Data["role_type"])
+	d.Set("type", resp.Data["type"])
 	d.Set("project_id", resp.Data["project_id"])
 	d.Set("period", resp.Data["period"])
 

--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -252,9 +252,18 @@ func gcpAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("ttl", resp.Data["ttl"])
 	d.Set("max_ttl", resp.Data["max_ttl"])
-	d.Set("type", resp.Data["type"])
 	d.Set("project_id", resp.Data["project_id"])
 	d.Set("period", resp.Data["period"])
+
+	// These checks are done for backwards compatibility. The 'type' key used to be
+	// 'role_type' and was changed to 'role' errorneously before being corrected
+	if val, ok := resp.Data["type"]; ok {
+		d.Set("type", val)
+	} else if val, ok := resp.Data["role_type"]; ok {
+		d.Set("type", val)
+	} else if val, ok := resp.Data["role"]; ok {
+		d.Set("type", val)
+	}
 
 	d.Set("policies",
 		schema.NewSet(

--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -257,12 +257,12 @@ func gcpAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	// These checks are done for backwards compatibility. The 'type' key used to be
 	// 'role_type' and was changed to 'role' errorneously before being corrected
-	if val, ok := resp.Data["type"]; ok {
-		d.Set("type", val)
-	} else if val, ok := resp.Data["role_type"]; ok {
-		d.Set("type", val)
-	} else if val, ok := resp.Data["role"]; ok {
-		d.Set("type", val)
+	if v, ok := resp.Data["type"]; ok {
+		d.Set("type", v)
+	} else if v, ok := resp.Data["role_type"]; ok {
+		d.Set("type", v)
+	} else if v, ok := resp.Data["role"]; ok {
+		d.Set("type", v)
 	}
 
 	d.Set("policies",

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -106,7 +106,7 @@ func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckF
 		}
 
 		attrs := map[string]string{
-			"type":                   "role_type",
+			"type":                   "type",
 			"project_id":             "project_id",
 			"ttl":                    "ttl",
 			"max_ttl":                "max_ttl",

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -106,7 +106,7 @@ func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckF
 		}
 
 		attrs := map[string]string{
-			"type":                   "type",
+			"type":                   "role_type",
 			"project_id":             "project_id",
 			"ttl":                    "ttl",
 			"max_ttl":                "max_ttl",


### PR DESCRIPTION
As of https://github.com/hashicorp/vault-plugin-auth-gcp/commit/438b86d4b944867fc9ca0d713280088eb72df744, the `role_type` field has been changed to `type`.

This pull request should resolve #228.