### PR TITLE
Add vault_policy_document data source

### DIFF
--- a/vault/data_source_policy_document.go
+++ b/vault/data_source_policy_document.go
@@ -1,0 +1,123 @@
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type Policy struct {
+	Rules []PolicyRule
+}
+
+type PolicyRule struct {
+	Path         string
+	Description  string
+	Capabilities []string
+}
+
+var allowedCapabilities = []string{"create", "read", "update", "delete", "list", "sudo", "deny"}
+
+func policyDocumentDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: policyDocumentDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"rule": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "The policy rule",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"capabilities": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								ValidateFunc: capabilityValidation,
+								Type:         schema.TypeString,
+							},
+						},
+
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"hcl": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func policyDocumentDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	policyHCL := renderPolicy(policyConvert(d.Get("rule").([]interface{})))
+	err := d.Set("hcl", policyHCL)
+	if err != nil {
+		return fmt.Errorf("failed to store policy hcl: %s", err)
+	}
+	d.SetId(strconv.Itoa(hashcode.String(policyHCL)))
+	return nil
+}
+
+func capabilityValidation(configI interface{}, k string) ([]string, []error) {
+	for _, capability := range allowedCapabilities {
+		if configI.(string) == capability {
+			return nil, nil
+		}
+	}
+	return nil, []error{fmt.Errorf("invalid capability: \"%s\" in: %s", configI.(string), k)}
+}
+
+func policyRuleConvert(rawRule interface{}) (policyRule PolicyRule) {
+	policyRule.Path = rawRule.(map[string]interface{})["path"].(string)
+	policyRule.Description = rawRule.(map[string]interface{})["description"].(string)
+
+	rawCaps := rawRule.(map[string]interface{})["capabilities"].([]interface{})
+	policyRule.Capabilities = make([]string, len(rawCaps))
+	for i, v := range rawCaps {
+		policyRule.Capabilities[i] = v.(string)
+	}
+
+	return
+}
+
+func policyConvert(rawRules []interface{}) (policy Policy) {
+	policy.Rules = make([]PolicyRule, len(rawRules))
+	for i, rawRule := range rawRules {
+		policy.Rules[i] = policyRuleConvert(rawRule)
+	}
+	return
+}
+
+func renderList(items []string) string {
+	return fmt.Sprintf(`["%s"]`, strings.Join(items, `", "`))
+}
+
+func renderRule(rule PolicyRule) string {
+	renderedRule := fmt.Sprintf("path \"%s\" {\n  capabilities = %s\n}", rule.Path, renderList(rule.Capabilities))
+	if rule.Description != "" {
+		renderedRule = fmt.Sprintf("# %s\n%s", rule.Description, renderedRule)
+	}
+	return renderedRule
+}
+
+func renderPolicy(policy Policy) string {
+	rules := make([]string, len(policy.Rules))
+	for i, rule := range policy.Rules {
+		rules[i] = renderRule(rule)
+	}
+	return strings.Join(rules, "\n\n")
+}

--- a/vault/data_source_policy_document_test.go
+++ b/vault/data_source_policy_document_test.go
@@ -1,0 +1,52 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDataSourcePolicyDocument(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePolicyDocument_config,
+				Check:  testDataSourcePolicyDocument_check,
+			},
+		},
+	})
+
+}
+
+var testDataSourcePolicyDocument_config = `
+data "vault_policy_document" "test" {
+  rule {
+    path = "secret/"
+	capabilities = ["create", "read", "update", "delete", "list"]
+	description = "test policy rule"
+  }
+}
+`
+
+func testDataSourcePolicyDocument_check(s *terraform.State) error {
+	resourceState := s.Modules[0].Resources["data.vault_policy_document.test"]
+	if resourceState == nil {
+		return fmt.Errorf("resource not found in state %v", s.Modules[0].Resources)
+	}
+
+	iState := resourceState.Primary
+	if iState == nil {
+		return fmt.Errorf("resource has no primary instance")
+	}
+
+	wantHCL := "# test policy rule\npath \"secret/\" {\n  capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"]\n}"
+	if got, want := iState.Attributes["hcl"], wantHCL; got != want {
+		return fmt.Errorf("hcl contains %s; want %s", got, want)
+	}
+
+	return nil
+}

