### PR TITLE
Fix for namespaces (#262)

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -202,11 +202,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, errors.New("no vault token found")
 	}
 
-	namespace := d.Get("namespace").(string)
-	if namespace != "" {
-		client.SetNamespace(namespace)
-	}
-
 	// In order to enforce our relatively-short lease TTL, we derive a
 	// temporary child token that inherits all of the policies of the
 	// token we were given but expires after max_lease_ttl_seconds.
@@ -236,6 +231,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	policies := childTokenLease.Auth.Policies
 
 	log.Printf("[INFO] Using Vault token with the following policies: %s", strings.Join(policies, ", "))
+
+	namespace := d.Get("namespace").(string)
+	if namespace != "" {
+		client.SetNamespace(namespace)
+	}
 
 	client.SetToken(childToken)
 


### PR DESCRIPTION
Implementation of #262 was buggy.
Vault token used by Terraform should be created without namespace - otherwise the token will have wrong set of policies assigned