### PR TITLE
Fix issue where boolean parameters are not being set when value is false

### DIFF
--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -379,7 +379,7 @@ func awsAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("inferred_aws_region"); ok {
 			data["inferred_aws_region"] = v.(string)
 		}
-		if v, ok := d.GetOk("resolve_aws_unique_ids"); ok {
+		if v, ok := d.GetOkExists("resolve_aws_unique_ids"); ok {
 			data["resolve_aws_unique_ids"] = v.(bool)
 		}
 	}
@@ -617,7 +617,7 @@ func awsAuthBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 			data["inferred_aws_region"] = v.(string)
 		}
 
-		if v, ok := d.GetOk("resolve_aws_unique_ids"); ok {
+		if v, ok := d.GetOkExists("resolve_aws_unique_ids"); ok {
 			data["resolve_aws_unique_ids"] = v.(bool)
 		}
 	}

--- a/vault/resource_aws_auth_backend_role_test.go
+++ b/vault/resource_aws_auth_backend_role_test.go
@@ -131,6 +131,23 @@ func TestAccAWSAuthBackendRole_iam(t *testing.T) {
 	})
 }
 
+func TestAccAWSAuthBackendRole_iam_resolve_aws_unique_ids(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendRoleConfig_iam_resolve_aws_unique_ids(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+			},
+		},
+	})
+}
+
 func TestAccAWSAuthBackendRole_iamUpdate(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
@@ -353,6 +370,24 @@ resource "vault_aws_auth_backend_role" "role" {
   auth_type = "iam"
   bound_iam_principal_arns = ["arn:aws:iam::123456789012:role/*"]
   resolve_aws_unique_ids = true
+  ttl = 60
+  max_ttl = 120
+  policies = ["default", "dev", "prod"]
+}`, backend, role)
+}
+
+func testAccAWSAuthBackendRoleConfig_iam_resolve_aws_unique_ids(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+}
+resource "vault_aws_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.aws.path}"
+  role = "%s"
+  auth_type = "iam"
+  bound_iam_principal_arns = ["arn:aws:iam::123456789012:role/*"]
+  resolve_aws_unique_ids = false
   ttl = 60
   max_ttl = 120
   policies = ["default", "dev", "prod"]


### PR DESCRIPTION
While using the **vault_aws_auth_backend_role** resource we wanted to set the parameter **resolve_aws_unique_ids** to false. However we noticed this was being ignored because **GetOk** method returns ok as false when the boolean value is false.

Therefore parameter is not supplied to underlying Vault API call. The default value for **resolve_aws_unique_ids** in Vault is true.

Method **GetOkExists** seems more appropriate for boolean parameters that do not default to being false.