### PR TITLE
Fix token_auth_backend_role role_name updates not working

### DIFF
--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -29,6 +29,7 @@ func tokenAuthBackendRoleResource() *schema.Resource {
 			"role_name": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Name of the role.",
 			},
 			"allowed_policies": {
@@ -128,6 +129,7 @@ func tokenAuthBackendRoleCreate(d *schema.ResourceData, meta interface{}) error 
 	data["ttl"] = d.Get("ttl").(string)
 	data["max_ttl"] = d.Get("max_ttl").(string)
 	data["orphan"] = d.Get("orphan").(bool)
+	data["period"] = d.Get("period").(string)
 	data["renewable"] = d.Get("renewable").(bool)
 	data["path_suffix"] = d.Get("path_suffix").(string)
 


### PR DESCRIPTION
Fixes issue where the role_name on the `token_auth_backend_role` would not be updated when changed and would always be read as out of date.