### PR TITLE
base ldap_auth_backend_config on vault_auth_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ BUG FIXES:
 * Fixes issue where the `role_name` on `token_auth_backend_role` would not be updated ([#279](https://github.com/terraform-providers/terraform-provider-vault/pull/279))
 * Fixes wrong response data from `gcp_auth_backend_role` ([#243](https://github.com/terraform-providers/terraform-provider-vault/pull/243))
 
+* **New Resource**: `ldap_auth_backend_config` ([#273](https://github.com/terraform-providers/terraform-provider-vault/pull/273))
+
+BACKWARDS INCOMPATIBILITIES / NOTES:
+* `ldap_auth_backend` is deprecated; use `ldap_auth_backend_config` instead.
+
 ## 1.4.1 (December 14, 2018)
 
 BUG FIXES:

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -134,6 +134,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_okta_auth_backend":                            oktaAuthBackendResource(),
 			"vault_okta_auth_backend_user":                       oktaAuthBackendUserResource(),
 			"vault_okta_auth_backend_group":                      oktaAuthBackendGroupResource(),
+			"vault_ldap_auth_backend":                            ldapAuthBackendResource(),
 			"vault_ldap_auth_backend_config":                     ldapAuthBackendConfigResource(),
 			"vault_ldap_auth_backend_user":                       ldapAuthBackendUserResource(),
 			"vault_ldap_auth_backend_group":                      ldapAuthBackendGroupResource(),

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -134,7 +134,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_okta_auth_backend":                            oktaAuthBackendResource(),
 			"vault_okta_auth_backend_user":                       oktaAuthBackendUserResource(),
 			"vault_okta_auth_backend_group":                      oktaAuthBackendGroupResource(),
-			"vault_ldap_auth_backend":                            ldapAuthBackendResource(),
+			"vault_ldap_auth_backend_config":                     ldapAuthBackendConfigResource(),
 			"vault_ldap_auth_backend_user":                       ldapAuthBackendUserResource(),
 			"vault_ldap_auth_backend_group":                      ldapAuthBackendGroupResource(),
 			"vault_policy":                                       policyResource(),

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -3,26 +3,26 @@ package vault
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
+
 	"github.com/hashicorp/vault/api"
 )
 
-var (
-	ldapAuthBackendConfigFromPathRegex = regexp.MustCompile("^auth/(.+)/config$")
-)
+const ldapAuthType string = "ldap"
 
-func ldapAuthBackendConfigResource() *schema.Resource {
+func ldapAuthBackendResource() *schema.Resource {
 	return &schema.Resource{
 		SchemaVersion: 1,
 
-		Create: ldapAuthBackendConfigCreate,
-		Update: ldapAuthBackendConfigUpdate,
-		Read:   ldapAuthBackendConfigRead,
-		Delete: ldapAuthBackendConfigDelete,
-		Exists: ldapAuthBackendConfigExists,
+		Create: ldapAuthBackendWrite,
+		Update: ldapAuthBackendUpdate,
+		Read:   ldapAuthBackendRead,
+		Delete: ldapAuthBackendDelete,
+		Exists: ldapAuthBackendExists,
+
+		DeprecationMessage: "ldap_auth_backend resource is deprecated and will be removed with version 1.5 - use ldap_auth_backend_config",
 
 		Schema: map[string]*schema.Schema{
 			"url": {
@@ -108,42 +108,59 @@ func ldapAuthBackendConfigResource() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"backend": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Unique name of the ldap backend to configure.",
-				ForceNew:    true,
-				Default:     "ldap",
-				// standardise on no beginning or trailing slashes
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "ldap",
 				StateFunc: func(v interface{}) string {
 					return strings.Trim(v.(string), "/")
 				},
+			},
+
+			"accessor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The accessor of the LDAP auth backend",
 			},
 		},
 	}
 }
 
-func baseAuthBackendConfigPath(path string) string {
+func ldapAuthBackendConfigPath(path string) string {
 	return "auth/" + strings.Trim(path, "/") + "/config"
 }
 
-func ldapAuthBackendConfigBackendFromPath(path string) (string, error) {
-	if !ldapAuthBackendConfigFromPathRegex.MatchString(path) {
-		return "", fmt.Errorf("no backend found")
+func ldapAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	authType := ldapAuthType
+	path := d.Get("path").(string)
+	desc := d.Get("description").(string)
+
+	log.Printf("[DEBUG] Enabling LDAP auth backend %q", path)
+	err := client.Sys().EnableAuth(path, authType, desc)
+	if err != nil {
+		return fmt.Errorf("error enabling ldap auth backend %q: %s", path, err)
 	}
-	res := ldapAuthBackendConfigFromPathRegex.FindStringSubmatch(path)
-	if len(res) != 2 {
-		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
-	}
-	return res[1], nil
+	log.Printf("[DEBUG] Enabled LDAP auth backend %q", path)
+
+	d.SetId(path)
+
+	return ldapAuthBackendUpdate(d, meta)
 }
 
-func ldapAuthBackendConfigCreate(d *schema.ResourceData, meta interface{}) error {
+func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
-	backend := d.Get("backend").(string)
-	path := baseAuthBackendConfigPath(backend)
-	log.Printf("[DEBUG] Writing ldap auth backend config %q", path)
 
+	path := ldapAuthBackendConfigPath(d.Id())
 	data := map[string]interface{}{}
 
 	if v, ok := d.GetOk("url"); ok {
@@ -212,8 +229,6 @@ func ldapAuthBackendConfigCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Writing LDAP config %q", path)
 	_, err := client.Logical().Write(path, data)
-
-	d.SetId(path)
 
 	if err != nil {
 		d.SetId("")
@@ -221,117 +236,41 @@ func ldapAuthBackendConfigCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	log.Printf("[DEBUG] Wrote LDAP config %q", path)
 
-	return ldapAuthBackendConfigRead(d, meta)
+	return ldapAuthBackendRead(d, meta)
 }
 
-func ldapAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
+
 	path := d.Id()
-
-	log.Printf("[DEBUG] Updating ldap auth backend config %q", path)
-
-	data := map[string]interface{}{}
-
-	if v, ok := d.GetOk("url"); ok {
-		data["url"] = v.(string)
-	}
-
-	if v, ok := d.GetOkExists("starttls"); ok {
-		data["starttls"] = v.(bool)
-	}
-
-	if v, ok := d.GetOk("tls_min_version"); ok {
-		data["tls_min_version"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("tls_max_version"); ok {
-		data["tls_max_version"] = v.(string)
-	}
-
-	if v, ok := d.GetOkExists("insecure_tls"); ok {
-		data["insecure_tls"] = v.(bool)
-	}
-
-	if v, ok := d.GetOk("certificate"); ok {
-		data["certificate"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("binddn"); ok {
-		data["binddn"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("bindpass"); ok {
-		data["bindpass"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("userdn"); ok {
-		data["userdn"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("userattr"); ok {
-		data["userattr"] = v.(string)
-	}
-
-	if v, ok := d.GetOkExists("discoverdn"); ok {
-		data["discoverdn"] = v.(bool)
-	}
-
-	if v, ok := d.GetOkExists("deny_null_bind"); ok {
-		data["deny_null_bind"] = v.(bool)
-	}
-
-	if v, ok := d.GetOk("upndomain"); ok {
-		data["upndomain"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("groupfilter"); ok {
-		data["groupfilter"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("groupdn"); ok {
-		data["groupdn"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("groupattr"); ok {
-		data["groupattr"] = v.(string)
-	}
-
-	log.Printf("[DEBUG] Writing LDAP config %q", path)
-	_, err := client.Logical().Write(path, data)
+	auths, err := client.Sys().ListAuth()
 	if err != nil {
-		return fmt.Errorf("error updating ldap config %q: %s", path, err)
+		return fmt.Errorf("error reading from Vault: %s", err)
 	}
 
-	// NOTE: Only `SetId` after it's successfully written in Vault
-	d.SetId(path)
-
-	log.Printf("[DEBUG] Wrote LDAP config %q", path)
-
-	return ldapAuthBackendConfigRead(d, meta)
-}
-
-func ldapAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
-	path := d.Id()
-
-	backend, err := ldapAuthBackendConfigBackendFromPath(path)
-	if err != nil {
-		return fmt.Errorf("invalid path %q for ldap auth backend config: %s", path, err)
+	authMount := auths[strings.Trim(path, "/")+"/"]
+	if authMount == nil {
+		return fmt.Errorf("auth mount %s not present", path)
 	}
 
-	log.Printf("[DEBUG] Reading ldap auth backend config %q", path)
+	d.Set("description", authMount.Description)
+	d.Set("accessor", authMount.Accessor)
+
+	path = ldapAuthBackendConfigPath(path)
+
+	log.Printf("[DEBUG] Reading LDAP auth backend config %q", path)
 	resp, err := client.Logical().Read(path)
 	if err != nil {
 		return fmt.Errorf("error reading ldap auth backend config %q: %s", path, err)
 	}
-	log.Printf("[DEBUG] Read ldap auth backend config %q", path)
+	log.Printf("[DEBUG] Read LDAP auth backend config %q", path)
+
 	if resp == nil {
-		log.Printf("[WARN] ldap auth backend config %q not found, removing from state", path)
+		log.Printf("[WARN] LDAP auth backend config %q not found, removing from state", path)
 		d.SetId("")
 		return nil
 	}
 
-	d.Set("backend", backend)
 	d.Set("url", resp.Data["url"])
 	d.Set("starttls", resp.Data["starttls"])
 	d.Set("tls_min_version", resp.Data["tls_min_version"])
@@ -354,24 +293,30 @@ func ldapAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func ldapAuthBackendConfigDelete(d *schema.ResourceData, meta interface{}) error {
+func ldapAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
 	path := d.Id()
-	log.Printf("[DEBUG] Deleted ldap auth backend config %q", path)
-	d.SetId("")
+
+	log.Printf("[DEBUG] Deleting LDAP auth backend %q", path)
+	err := client.Sys().DisableAuth(path)
+	if err != nil {
+		return fmt.Errorf("error deleting ldap auth backend %q: %q", path, err)
+	}
+	log.Printf("[DEBUG] Deleted LDAP auth backend %q", path)
+
 	return nil
 }
 
-func ldapAuthBackendConfigExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+func ldapAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*api.Client)
+	path := ldapAuthBackendConfigPath(d.Id())
 
-	path := d.Id()
-	log.Printf("[DEBUG] Checking if ldap auth backend config %q exists", path)
-
+	log.Printf("[DEBUG] Checking if LDAP auth backend %q exists", path)
 	resp, err := client.Logical().Read(path)
 	if err != nil {
-		return true, fmt.Errorf("error checking if ldap auth backend config %q exists: %s", path, err)
+		return true, fmt.Errorf("error checking for existence of ldap config %q: %s", path, err)
 	}
-	log.Printf("[DEBUG] Checked if ldap auth backend config %q exists", path)
+	log.Printf("[DEBUG] Checked if LDAP auth backend %q exists", path)
 
 	return resp != nil, nil
 }

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -1,0 +1,199 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestLDAPAuthBackend_basic(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-test-ldap-path")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testLDAPAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testLDAPAuthBackendConfig_basic(path),
+				Check:  testLDAPAuthBackendCheck_attrs(path),
+			},
+		},
+	})
+}
+
+func testLDAPAuthBackendDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_ldap_auth_backend" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for ldap auth backend %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("ldap auth backend %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testLDAPAuthBackendCheck_attrs(path string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_ldap_auth_backend.test"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		endpoint := strings.Trim(path, "/")
+		if endpoint != instanceState.ID {
+			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		authMounts, err := client.Sys().ListAuth()
+		if err != nil {
+			return err
+		}
+		authMount := authMounts[strings.Trim(path, "/")+"/"]
+
+		if authMount == nil {
+			return fmt.Errorf("auth mount %s not present", path)
+		}
+
+		if "ldap" != authMount.Type {
+			return fmt.Errorf("incorrect mount type: %s", authMount.Type)
+		}
+
+		if instanceState.Attributes["accessor"] != authMount.Accessor {
+			return fmt.Errorf("accessor in state %s does not match accessor returned from vault %s", instanceState.Attributes["accessor"], authMount.Accessor)
+		}
+
+		configPath := "auth/" + endpoint + "/config"
+
+		resp, err := client.Logical().Read(configPath)
+		if err != nil {
+			return err
+		}
+
+		// Check that `bindpass`, if present in the state, is not returned by the API
+		if instanceState.Attributes["bindpass"] != "" && resp.Data["bindpass"] != nil {
+			return fmt.Errorf("expected api field bindpass to not be returned, but was %q", resp.Data["bindpass"])
+		}
+
+		attrs := map[string]string{
+			"url":             "url",
+			"starttls":        "starttls",
+			"tls_min_version": "tls_min_version",
+			"tls_max_version": "tls_max_version",
+			"insecure_tls":    "insecure_tls",
+			"certificate":     "certificate",
+			"binddn":          "binddn",
+			"userdn":          "userdn",
+			"userattr":        "userattr",
+			"discoverdn":      "discoverdn",
+			"deny_null_bind":  "deny_null_bind",
+			"upndomain":       "upndomain",
+			"groupfilter":     "groupfilter",
+			"groupdn":         "groupdn",
+			"groupattr":       "groupattr",
+		}
+
+		for stateAttr, apiAttr := range attrs {
+			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+				continue
+			}
+			var match bool
+			switch resp.Data[apiAttr].(type) {
+			case json.Number:
+				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
+				if err != nil {
+					return fmt.Errorf("expected api field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
+				}
+				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
+				if err != nil {
+					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
+				}
+				match = apiData == stateData
+			case bool:
+				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
+					match = true
+				} else {
+					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
+					if err != nil {
+						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
+					}
+					match = resp.Data[apiAttr] == stateData
+				}
+
+			case []interface{}:
+				apiData := resp.Data[apiAttr].([]interface{})
+				length := instanceState.Attributes[stateAttr+".#"]
+				if length == "" {
+					if len(resp.Data[apiAttr].([]interface{})) != 0 {
+						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
+					}
+					match = true
+				} else {
+					count, err := strconv.Atoi(length)
+					if err != nil {
+						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
+					}
+					if count != len(apiData) {
+						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
+					}
+					for i := 0; i < count; i++ {
+						stateData := instanceState.Attributes[stateAttr+"."+strconv.Itoa(i)]
+						if stateData != apiData[i] {
+							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be %q, got %q", i, apiAttr, stateAttr, endpoint, stateData, apiData[i])
+						}
+					}
+					match = true
+				}
+			default:
+				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+
+			}
+			if !match {
+				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
+			}
+
+		}
+
+		return nil
+	}
+}
+
+func testLDAPAuthBackendConfig_basic(path string) string {
+
+	return fmt.Sprintf(`
+resource "vault_ldap_auth_backend" "test" {
+    path                   = "%s"
+    url                    = "ldaps://example.org"
+    starttls               = true
+    tls_min_version        = "tls11"
+    tls_max_version        = "tls12"
+    insecure_tls           = false
+    binddn                 = "cn=example.com"
+    bindpass               = "supersecurepassword"
+    discoverdn             = false
+    deny_null_bind         = true
+    description            = "example"
+}
+`, path)
+
+}

--- a/website/docs/r/ldap_auth_backend_config.html.md
+++ b/website/docs/r/ldap_auth_backend_config.html.md
@@ -1,20 +1,24 @@
 ---
 layout: "vault"
-page_title: "Vault: vault_auth_backend resource"
-sidebar_current: "docs-vault-resource-ldap-auth-backend"
+page_title: "Vault: vault_auth_backend_config resource"
+sidebar_current: "docs-vault-resource-ldap-auth-backend-config"
 description: |-
   Managing LDAP auth backends in Vault
 ---
 
-# vault\_ldap\_auth\_backend
+# vault\_ldap\_auth\_backend\_config
 
 Provides a resource for managing an [LDAP auth backend within Vault](https://www.vaultproject.io/docs/auth/ldap.html).
 
 ## Example Usage
 
 ```hcl
-resource "vault_ldap_auth_backend" "ldap" {
-    path        = "ldap"
+resource "vault_auth_backend" "ldap" {
+  type = "ldap"
+}
+
+resource "vault_ldap_auth_backend_config" "example" {
+    path        = "${vault_auth_backend.ldap.path}"
     url         = "ldaps://dc-01.example.org"
     userdn      = "OU=Users,OU=Accounts,DC=example,DC=org"
     userattr    = "sAMAccountName"
@@ -63,10 +67,6 @@ The following arguments are supported:
 
 * `groupattr` - (Optional) LDAP attribute to follow on objects returned by groupfilter
 
-* `path` - (Optional) Path to mount the LDAP auth backend under
-
-* `description` - (Optional) Description for the LDAP auth backend mount
-
 For more details on the usage of each argument consult the [Vault LDAP API documentation](https://www.vaultproject.io/api/auth/ldap/index.html).
 
 ~> **Important** Because Vault does not support reading the configured
@@ -76,6 +76,4 @@ previously stored values.
 
 ## Attributes Reference
 
-In addition to the fields above, the following attributes are exported:
-
-* `accessor` - The accessor for this auth mount.
+No additional attributes are exported by this resource.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -156,7 +156,7 @@
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-ldap-auth-backend") %>>
-                            <a href="/docs/providers/vault/r/ldap_auth_backend.html">vault_ldap_auth_backend</a>
+                            <a href="/docs/providers/vault/r/ldap_auth_backend_config.html">vault_ldap_auth_backend_config</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-ldap-auth-backend-user") %>>


### PR DESCRIPTION
**Changes behaviour how a ldap auth backend is defined - vault_ldap_auth renamed to vault_ldap_auth_backend_config**

**Instead of creating a auth mount itself we require now a vault_auth_backend as base**

right now the ldap auth backend does not support to set a lease-ttl
this was already added to the vault_auth_backend

change the behaviour and rename resource to ldap_auth_backend_config
the resource requires not a vault_auth_backend as base

behaviour should now be similar to kubernetes_auth_backend_config

resolves https://github.com/terraform-providers/terraform-provider-vault/issues/269