### PR TITLE
Set namespace before attempting child token creation

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -220,6 +220,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if token == "" {
 		return nil, errors.New("no vault token found")
 	}
+	
+	namespace := d.Get("namespace").(string)
+	if namespace != "" {
+		client.SetNamespace(namespace)
+	}
 
 	// In order to enforce our relatively-short lease TTL, we derive a
 	// temporary child token that inherits all of the policies of the
@@ -250,11 +255,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	policies := childTokenLease.Auth.Policies
 
 	log.Printf("[INFO] Using Vault token with the following policies: %s", strings.Join(policies, ", "))
-
-	namespace := d.Get("namespace").(string)
-	if namespace != "" {
-		client.SetNamespace(namespace)
-	}
 
 	client.SetToken(childToken)
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -220,7 +220,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if token == "" {
 		return nil, errors.New("no vault token found")
 	}
-	
+
 	namespace := d.Get("namespace").(string)
 	if namespace != "" {
 		client.SetNamespace(namespace)


### PR DESCRIPTION
Problem with https://github.com/terraform-providers/terraform-provider-vault/pull/288 is that as it currently stands, if the terraform user has an admin token for a namespace, the child token creation will fail, as it attempts to create the child token before setting the namespace. So, the child token creation is attempted in the root namespace, not in the namespace where the user has the admin token.

This moves the namespace setter to be above the first actual Vault operations.

If we're having trouble with bugs, we should really set the client namespace to the be the namespace of the customer's token, but you can't do a token lookup in the root namespace if you only have a child namespace admin token.

An option may be to add additional configuration options ie add another "parent-token-namespace" config value so that the child can be created in the parent's namespace but still allow modification of resources in a target namespace.

Another option is to do away with the child token & instead add validation + a rule saying that the admin token cannot have a TTL > X hours

Curious for your opinion @sergeytrasko on all of the above