--- a/vault/data_source_policy_document_test.go
+++ b/vault/data_source_policy_document_test.go
@@ -25,10 +25,84 @@ func TestDataSourcePolicyDocument(t *testing.T) {
 var testDataSourcePolicyDocument_config = `
 data "vault_policy_document" "test" {
   rule {
-    path = "secret/"
-	capabilities = ["create", "read", "update", "delete", "list"]
-	description = "test policy rule"
+    path                = "secret/test1/*"
+    capabilities        = ["create", "read", "update", "delete", "list"]
+    description         = "test rule 1"
+    required_parameters = ["test_param1"]
+
+    allowed_parameter {
+      key   = "eggs"
+      value = ["foo", "bar"]
+    }
+
+    allowed_parameter {
+      key   = "spam"
+      value = ["eggs"]
+    }
+
+    denied_parameter {
+      key   = "*"
+      value = ["spam"]
+    }
+
+    max_wrapping_ttl = "1h"
   }
+
+  rule {
+    path                = "secret/test2/*"
+    capabilities        = ["read", "list"]
+    description         = "test rule 2"
+    required_parameters = ["test_param2"]
+
+    allowed_parameter {
+      key   = "all"
+      value = []
+    }
+
+    denied_parameter {
+      key   = "*"
+      value = []
+    }
+
+    min_wrapping_ttl = "1s"
+  }
+
+  rule {
+    path                = "secret/test3/"
+    capabilities        = ["read", "list"]
+  }
+}
+`
+
+var testResultPolicyHCLDocument = `# test rule 1
+path "secret/test1/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+  required_parameters = ["test_param1"]
+  allowed_parameters = {
+    "eggs" = ["foo", "bar"]
+    "spam" = ["eggs"]
+  }
+  denied_parameters = {
+    "*" = ["spam"]
+  }
+  max_wrapping_ttl = "1h"
+}
+
+# test rule 2
+path "secret/test2/*" {
+  capabilities = ["read", "list"]
+  required_parameters = ["test_param2"]
+  allowed_parameters = {
+    "all" = []
+  }
+  denied_parameters = {
+    "*" = []
+  }
+  min_wrapping_ttl = "1s"
+}
+
+path "secret/test3/" {
+  capabilities = ["read", "list"]
 }
 `
 
@@ -43,8 +117,7 @@ func testDataSourcePolicyDocument_check(s *terraform.State) error {
 		return fmt.Errorf("resource has no primary instance")
 	}
 
-	wantHCL := "# test policy rule\npath \"secret/\" {\n  capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"]\n}"
-	if got, want := iState.Attributes["hcl"], wantHCL; got != want {
+	if got, want := iState.Attributes["hcl"], testResultPolicyHCLDocument; got != want {
 		return fmt.Errorf("hcl contains %s; want %s", got, want)
 	}
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -89,6 +89,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_kubernetes_auth_backend_role":   kubernetesAuthBackendRoleDataSource(),
 			"vault_aws_access_credentials":         awsAccessCredentialsDataSource(),
 			"vault_generic_secret":                 genericSecretDataSource(),
+			"vault_policy_document":                policyDocumentDataSource(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/policy_document.md
+++ b/website/docs/d/policy_document.md
@@ -1,0 +1,44 @@
+---
+layout: "vault"
+page_title: "Vault: vault_policy_document data source"
+sidebar_current: "docs-vault-datasource-policy-document"
+description: |-
+  Generates an Vault policy document in HCL format.
+---
+
+# vault\_policy\_document
+
+This is a data source which can be used to construct a HCL representation of an Vault policy document, for use with resources which expect policy documents, such as the `vault_policy` resource.
+
+## Example Usage
+
+```hcl
+data "vault_policy_document" "example" {
+  rule {
+    path         = "secret/*"
+    capabilities = ["create", "read", "update", "delete", "list"]
+    description  = "allow all on secrets"
+  }
+}
+
+resource "vault_policy" "example" {
+  name   = "example_policy"
+  policy = "${data.vault_policy_document.hcl}"
+}
+```
+
+## Argument Reference
+
+Each document configuration may have one or more `rule` blocks, which each accept the following arguments:
+
+* `path` - (Required) A path in Vault that this rule applies to.
+
+* `capabilities` - (Required) A list of capabilities that this rule apply to `path`. For example, ["read", "write"].
+
+* `description` - (Optional) Description of the rule. Will be added as a commend to rendered rule.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `hcl` - The above arguments serialized as a standard Vault HCL policy document.

--- a/website/docs/d/policy_document.md
+++ b/website/docs/d/policy_document.md
@@ -37,6 +37,26 @@ Each document configuration may have one or more `rule` blocks, which each accep
 
 * `description` - (Optional) Description of the rule. Will be added as a commend to rendered rule.
 
+* `required_parameters` - (Optional) A list of parameters that must be specified.
+
+* `allowed_parameter` - (Optional) Whitelists a list of keys and values that are permitted on the given path. See [Parameters](#Parameters) below.
+
+* `denied_parameter` - (Optional) Blacklists a list of parameter and values. Any values specified here take precedence over `allowed_parameter`. See [Parameters](#Parameters) below.
+
+* `min_wrapping_ttl` - (Optional) The minimum allowed TTL that clients can specify for a wrapped response.
+
+* `max_wrapping_ttl` - (Optional) The maximum allowed TTL that clients can specify for a wrapped response.
+
+### Parameters
+
+Each of `*_parameter` attributes can optionally further restrict paths based on the keys and data at those keys when evaluating the permissions for a path.
+
+Support the following arguments:
+
+* `key` - (Required) name of permitted or denied parameter.
+
+* `value` - (Required) list of values what are permitted or denied by policy rule.
+
 ## Attributes Reference
 
 In addition to the above arguments, the following attributes are exported:


### PR DESCRIPTION
Add following data source to manage Vault policies, fix for #64

* `vault_policy_document`: render HCL with Vault policy

To test this PR:

```hcl
provider "vault" {}

 data "vault_policy_document" "example" {
  rule {
    path         = "secret/*"
    capabilities = ["create", "read", "update", "delete", "list"]
    description  = "allow all on secrets"
  }
}

resource "vault_policy" "example" {
  name   = "example_policy"
  policy = "${data.vault_policy_document.hcl}"
} 
```
