### PR TITLE
Update policy_arn to be more in line with vault 0.11.0

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -34,28 +34,49 @@ func awsSecretBackendRoleResource() *schema.Resource {
 				ForceNew:    true,
 				Description: "The path of the AWS Secret Backend the role belongs to.",
 			},
+			"policy_arn": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"policy_arns", "role_arns", "policy", "policy_document"},
+				Description:   "**Deprecated** IAM policy the role should use in JSON format.",
+				Deprecated:    "Use policy_arns or role_arns for iam_user or assumed_role respectively",
+			},
 			"policy_arns": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				ConflictsWith: []string{"policy", "role_arns"},
-				Description:   "ARN for an existing IAM policy the role should use.",
+				ConflictsWith: []string{"policy", "role_arns", "policy_arn", "policy_document"},
+				Description:   "ARNs for existing IAM policies the role should use.",
 			},
 			"role_arns": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				ConflictsWith: []string{"policy", "policy_arns"},
-				Description:   "ARN for an existing IAM policy the role should use.",
+				ConflictsWith: []string{"policy", "policy_arns", "policy_arn", "policy_document"},
+				Description:   "ARNs for existing roles that should be used.",
 			},
 			"policy": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ConflictsWith:    []string{"policy_arns", "role_arns"},
+				ConflictsWith:    []string{"policy_arns", "role_arns", "policy_arn", "credential_type", "policy_document"},
+				Description:      "**Deprecated** IAM policy the role should use in JSON format.",
+				Deprecated:       "Use policy_document with credential_type",
+				DiffSuppressFunc: util.JsonDiffSuppress,
+			},
+			"credential_type": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"policy"},
+				Description:   "Specifies the type of credential to be used when retrieving credentials from the role. Must be one of iam_user, assumed_role, or federation_token.",
+			},
+			"policy_document": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ConflictsWith:    []string{"policy_arns", "role_arns", "policy_arn", "policy"},
 				Description:      "IAM policy the role should use in JSON format.",
 				DiffSuppressFunc: util.JsonDiffSuppress,
 			},
@@ -68,25 +89,48 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
-	policyARNs := d.Get("policy_arns").([]string)
-	roleARNs := d.Get("role_arns").([]string)
-	policy := d.Get("policy").(string)
-
-	if policy == "" && policyARNs == nil && roleARNs == nil {
-		return fmt.Errorf("either policy, policy_arn, or role_arn must be set.")
-	}
+	credential_type := d.Get("credential_type").(string)
 
 	data := map[string]interface{}{}
