### PR TITLE
Fix gcp_auth_backend_role

### DIFF
--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -30,25 +30,20 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"project_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"ttl": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"max_ttl": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"period": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"policies": {
 				Type: schema.TypeSet,
@@ -56,7 +51,7 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"bound_service_accounts": {
 				Type: schema.TypeSet,
@@ -66,13 +61,21 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"bound_projects": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+				Computed: false,
+			},
 			"bound_zones": {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"bound_regions": {
 				Type: schema.TypeSet,
@@ -80,7 +83,7 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"bound_instance_groups": {
 				Type: schema.TypeSet,
@@ -88,7 +91,7 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"bound_labels": {
 				Type: schema.TypeSet,
@@ -96,7 +99,7 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional: true,
-				Computed: true,
+				Computed: false,
 			},
 			"backend": {
 				Type:     schema.TypeString,
@@ -129,10 +132,6 @@ func gcpAuthResourceWrite(d *schema.ResourceData, meta interface{}) error {
 		data["type"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("project_id"); ok {
-		data["project_id"] = v.(string)
-	}
-
 	if v, ok := d.GetOk("ttl"); ok {
 		data["ttl"] = v.(string)
 	}
@@ -151,6 +150,10 @@ func gcpAuthResourceWrite(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("bound_service_accounts"); ok {
 		data["bound_service_accounts"] = v.(*schema.Set).List()
+	}
+
+	if v, ok := d.GetOk("bound_projects"); ok {
+		data["bound_projects"] = v.(*schema.Set).List()
 	}
 
 	if v, ok := d.GetOk("bound_zones"); ok {
@@ -205,6 +208,10 @@ func gcpAuthResourceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("bound_service_accounts"); ok {
 		data["bound_service_accounts"] = v.(*schema.Set).List()
+	}
+
+	if v, ok := d.GetOk("bound_projects"); ok {
+		data["bound_projects"] = v.(*schema.Set).List()
 	}
 
 	if v, ok := d.GetOk("bound_zones"); ok {
@@ -273,6 +280,12 @@ func gcpAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("bound_service_accounts",
 			schema.NewSet(
 				schema.HashString, accounts.([]interface{})))
+	}
+
+	if projects, ok := resp.Data["bound_projects"]; ok {
+		d.Set("bound_projects",
+			schema.NewSet(
+				schema.HashString, projects.([]interface{})))
 	}
 
 	if zones, ok := resp.Data["bound_zones"]; ok {

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -106,12 +106,12 @@ func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckF
 		}
 
 		attrs := map[string]string{
-			"type":                   "role_type",
-			"project_id":             "project_id",
+			"type":                   "type",
 			"ttl":                    "ttl",
 			"max_ttl":                "max_ttl",
 			"period":                 "period",
 			"policies":               "policies",
+			"bound_projects":         "bound_projects",
 			"bound_service_accounts": "bound_service_accounts",
 			"bound_regions":          "bound_regions",
 			"bound_zones":            "bound_zones",
@@ -196,19 +196,19 @@ func testGCPAuthBackendRoleConfig_basic(backend, name, serviceAccount, projectId
 	return fmt.Sprintf(`
 
 resource "vault_auth_backend" "gcp" {
-    path = "%s"
-    type = "gcp"
+	path = "%s"
+	type = "gcp"
 }
 
 resource "vault_gcp_auth_backend_role" "test" {
-    backend                = "${vault_auth_backend.gcp.path}"
-    role                   = "%s"
-    type                   = "iam"
-    bound_service_accounts = ["%s"]
-    project_id             = "%s"
-    ttl                    = 300
-    max_ttl                = 600
-    policies               = ["policy_a", "policy_b"]
+	backend                = "${vault_auth_backend.gcp.path}"
+	role                   = "%s"
+	type                   = "iam"
+	bound_service_accounts = ["%s"]
+	bound_projects         = ["%s"]
+	ttl                    = 300
+	max_ttl                = 600
+	policies               = ["policy_a", "policy_b"]
 }
 `, backend, name, serviceAccount, projectId)
 
@@ -219,21 +219,21 @@ func testGCPAuthBackendRoleConfig_gce(backend, name, projectId string) string {
 	return fmt.Sprintf(`
 
 resource "vault_auth_backend" "gcp" {
-    path = "%s"
-    type = "gcp"
+	path = "%s"
+	type = "gcp"
 }
 
 resource "vault_gcp_auth_backend_role" "test" {
-    backend                = "${vault_auth_backend.gcp.path}"
-    role                   = "%s"
-    type                   = "gce"
-    project_id             = "%s"
-    ttl                    = 300
-    max_ttl                = 600
-		policies               = ["policy_a", "policy_b"]
-		bound_regions					 = ["eu-west2"]
-		bound_zones  					 = ["europe-west2-c"]
-		bound_labels					 = ["foo"]
+	backend        = "${vault_auth_backend.gcp.path}"
+	role           = "%s"
+	type           = "gce"
+	bound_projects = ["%s"]
+	ttl            = 300
+	max_ttl        = 600
+	policies       = ["policy_a", "policy_b"]
+	bound_regions  = ["eu-west2"]
+	bound_zones    = ["europe-west2-c"]
+	bound_labels   = ["foo"]
 }
 `, backend, name, projectId)
 


### PR DESCRIPTION
Fixes #228, but I was also seeing the same behaviour with the `project_id` attribute. Upon looking into this it looks like this attribute has been renamed to [`bound_projects`](https://www.vaultproject.io/api/auth/gcp/index.html#bound_projects) (see this [PR](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/55) too).

This PR removes `project_id`, adds `bound_projects`, and I've gone ahead and cherry-picked @Phylu's commit from his open PR 🙏I also noticed that most of the optional attributes were set to `Computed: true`, and I believe this is to be wrong. I'll revert this change if asked, but what I was seeing when it was set to true was the removal of an optional attribute failing to trigger an update to the `gcp_auth_backend_role` resource.

These changes were tested locally with Vault version 1.0.1 & Terraform 0.11.0.