### PR TITLE
Extra config options for auth_backend

### DIFF
--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -27,6 +27,14 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of the auth backend
 
+* `default_lease_ttl_seconds` - (Optional) The default lease duration in seconds.
+
+* `max_lease_ttl_seconds` - (Optional) The maximum lease duration in seconds.
+
+* `listing_visibility` - (Optional) Speficies whether to show this mount in the UI-specific listing endpoint.
+
+* `local` - (Optional) Specifies if the auth method is local only.
+
 ## Attributes Reference
 
 In addition to the fields above, the following attributes are exported:


### PR DESCRIPTION
Adds ability to configure following config parameters for `auth_backend`:
- `default_lease_ttl_seconds`
- `max_lease_ttl_seconds`
- `listing_visibility`
- `local`

Test output:
```sh
$ make testacc TESTARGS='-run=TestResourceAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestResourceAuth -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestResourceAuth
--- PASS: TestResourceAuth (0.11s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   0.139s
```

Fixes #203 