-	if policy != "" {
-		data["policy"] = policy
+	attrSet := false
+
+	if policy, ok := d.GetOkExists("policy"); ok {
+		data["policy"] = policy.(string)
+		credential_type = ""
+		attrSet = true
+	} else if policy_document, ok := d.GetOk("policy_document"); ok {
+		data["policy_document"] = policy_document.(string)
+		if credential_type == "" {
+			return fmt.Errorf("You need to supply a credential_type of iam_user or assumed_role")
+		}
+		attrSet = true
 	}
-	if policyARNs != nil {
-		data["policy_arns"] = policyARNs
+	if ARN, ok := d.GetOk("policy_arn"); ok {
+		data["arn"] = ARN.(string)
+		credential_type = ""
+		attrSet = true
+	} else if policyARNs, ok := d.GetOk("policy_arns"); ok {
+		data["policy_arns"] = util.ToStringArray(policyARNs.(*schema.Set).List())
+		if credential_type == "" {
+			credential_type = "iam_user"
+		}
+		attrSet = true
+	}
+	if roleARNs, ok := d.GetOk("role_arns"); ok {
+		data["role_arns"] = util.ToStringArray(roleARNs.(*schema.Set).List())
+		if credential_type == "" {
+			credential_type = "assumed_role"
+		}
+		attrSet = true
+	}
+	if !attrSet {
+		return fmt.Errorf("either policy, policy_arn, policy_arns, policy_document or role_arns must be set.")
 	}
 
-	if roleARNs != nil {
-		data["role_arns"] = roleARNs
+	if credential_type != "" {
+		data["credential_type"] = credential_type
 	}
+
 	log.Printf("[DEBUG] Creating role %q on AWS backend %q", name, backend)
 	_, err := client.Logical().Write(backend+"/roles/"+name, data)
 	if err != nil {
@@ -118,9 +162,36 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	d.Set("policy", secret.Data["policy"])
-	d.Set("policy_arns", secret.Data["policy_arns"])
+
+	credential_set := true // Deprecated `policy_arn` and `policy` can't use credential_type
+	var ok bool
+
+	// 0.11.0 Uses version policy_document over deprecated policy
+	if _, ok = d.GetOk("policy"); ok {
+		d.Set("policy", secret.Data["policy_document"])
+		credential_set = false
+	} else {
+		d.Set("policy_document", secret.Data["policy_document"])
+	}
+
+	// 0.11.0 Uses version policy_arns over deprecated policy_arn
+	if _, ok = d.GetOk("policy_arn"); ok {
+		if secret.Data["policy_arns"] != nil {
+			d.Set("policy_arn", util.ToStringArray(secret.Data["policy_arns"].([]interface{}))[0])
+		}
+		credential_set = false
+	} else {
+		d.Set("policy_arns", secret.Data["policy_arns"])
+	}
+
+	// 0.11.0 Uses  role_arns and policy_arns over old `arn` which was implemented with `policy_arn`
 	d.Set("role_arns", secret.Data["role_arns"])
+
+	if secret.Data["credential_type"] != nil && credential_set {
+		// Credential_type is single value, but vault returns multi-value credential_types. Sometimes adding federation_token
+		d.Set("credential_type", util.ToStringArray(secret.Data["credential_types"].([]interface{}))[0])
+	}
+
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
 	d.Set("name", pathPieces[len(pathPieces)-1])
 	return nil

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -185,7 +185,7 @@ resource "vault_aws_secret_backend_role" "test_role_arn" {
   role_arns = ["%s"]
   backend = "${vault_aws_secret_backend.test.path}"
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAwsSecretBackendRoleRoleArn_basic)
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRoleRoleArn_basic)
 }
 
 func testAccAWSSecretBackendRoleConfig_updated(name, path, accessKey, secretKey string) string {

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -2,6 +2,8 @@ package vault
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -13,14 +15,21 @@ import (
 
 const testAccAWSSecretBackendRolePolicyInline_basic = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "iam:*","Resource": "*"}]}`
 const testAccAWSSecretBackendRolePolicyInline_updated = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "ec2:*","Resource": "*"}]}`
+
+const testAccAWSSecretBackendRolePolicyDocument_basic = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "s3:*","Resource": "*"}]}`
+const testAccAWSSecretBackendRolePolicyDocument_updated = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "ecs:*","Resource": "*"}]}`
 const testAccAWSSecretBackendRolePolicyArn_basic = "arn:aws:iam::123456789123:policy/foo"
 const testAccAWSSecretBackendRolePolicyArn_updated = "arn:aws:iam::123456789123:policy/bar"
-const testAccAWSSecretBackendRoleRoleArn_basic = "arn:aws:iam::123456789123:role/bar"
-const testAccAWSSecretBackendRoleRoleArn_updated = "arn:aws:iam::123456789123:role/bar"
 
 func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-aws")
 	name := acctest.RandomWithPrefix("tf-test-aws")
+
+	policies_basic := []string{"arn:aws:iam::123456789123:policy/fizz"}
+	policies_updated := []string{"arn:aws:iam::123456789123:policy/buzz"}
+	roles_basic := []string{"arn:aws:iam::123456789123:role/fizz"}
+	roles_updated := []string{"arn:aws:iam::123456789123:role/buzz"}
+
 	accessKey, secretKey := getTestAWSCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -28,31 +37,35 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 		CheckDestroy: testAccAWSSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey, policies_basic, roles_basic),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "name", fmt.Sprintf("%s-policy-document", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_document", "policy_document", testAccAWSSecretBackendRolePolicyDocument_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_policy_arns", "policy_arns", policies_basic),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_role_arns", "role_arns", roles_basic),
 				),
 			},
 			{
-				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey, policies_updated, roles_updated),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "name", fmt.Sprintf("%s-policy-document", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_document", "policy_document", testAccAWSSecretBackendRolePolicyDocument_updated),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_policy_arns", "policy_arns", policies_updated),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_role_arns", "role_arns", roles_updated),
 				),
 			},
 		},
