### PR TITLE
Fix "panic: interface conversion"

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/vault/api"
@@ -390,11 +391,11 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 		}
 	}
 	if v, ok := data["max_connection_lifetime"]; ok {
-		i, err := v.(json.Number).Int64()
+		n, err := time.ParseDuration(v.(string))
 		if err != nil {
 			log.Printf("[WARN] Non-number %s returned from Vault server: %s", v, err)
 		} else {
-			result["max_connection_lifetime"] = i
+			result["max_connection_lifetime"] = n.Seconds()
 		}
 	}
 	return []map[string]interface{}{result}


### PR DESCRIPTION
The `max_connection_lifetime` parameter is [defined in the schema as an TypeInt](https://github.com/terraform-providers/terraform-provider-vault/blob/master/vault/resource_database_secret_backend_connection.go#L252-L255), however, the Vault API expects it as a string (time.Duration) representation.

Parse the string as a time.Duration and [use the representation in seconds](https://www.terraform.io/docs/providers/vault/r/database_secret_backend_connection.html#max_connection_lifetime-2).

Resolves: #114 #117 #152 #154 