@@ -62,6 +75,10 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 func TestAccAWSSecretBackendRole_import(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-aws")
 	name := acctest.RandomWithPrefix("tf-test-aws")
+
+	policies_basic := []string{"arn:aws:iam::123456789123:policy/fizz"}
+	roles_basic := []string{"arn:aws:iam::123456789123:role/fizz"}
+
 	accessKey, secretKey := getTestAWSCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -69,31 +86,27 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 		CheckDestroy: testAccAWSSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfig_import(name, backend, accessKey, secretKey, policies_basic, roles_basic),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "name", fmt.Sprintf("%s-policy-document", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_document", "policy_document", testAccAWSSecretBackendRolePolicyDocument_basic),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_policy_arns", "policy_arns", policies_basic),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_role_arns", "role_arns", roles_basic),
 				),
 			},
 			{
-				ResourceName:      "vault_aws_secret_backend_role.test_policy_inline",
+				ResourceName:      "vault_aws_secret_backend_role.test_policy_document",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "vault_aws_secret_backend_role.test_policy_arn",
+				ResourceName:      "vault_aws_secret_backend_role.test_policy_arns",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "vault_aws_secret_backend_role.test_role_arn",
+				ResourceName:      "vault_aws_secret_backend_role.test_role_arns",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -104,6 +117,12 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-aws/nested")
 	name := acctest.RandomWithPrefix("tf-test-aws")
+
+	policies_basic := []string{"arn:aws:iam::123456789123:policy/fizz"}
+	policies_updated := []string{"arn:aws:iam::123456789123:policy/buzz"}
+	roles_basic := []string{"arn:aws:iam::123456789123:role/fizz"}
+	roles_updated := []string{"arn:aws:iam::123456789123:role/buzz"}
+
 	accessKey, secretKey := getTestAWSCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -111,37 +130,40 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 		CheckDestroy: testAccAWSSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey, policies_basic, roles_basic),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "name", fmt.Sprintf("%s-policy-document", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_document", "policy_document", testAccAWSSecretBackendRolePolicyDocument_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_policy_arns", "policy_arns", policies_basic),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_role_arns", "role_arns", roles_basic),
 				),
 			},
 			{
-				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey, policies_updated, roles_updated),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "name", fmt.Sprintf("%s-policy-document", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_document", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_document", "policy_document", testAccAWSSecretBackendRolePolicyDocument_updated),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_policy_arns", "policy_arns", policies_updated),
+					testAWSSecretBackendRoleCheck_values(backend, "vault_aws_secret_backend_role.test_role_arns", "role_arns", roles_updated),
 				),
 			},
 		},
 	})
 }
-
 func testAccAWSSecretBackendRoleCheckDestroy(s *terraform.State) error {
 	client := testProvider.Meta().(*api.Client)
 
@@ -160,7 +182,53 @@ func testAccAWSSecretBackendRoleCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSSecretBackendRoleConfig_basic(name, path, accessKey, secretKey string) string {
+func testAWSSecretBackendRoleCheck_values(backend, name, key string, value []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources[name]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		resp, err := client.Logical().Read(instanceState.ID)
+		if err != nil {
+			return err
+		}
+
+		values := util.ToStringArray(resp.Data[key].([]interface{}))
+
+		count, err := strconv.Atoi(instanceState.Attributes[fmt.Sprintf("%s.#", key)])
+		if err != nil {
+			return err
+		}
+		if len(values) != count {
+			return fmt.Errorf("saw %d %s on server, expected %d", len(values), key, count)
+		}
+
+		for _, value := range values {
+			found := false
+			for stateKey, stateValue := range instanceState.Attributes {
+				if strings.HasPrefix(stateKey, fmt.Sprintf("%s.", key)) {
+					if stateValue == value {
+						found = true
+						break
+					}
+				}
+			}
+			if !found {
+				return fmt.Errorf("unable to find %s %s in state file", key, value)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccAWSSecretBackendRoleConfig_basic(name, path, accessKey, secretKey string, policies_basic, roles_basic []string) string {
 	return fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
   path = "%s"
@@ -174,21 +242,34 @@ resource "vault_aws_secret_backend_role" "test_policy_inline" {
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
+resource "vault_aws_secret_backend_role" "test_policy_document" {
+  name = "%s-policy-document"
+  policy_document = %q
+  credential_type = "iam_user"
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+
 resource "vault_aws_secret_backend_role" "test_policy_arn" {
   name = "%s-policy-arn"
-  policy_arns = ["%s"]
+  policy_arn = "%s"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
-resource "vault_aws_secret_backend_role" "test_role_arn" {
-  name = "%s-role-arn"
-  role_arns = ["%s"]
+resource "vault_aws_secret_backend_role" "test_policy_arns" {
+  name = "%s-policy-arns"
+  policy_arns = %s
   backend = "${vault_aws_secret_backend.test.path}"
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRoleRoleArn_basic)
+
+resource "vault_aws_secret_backend_role" "test_role_arns" {
+  name = "%s-role-arns"
+  role_arns = %s
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyDocument_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, util.ArrayToTerraformList(policies_basic), name, util.ArrayToTerraformList(roles_basic))
 }
 
-func testAccAWSSecretBackendRoleConfig_updated(name, path, accessKey, secretKey string) string {
+func testAccAWSSecretBackendRoleConfig_updated(name, path, accessKey, secretKey string, policies_updated, roles_updated []string) string {
 	return fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
   path = "%s"
@@ -202,16 +283,58 @@ resource "vault_aws_secret_backend_role" "test_policy_inline" {
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
-resource "vault_aws_secret_backend_role" "test_policy_arn" {
-  name = "%s-policy-arn"
-  policy_arns = ["%s"]
+resource "vault_aws_secret_backend_role" "test_policy_document" {
+  name = "%s-policy-document"
+  policy_document = %q
+  credential_type = "iam_user"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
-resource "vault_aws_secret_backend_role" "test_role_arn" {
-  name = "%s-role-arn"
-  role_arns = ["%s"]
+resource "vault_aws_secret_backend_role" "test_policy_arn" {
+  name = "%s-policy-arn"
+  policy_arn = "%s"
   backend = "${vault_aws_secret_backend.test.path}"
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRoleRoleArn_updated)
+
+resource "vault_aws_secret_backend_role" "test_policy_arns" {
+  name = "%s-policy-arns"
+  policy_arns = %s
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+
+resource "vault_aws_secret_backend_role" "test_role_arns" {
+  name = "%s-role-arns"
+  role_arns = %s
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyDocument_updated, name, testAccAWSSecretBackendRolePolicyArn_updated, name, util.ArrayToTerraformList(policies_updated), name, util.ArrayToTerraformList(roles_updated))
+}
+
+func testAccAWSSecretBackendRoleConfig_import(name, path, accessKey, secretKey string, policies_basic, roles_basic []string) string {
+	return fmt.Sprintf(`
+resource "vault_aws_secret_backend" "test" {
+  path = "%s"
+  access_key = "%s"
+  secret_key = "%s"
+}
+
+resource "vault_aws_secret_backend_role" "test_policy_document" {
+  name = "%s-policy-document"
+  policy_document = %q
+  credential_type = "iam_user"
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+
+resource "vault_aws_secret_backend_role" "test_policy_arns" {
+  name = "%s-policy-arns"
+  policy_arns = %s
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+
+resource "vault_aws_secret_backend_role" "test_role_arns" {
+  name = "%s-role-arns"
+  role_arns = %s
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyDocument_basic, name, util.ArrayToTerraformList(policies_basic), name, util.ArrayToTerraformList(roles_basic))
 }

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -15,6 +15,8 @@ const testAccAWSSecretBackendRolePolicyInline_basic = `{"Version": "2012-10-17",
 const testAccAWSSecretBackendRolePolicyInline_updated = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "ec2:*","Resource": "*"}]}`
 const testAccAWSSecretBackendRolePolicyArn_basic = "arn:aws:iam::123456789123:policy/foo"
 const testAccAWSSecretBackendRolePolicyArn_updated = "arn:aws:iam::123456789123:policy/bar"
+const testAccAWSSecretBackendRoleRoleArn_basic = "arn:aws:iam::123456789123:role/bar"
+const testAccAWSSecretBackendRoleRoleArn_updated = "arn:aws:iam::123456789123:role/bar"
 
 func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-aws")
@@ -33,7 +35,10 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
 				),
 			},
 			{
@@ -44,7 +49,10 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_updated),
 				),
 			},
 		},
@@ -68,7 +76,10 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
 				),
 			},
 			{
@@ -78,6 +89,11 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 			},
 			{
 				ResourceName:      "vault_aws_secret_backend_role.test_policy_arn",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "vault_aws_secret_backend_role.test_role_arn",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -102,7 +118,10 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
 				),
 			},
 			{
@@ -113,7 +132,10 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arns", testAccAWSSecretBackendRolePolicyArn_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "name", fmt.Sprintf("%s-role-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arn", "role_arns", testAccAWSSecretBackendRoleRoleArn_basic),
 				),
 			},
 		},
@@ -154,10 +176,16 @@ resource "vault_aws_secret_backend_role" "test_policy_inline" {
 
 resource "vault_aws_secret_backend_role" "test_policy_arn" {
   name = "%s-policy-arn"
-  policy_arn = "%s"
+  policy_arns = ["%s"]
   backend = "${vault_aws_secret_backend.test.path}"
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic)
+
+resource "vault_aws_secret_backend_role" "test_role_arn" {
+  name = "%s-role-arn"
+  role_arns = ["%s"]
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAwsSecretBackendRoleRoleArn_basic)
 }
 
 func testAccAWSSecretBackendRoleConfig_updated(name, path, accessKey, secretKey string) string {
@@ -176,8 +204,14 @@ resource "vault_aws_secret_backend_role" "test_policy_inline" {
 
 resource "vault_aws_secret_backend_role" "test_policy_arn" {
   name = "%s-policy-arn"
-  policy_arn = "%s"
+  policy_arns = ["%s"]
   backend = "${vault_aws_secret_backend.test.path}"
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated)
+
+resource "vault_aws_secret_backend_role" "test_role_arn" {
+  name = "%s-role-arn"
+  role_arns = ["%s"]
+  backend = "${vault_aws_secret_backend.test.path}"
+}
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRoleRoleArn_updated)
 }

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -27,8 +27,9 @@ resource "vault_aws_secret_backend" "aws" {
 }
 
 resource "vault_aws_secret_backend_role" "role" {
-  backend = "${vault_aws_secret_backend.aws.path}"
-  name    = "deploy"
+  backend         = "${vault_aws_secret_backend.aws.path}"
+  name            = "deploy"
+  credential_type = "iam_user"
 
   policy = <<EOT
 {
@@ -56,13 +57,16 @@ with no leading or trailing `/`s.
 Must be unique within the backend.
 
 * `policy` - (Optional) The JSON-formatted policy to associate with this
-role. Either `policy`, `policy_arns`, or `role_arns` must be specified.
+role. Either `policy`, `policy_arns`, or `role_arns` must be specified. 
 
 * `policy_arns` - (Optional) A list of the ARNs for pre-existing policies to associate
 with this role. Either `policy`, `policy_arns`, or `role_arns`  must be specified.
 
 * `role_arns` - (Optional) A list of the ARNs for pre-existing roles to associate
 with this. Either `policy`, `policy_arns`, or `role_arns`  must be specified.
+
+* `credential_type` - (Optional) Specifies the type of credential to be used when 
+retrieving credentials from the role.  Must be one of iam_user, assumed_role, or federation_token.
 
 ## Attributes Reference
 

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -56,10 +56,13 @@ with no leading or trailing `/`s.
 Must be unique within the backend.
 
 * `policy` - (Optional) The JSON-formatted policy to associate with this
-role. Either `policy` or `policy_arn` must be specified.
+role. Either `policy`, `policy_arns`, or `role_arns` must be specified.
 
-* `policy_arn` - (Optional) The ARN for a pre-existing policy to associate
-with this role. Either `policy` or `policy_arn` must be specified.
+* `policy_arns` - (Optional) A list of the ARNs for pre-existing policies to associate
+with this role. Either `policy`, `policy_arns`, or `role_arns`  must be specified.
+
+* `role_arns` - (Optional) A list of the ARNs for pre-existing roles to associate
+with this. Either `policy`, `policy_arns`, or `role_arns`  must be specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Vault was changed from using `arn` to use `policy_arns` and `role_arns` in https://github.com/hashicorp/vault/pull/4360 

Without this change terraform will not be able to read the aws_secret_backend_role properly and assumes it always needs to be updated with policy_arn. 

Have not tested the Acceptance tests. But have tested locally to existing vault > 0.11.0 where this issue came up.

