### PR TITLE
jwt_auth_backend_role: add groups_claim_delimiter_pattern support

### DIFF
--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -96,6 +96,11 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "The claim to use to uniquely identify the set of groups to which the user belongs; this will be used as the names for the Identity group aliases created due to a successful login. The claim value must be a list of strings.",
 			},
+			"groups_claim_delimiter_pattern": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A pattern of delimiters used to allow the groups_claim to live outside of the top-level JWT structure. For instance, a groups_claim of meta/user.name/groups with this field set to // will expect nested structures named meta, user.name, and groups. If this field was set to /./ the groups information would expect to be via nested structures of meta, user, name, and groups.",
+			},
 			"backend": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -218,6 +223,7 @@ func jwtAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("groups_claim", resp.Data["groups_claim"].(string))
+	d.Set("groups_claim_delimiter_pattern", resp.Data["groups_claim_delimiter_pattern"].(string))
 
 	d.Set("backend", backend)
 	d.Set("role_name", role)
@@ -347,6 +353,10 @@ func jwtAuthBackendRoleDataToWrite(d *schema.ResourceData) map[string]interface{
 
 	if v, ok := d.GetOkExists("groups_claim"); ok {
 		data["groups_claim"] = v.(string)
+	}
+
+	if v, ok := d.GetOkExists("groups_claim_delimiter_pattern"); ok {
+		data["groups_claim_delimiter_pattern"] = v.(string)
 	}
 
 	return data

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -237,6 +237,8 @@ func TestAccJWTAuthBackendRole_full(t *testing.T) {
 						"user_claim", "https://vault/user"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"groups_claim", "https://vault/groups"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"groups_claim_delimiter_pattern", "."),
 				),
 			},
 		},
@@ -291,6 +293,8 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 						"user_claim", "https://vault/user"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"groups_claim", "https://vault/groups"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"groups_claim_delimiter_pattern", "."),
 				),
 			},
 			{
@@ -404,6 +408,7 @@ resource "vault_jwt_auth_backend_role" "role" {
   bound_audiences = ["https://myco.test"]
   user_claim = "https://vault/user"
   groups_claim = "https://vault/groups"
+  groups_claim_delimiter_pattern = "."
   policies = ["default", "dev", "prod"]
   ttl = 3600
   num_uses = 12
@@ -427,6 +432,7 @@ resource "vault_jwt_auth_backend_role" "role" {
   bound_audiences = ["https://myco.update",]
   user_claim = "https://vault/updateuser"
   groups_claim = "https://vault/updategroups"
+  groups_claim_delimiter_pattern = "."
   policies = ["default", "dev"]
   ttl = 7200
   num_uses = 24

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -238,7 +238,7 @@ func TestAccJWTAuthBackendRole_full(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"groups_claim", "https://vault/groups"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
-						"groups_claim_delimiter_pattern", "."),
+						"groups_claim_delimiter_pattern", "/"),
 				),
 			},
 		},
@@ -294,7 +294,7 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"groups_claim", "https://vault/groups"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
-						"groups_claim_delimiter_pattern", "."),
+						"groups_claim_delimiter_pattern", "/"),
 				),
 			},
 			{
@@ -408,7 +408,7 @@ resource "vault_jwt_auth_backend_role" "role" {
   bound_audiences = ["https://myco.test"]
   user_claim = "https://vault/user"
   groups_claim = "https://vault/groups"
-  groups_claim_delimiter_pattern = "."
+  groups_claim_delimiter_pattern = "/"
   policies = ["default", "dev", "prod"]
   ttl = 3600
   num_uses = 12
@@ -432,7 +432,7 @@ resource "vault_jwt_auth_backend_role" "role" {
   bound_audiences = ["https://myco.update",]
   user_claim = "https://vault/updateuser"
   groups_claim = "https://vault/updategroups"
-  groups_claim_delimiter_pattern = "."
+  groups_claim_delimiter_pattern = "/"
   policies = ["default", "dev"]
   ttl = 7200
   num_uses = 24

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/Gopkg.lock
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/Gopkg.lock
@@ -15,12 +15,12 @@
   version = "1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:6bf6d532e503d9526d46e69aff04d11632c8c1e28b847dbd226babc1689aa723"
+  digest = "1:c47f4964978e211c6e566596ec6246c329912ea92e9bb99c00798bb4564c5b09"
   name = "github.com/armon/go-radix"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7fddfc383310abc091d79a27f116d30cf0424032"
+  revision = "1a2de0c21c94309923825da3df33a4381872c795"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:f6e5e1bc64c2908167e6aa9a1fe0c084d515132a1c63ad5b6c84036aa06dc0c1"
@@ -39,7 +39,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
+  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -49,8 +49,8 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -62,106 +62,108 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d1971637b21871ec2033a44ca87c99c5608a7340cb34ec75fab8d2ab503276c9"
+  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
 
 [[projects]]
   branch = "master"
-  digest = "1:77cb3be9b21ba7f1a4701e870c84ea8b66e7d74c7c8951c58155fdadae9414ec"
+  digest = "1:f47d6109c2034cb16bd62b220e18afd5aa9d5a1630fe5d937ad96a4fb7cbb277"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
+  revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
 
 [[projects]]
   branch = "master"
-  digest = "1:e8d99882caa8c74d68f340ddb9bba3f7e433117ce57c3e52501edfa7e195d2c7"
+  digest = "1:0876aeb6edb07e20b6b0ce1d346655cb63dbe0a26ccfb47b68a9b7697709777b"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ff2cf002a8dd750586d91dddd4470c341f981fe1"
+  revision = "4783caec6f2e5cdd47fab8b2bb47ce2ce5c546b7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2394f5a25132b3868eff44599cc28d44bdd0330806e34c495d754dd052df612b"
+  digest = "1:2be5a35f0c5b35162c41bb24971e5dcf6ce825403296ee435429cdcc4e1e847e"
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7f3cd4390caab3250a57f30efdb2a65dd7649ecf"
+  revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:46fb6a9f1b9667f32ac93e08b1da118b2c666991424ea12e848b05d4fe5155ef"
+  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:20f78c1cf1b6fe6c55ba1407350d6fc7dc77d1591f8106ba693c28014a1a1b37"
+  digest = "1:6c04f2be110107d22b82c18826df6f44004983147636e767e3a8bcd0ed228d16"
   name = "github.com/hashicorp/go-plugin"
-  packages = ["."]
+  packages = [
+    ".",
+    "internal/plugin",
+  ]
   pruneopts = "UT"
-  revision = "a4620f9913d19f03a6bf19b2f304daaaf83ea130"
+  revision = "b838ffee39ce7c7c38226c1413aa4ecae61b4d27"
 
 [[projects]]
-  branch = "master"
-  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
+  digest = "1:d260503602063d71718eb21f85c02133ad5eac894c2a6f0e0546b7dc017dc97e"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+  revision = "73489d0a1476f0c9e6fb03f9c39241523a496dfd"
+  version = "v0.5.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:45aad874d3c7d5e8610427c81870fb54970b981692930ec2a319ce4cb89d7a00"
+  digest = "1:a54ada9beb59fdc35b69322979e870ff0b780e03f4dc309c4c8674b94927df75"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+  revision = "63503fb4e1eca22f9ae0f90b49c5d5538a0e87eb"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:14f2005c31ddf99c4a0f36fc440f8d1ac43224194c7c4a904b3c8f4ba5654d0b"
+  digest = "1:3c4c27026ab6a3218dbde897568f651c81062e2ee6e617e57ae46ca95bb1db6b"
   name = "github.com/hashicorp/go-sockaddr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
+  revision = "3aed17b5ee41761cc2b04f2a94c7107d428967e5"
 
 [[projects]]
-  branch = "master"
-  digest = "1:354978aad16c56c27f57e5b152224806d87902e4935da3b03e18263d82ae77aa"
+  digest = "1:f14364057165381ea296e49f8870a9ffce2b8a95e34d6ae06c759106aaef428c"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "27454136f0364f2d44b1276c552d69105cf8c498"
+  revision = "4f571afc59f3043a65f8fe6bf46d887b10a01d43"
+  version = "v1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:32c0e96a63bd093eccf37db757fb314be5996f34de93969321c2cbef893a7bd6"
+  digest = "1:950caca7dfcf796419232ba996c9c3539d09f26af27ba848c4508e604c13efbb"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
   pruneopts = "UT"
-  revision = "270f2f71b1ee587f3b609f00f422b76a6b28f348"
+  revision = "d40cf49b3a77bba84a7afdbd7f1dc295d114efb1"
+  version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cf296baa185baae04a9a7004efee8511d08e2f5f51d4cbe5375da89722d681db"
+  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "UT"
-  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:12247a2e99a060cc692f6680e5272c8adf0b8f572e6bce0d7095e624c958a240"
+  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -175,11 +177,12 @@
     "json/token",
   ]
   pruneopts = "UT"
-  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:d00de8725219a569ffbb5dd1042e4ced1f3b5ccee2b07218371f71026cc7609a"
+  digest = "1:961541c49385b69f1d3ee6087df21d7d9595f98a8f29170e810267180ff6a9fb"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -187,9 +190,11 @@
     "helper/cidrutil",
     "helper/compressutil",
     "helper/consts",
+    "helper/cryptoutil",
     "helper/errutil",
     "helper/hclutil",
     "helper/jsonutil",
+    "helper/license",
     "helper/locksutil",
     "helper/logging",
     "helper/mlock",
@@ -209,39 +214,47 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "8655d167084028d627f687ddc25d0c71307eb5be"
+  revision = "5d444354923ab54c8207f8c8820cfe78c1572656"
 
 [[projects]]
   branch = "master"
-  digest = "1:89658943622e6bc5e76b4da027ee9583fa0b321db0c797bd554edab96c1ca2b1"
+  digest = "1:a4826c308e84f5f161b90b54a814f0be7d112b80164b9b884698a6903ea47ab3"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
+  revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c7354463195544b1ab3c1f1fadb41430947f5d28dfbf2cdbd38268c5717a5a03"
+  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = "UT"
-  revision = "58046073cbffe2f25d425fe1331102f55cf719de"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cae1afe858922bd10e9573b87130f730a6e4183a00eba79920d6656629468bfa"
+  digest = "1:42eb1f52b84a06820cedc9baec2e710bfbda3ee6dac6cdb97f8b9a5066134ec6"
   name = "github.com/mitchellh/go-testing-interface"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
+  revision = "6d0b8010fcc857872e42fc6c931227569016843c"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:302de3c669b04a566d4e99760d6fb35a22177fc14c7a9284e8b3cf6e9fe3f28a"
+  name = "github.com/mitchellh/pointerstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f2329fcfa9e280bdb5a3f2544aec815a508ad72f"
 
 [[projects]]
   digest = "1:9ec6cf1df5ad1d55cf41a43b6b1e7e118a91bade4f68ff4303379343e40c0e25"
@@ -250,6 +263,25 @@
   pruneopts = "UT"
   revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
+  name = "github.com/patrickmn/go-cache"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
+  version = "v2.1.0"
+
+[[projects]]
+  digest = "1:c7a5e79396b6eb570159df7a1d487ce5775bf43b7907976fbef6de544ea160ad"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = "UT"
+  revision = "473cd7ce01a1113208073166464b98819526150e"
+  version = "v2.0.8"
 
 [[projects]]
   branch = "master"
@@ -263,28 +295,29 @@
   revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
 
 [[projects]]
-  digest = "1:0e792eea6c96ec55ff302ef33886acbaa5006e900fefe82689e88d96439dcd84"
+  digest = "1:6baa565fe16f8657cf93469b2b8a6c61a277827734400d27e44d589547297279"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
   pruneopts = "UT"
-  revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
-  version = "v0.1"
+  revision = "51a8f68e6c24dc43f1e371749c89a267de4ebc53"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:b8fa1ff0fc20983395978b3f771bb10438accbfe19326b02e236c1d4bf1c91b2"
+  digest = "1:5bce6a1c0d1492cef01d74084ddbac09c4bbc4cbc1db3fdd0c138ed9bc945bf8"
   name = "golang.org/x/crypto"
   packages = [
+    "blake2b",
     "ed25519",
     "ed25519/internal/edwards25519",
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
+  revision = "74369b46fc6756741c016591724fd1cb8e26845f"
 
 [[projects]]
   branch = "master"
-  digest = "1:3c4175c2711d67096567fc2d84a83464d6ff58119af3efc89983339d64144cb0"
+  digest = "1:9d2f08c64693fbe7177b5980f80c35672c80f12be79bb3bc86948b934d70e4ee"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -297,26 +330,29 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "aaf60122140d3fcf75376d319f0554393160eb50"
+  revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
 
 [[projects]]
   branch = "master"
-  digest = "1:af19f6e6c369bf51ef226e989034cd88a45083173c02ac4d7ab74c9a90d356b7"
+  digest = "1:c664d4451770ebc9ab63d54bccb9e4f2c6106cde7e566ea02889930b836c7d4c"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
+  revision = "3e8b2be1363542a95c52ea0796d4a40dacfb5b95"
 
 [[projects]]
   branch = "master"
-  digest = "1:05662433b3a13c921587a6e622b5722072edff83211efd1cd79eeaeedfd83f07"
+  digest = "1:83552c87ddffa6a9095b7b4a005fcb8d35ff05108246b247a8bbddc78a91db64"
   name = "golang.org/x/sys"
-  packages = ["unix"]
+  packages = [
+    "cpu",
+    "unix",
+  ]
   pruneopts = "UT"
-  revision = "1c9583448a9c3aa0f9a6a5241bf73c0bd8aafded"
+  revision = "983097b1a8a340cd1cc7df17d735154d89e10b1a"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -343,14 +379,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
-  digest = "1:328b5e4f197d928c444a51a75385f4b978915c0e75521f0ad6a3db976c97a7d3"
+  digest = "1:6f3bd49ddf2e104e52062774d797714371fac1b8bddfd8e124ce78e6b2264a10"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -362,8 +398,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
-  version = "v1.1.0"
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"
@@ -371,19 +407,21 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "d0a8f471bba2dbb160885b0000d814ee5d559bad"
+  revision = "4b09977fb92221987e99d190c8f88f2c92727a29"
 
 [[projects]]
-  digest = "1:047efbc3c9a51f3002b0002f92543857d372654a676fb6b01931982cd80467dd"
+  digest = "1:a887a56d0ff92cf05b4bb6004b46fc6e64d3fb6aca4eaeb1466bdce183ba5004"
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
     "balancer/base",
     "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
     "codes",
     "connectivity",
     "credentials",
+    "credentials/internal",
     "encoding",
     "encoding/proto",
     "grpclog",
@@ -391,9 +429,12 @@
     "health/grpc_health_v1",
     "internal",
     "internal/backoff",
+    "internal/binarylog",
     "internal/channelz",
     "internal/envconfig",
     "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
     "internal/transport",
     "keepalive",
     "metadata",
@@ -407,11 +448,11 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
-  version = "v1.14.0"
+  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
+  version = "v1.18.0"
 
 [[projects]]
-  digest = "1:b57bb9a6a2a03558d63166f1afc3c0c4f91ad137f63bf2bee995e9baeb976a9c"
+  digest = "1:a4cde1eec9a17eb2399a50c6e1a9fe3fde039994de058f9dbf6592d157bfe97b"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -420,8 +461,8 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "8254d6c783765f38c8675fae4427a1fe73fbd09d"
-  version = "v2.1.8"
+  revision = "e94fb177d3668d35ab39c61cbb2f311550557e83"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -433,6 +474,8 @@
     "github.com/hashicorp/go-cleanhttp",
     "github.com/hashicorp/go-hclog",
     "github.com/hashicorp/go-sockaddr",
+    "github.com/hashicorp/go-uuid",
+    "github.com/hashicorp/vault/api",
     "github.com/hashicorp/vault/helper/certutil",
     "github.com/hashicorp/vault/helper/cidrutil",
     "github.com/hashicorp/vault/helper/logging",
@@ -443,6 +486,8 @@
     "github.com/hashicorp/vault/logical",
     "github.com/hashicorp/vault/logical/framework",
     "github.com/hashicorp/vault/logical/plugin",
+    "github.com/mitchellh/pointerstructure",
+    "github.com/patrickmn/go-cache",
     "golang.org/x/oauth2",
     "gopkg.in/square/go-jose.v2",
     "gopkg.in/square/go-jose.v2/jwt",

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/Gopkg.lock
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/Gopkg.lock
@@ -15,12 +15,12 @@
   version = "1.1"
 
 [[projects]]
-  digest = "1:c47f4964978e211c6e566596ec6246c329912ea92e9bb99c00798bb4564c5b09"
+  branch = "master"
+  digest = "1:6bf6d532e503d9526d46e69aff04d11632c8c1e28b847dbd226babc1689aa723"
   name = "github.com/armon/go-radix"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1a2de0c21c94309923825da3df33a4381872c795"
-  version = "v1.0.0"
+  revision = "7fddfc383310abc091d79a27f116d30cf0424032"
 
 [[projects]]
   digest = "1:f6e5e1bc64c2908167e6aa9a1fe0c084d515132a1c63ad5b6c84036aa06dc0c1"
@@ -39,7 +39,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
+  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -49,8 +49,8 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -62,108 +62,106 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
+  digest = "1:d1971637b21871ec2033a44ca87c99c5608a7340cb34ec75fab8d2ab503276c9"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
 
 [[projects]]
   branch = "master"
-  digest = "1:f47d6109c2034cb16bd62b220e18afd5aa9d5a1630fe5d937ad96a4fb7cbb277"
+  digest = "1:77cb3be9b21ba7f1a4701e870c84ea8b66e7d74c7c8951c58155fdadae9414ec"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
+  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
-  digest = "1:0876aeb6edb07e20b6b0ce1d346655cb63dbe0a26ccfb47b68a9b7697709777b"
+  digest = "1:e8d99882caa8c74d68f340ddb9bba3f7e433117ce57c3e52501edfa7e195d2c7"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4783caec6f2e5cdd47fab8b2bb47ce2ce5c546b7"
+  revision = "ff2cf002a8dd750586d91dddd4470c341f981fe1"
 
 [[projects]]
-  digest = "1:2be5a35f0c5b35162c41bb24971e5dcf6ce825403296ee435429cdcc4e1e847e"
+  branch = "master"
+  digest = "1:2394f5a25132b3868eff44599cc28d44bdd0330806e34c495d754dd052df612b"
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
   pruneopts = "UT"
-  revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
-  version = "v1.0.0"
+  revision = "7f3cd4390caab3250a57f30efdb2a65dd7649ecf"
 
 [[projects]]
-  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
+  branch = "master"
+  digest = "1:46fb6a9f1b9667f32ac93e08b1da118b2c666991424ea12e848b05d4fe5155ef"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
-  version = "v1.0.0"
+  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
 
 [[projects]]
   branch = "master"
-  digest = "1:6c04f2be110107d22b82c18826df6f44004983147636e767e3a8bcd0ed228d16"
+  digest = "1:20f78c1cf1b6fe6c55ba1407350d6fc7dc77d1591f8106ba693c28014a1a1b37"
   name = "github.com/hashicorp/go-plugin"
-  packages = [
-    ".",
-    "internal/plugin",
-  ]
+  packages = ["."]
   pruneopts = "UT"
-  revision = "b838ffee39ce7c7c38226c1413aa4ecae61b4d27"
+  revision = "a4620f9913d19f03a6bf19b2f304daaaf83ea130"
 
 [[projects]]
-  digest = "1:d260503602063d71718eb21f85c02133ad5eac894c2a6f0e0546b7dc017dc97e"
+  branch = "master"
+  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "73489d0a1476f0c9e6fb03f9c39241523a496dfd"
-  version = "v0.5.2"
-
-[[projects]]
-  digest = "1:a54ada9beb59fdc35b69322979e870ff0b780e03f4dc309c4c8674b94927df75"
-  name = "github.com/hashicorp/go-rootcerts"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "63503fb4e1eca22f9ae0f90b49c5d5538a0e87eb"
-  version = "v1.0.0"
+  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
 
 [[projects]]
   branch = "master"
-  digest = "1:3c4c27026ab6a3218dbde897568f651c81062e2ee6e617e57ae46ca95bb1db6b"
+  digest = "1:45aad874d3c7d5e8610427c81870fb54970b981692930ec2a319ce4cb89d7a00"
+  name = "github.com/hashicorp/go-rootcerts"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+
+[[projects]]
+  branch = "master"
+  digest = "1:14f2005c31ddf99c4a0f36fc440f8d1ac43224194c7c4a904b3c8f4ba5654d0b"
   name = "github.com/hashicorp/go-sockaddr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3aed17b5ee41761cc2b04f2a94c7107d428967e5"
+  revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
 
 [[projects]]
-  digest = "1:f14364057165381ea296e49f8870a9ffce2b8a95e34d6ae06c759106aaef428c"
+  branch = "master"
+  digest = "1:354978aad16c56c27f57e5b152224806d87902e4935da3b03e18263d82ae77aa"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4f571afc59f3043a65f8fe6bf46d887b10a01d43"
-  version = "v1.0.1"
+  revision = "27454136f0364f2d44b1276c552d69105cf8c498"
 
 [[projects]]
-  digest = "1:950caca7dfcf796419232ba996c9c3539d09f26af27ba848c4508e604c13efbb"
+  branch = "master"
+  digest = "1:32c0e96a63bd093eccf37db757fb314be5996f34de93969321c2cbef893a7bd6"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d40cf49b3a77bba84a7afdbd7f1dc295d114efb1"
-  version = "v1.1.0"
+  revision = "270f2f71b1ee587f3b609f00f422b76a6b28f348"
 
 [[projects]]
-  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
+  branch = "master"
+  digest = "1:cf296baa185baae04a9a7004efee8511d08e2f5f51d4cbe5375da89722d681db"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "UT"
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
-  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
+  branch = "master"
+  digest = "1:12247a2e99a060cc692f6680e5272c8adf0b8f572e6bce0d7095e624c958a240"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -177,12 +175,11 @@
     "json/token",
   ]
   pruneopts = "UT"
-  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
-  version = "v1.0.0"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   branch = "master"
-  digest = "1:961541c49385b69f1d3ee6087df21d7d9595f98a8f29170e810267180ff6a9fb"
+  digest = "1:d00de8725219a569ffbb5dd1042e4ced1f3b5ccee2b07218371f71026cc7609a"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -190,11 +187,9 @@
     "helper/cidrutil",
     "helper/compressutil",
     "helper/consts",
-    "helper/cryptoutil",
     "helper/errutil",
     "helper/hclutil",
     "helper/jsonutil",
-    "helper/license",
     "helper/locksutil",
     "helper/logging",
     "helper/mlock",
@@ -214,47 +209,39 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "5d444354923ab54c8207f8c8820cfe78c1572656"
+  revision = "8655d167084028d627f687ddc25d0c71307eb5be"
 
 [[projects]]
   branch = "master"
-  digest = "1:a4826c308e84f5f161b90b54a814f0be7d112b80164b9b884698a6903ea47ab3"
+  digest = "1:89658943622e6bc5e76b4da027ee9583fa0b321db0c797bd554edab96c1ca2b1"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
-
-[[projects]]
-  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
-  name = "github.com/mitchellh/go-homedir"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
-  version = "v1.1.0"
-
-[[projects]]
-  digest = "1:42eb1f52b84a06820cedc9baec2e710bfbda3ee6dac6cdb97f8b9a5066134ec6"
-  name = "github.com/mitchellh/go-testing-interface"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "6d0b8010fcc857872e42fc6c931227569016843c"
-  version = "v1.0.0"
-
-[[projects]]
-  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
-  name = "github.com/mitchellh/mapstructure"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
-  version = "v1.1.2"
+  revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
   branch = "master"
-  digest = "1:302de3c669b04a566d4e99760d6fb35a22177fc14c7a9284e8b3cf6e9fe3f28a"
-  name = "github.com/mitchellh/pointerstructure"
+  digest = "1:c7354463195544b1ab3c1f1fadb41430947f5d28dfbf2cdbd38268c5717a5a03"
+  name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f2329fcfa9e280bdb5a3f2544aec815a508ad72f"
+  revision = "58046073cbffe2f25d425fe1331102f55cf719de"
+
+[[projects]]
+  branch = "master"
+  digest = "1:cae1afe858922bd10e9573b87130f730a6e4183a00eba79920d6656629468bfa"
+  name = "github.com/mitchellh/go-testing-interface"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
   digest = "1:9ec6cf1df5ad1d55cf41a43b6b1e7e118a91bade4f68ff4303379343e40c0e25"
@@ -263,25 +250,6 @@
   pruneopts = "UT"
   revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
   version = "v1.0.0"
-
-[[projects]]
-  digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
-  name = "github.com/patrickmn/go-cache"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
-  version = "v2.1.0"
-
-[[projects]]
-  digest = "1:c7a5e79396b6eb570159df7a1d487ce5775bf43b7907976fbef6de544ea160ad"
-  name = "github.com/pierrec/lz4"
-  packages = [
-    ".",
-    "internal/xxh32",
-  ]
-  pruneopts = "UT"
-  revision = "473cd7ce01a1113208073166464b98819526150e"
-  version = "v2.0.8"
 
 [[projects]]
   branch = "master"
@@ -295,29 +263,28 @@
   revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
 
 [[projects]]
-  digest = "1:6baa565fe16f8657cf93469b2b8a6c61a277827734400d27e44d589547297279"
+  digest = "1:0e792eea6c96ec55ff302ef33886acbaa5006e900fefe82689e88d96439dcd84"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
   pruneopts = "UT"
-  revision = "51a8f68e6c24dc43f1e371749c89a267de4ebc53"
-  version = "v1.0.0"
+  revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
+  version = "v0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:5bce6a1c0d1492cef01d74084ddbac09c4bbc4cbc1db3fdd0c138ed9bc945bf8"
+  digest = "1:b8fa1ff0fc20983395978b3f771bb10438accbfe19326b02e236c1d4bf1c91b2"
   name = "golang.org/x/crypto"
   packages = [
-    "blake2b",
     "ed25519",
     "ed25519/internal/edwards25519",
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "74369b46fc6756741c016591724fd1cb8e26845f"
+  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
 
 [[projects]]
   branch = "master"
-  digest = "1:9d2f08c64693fbe7177b5980f80c35672c80f12be79bb3bc86948b934d70e4ee"
+  digest = "1:3c4175c2711d67096567fc2d84a83464d6ff58119af3efc89983339d64144cb0"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -330,29 +297,26 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
+  revision = "aaf60122140d3fcf75376d319f0554393160eb50"
 
 [[projects]]
   branch = "master"
-  digest = "1:c664d4451770ebc9ab63d54bccb9e4f2c6106cde7e566ea02889930b836c7d4c"
+  digest = "1:af19f6e6c369bf51ef226e989034cd88a45083173c02ac4d7ab74c9a90d356b7"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "3e8b2be1363542a95c52ea0796d4a40dacfb5b95"
+  revision = "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
 
 [[projects]]
   branch = "master"
-  digest = "1:83552c87ddffa6a9095b7b4a005fcb8d35ff05108246b247a8bbddc78a91db64"
+  digest = "1:05662433b3a13c921587a6e622b5722072edff83211efd1cd79eeaeedfd83f07"
   name = "golang.org/x/sys"
-  packages = [
-    "cpu",
-    "unix",
-  ]
+  packages = ["unix"]
   pruneopts = "UT"
-  revision = "983097b1a8a340cd1cc7df17d735154d89e10b1a"
+  revision = "1c9583448a9c3aa0f9a6a5241bf73c0bd8aafded"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -379,14 +343,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
-  digest = "1:6f3bd49ddf2e104e52062774d797714371fac1b8bddfd8e124ce78e6b2264a10"
+  digest = "1:328b5e4f197d928c444a51a75385f4b978915c0e75521f0ad6a3db976c97a7d3"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -398,8 +362,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
-  version = "v1.4.0"
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -407,21 +371,19 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "4b09977fb92221987e99d190c8f88f2c92727a29"
+  revision = "d0a8f471bba2dbb160885b0000d814ee5d559bad"
 
 [[projects]]
-  digest = "1:a887a56d0ff92cf05b4bb6004b46fc6e64d3fb6aca4eaeb1466bdce183ba5004"
+  digest = "1:047efbc3c9a51f3002b0002f92543857d372654a676fb6b01931982cd80467dd"
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
     "balancer/base",
     "balancer/roundrobin",
-    "binarylog/grpc_binarylog_v1",
     "codes",
     "connectivity",
     "credentials",
-    "credentials/internal",
     "encoding",
     "encoding/proto",
     "grpclog",
@@ -429,12 +391,9 @@
     "health/grpc_health_v1",
     "internal",
     "internal/backoff",
-    "internal/binarylog",
     "internal/channelz",
     "internal/envconfig",
     "internal/grpcrand",
-    "internal/grpcsync",
-    "internal/syscall",
     "internal/transport",
     "keepalive",
     "metadata",
@@ -448,11 +407,11 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
-  version = "v1.18.0"
+  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
+  version = "v1.14.0"
 
 [[projects]]
-  digest = "1:a4cde1eec9a17eb2399a50c6e1a9fe3fde039994de058f9dbf6592d157bfe97b"
+  digest = "1:b57bb9a6a2a03558d63166f1afc3c0c4f91ad137f63bf2bee995e9baeb976a9c"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -461,8 +420,8 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "e94fb177d3668d35ab39c61cbb2f311550557e83"
-  version = "v2.2.2"
+  revision = "8254d6c783765f38c8675fae4427a1fe73fbd09d"
+  version = "v2.1.8"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -474,8 +433,6 @@
     "github.com/hashicorp/go-cleanhttp",
     "github.com/hashicorp/go-hclog",
     "github.com/hashicorp/go-sockaddr",
-    "github.com/hashicorp/go-uuid",
-    "github.com/hashicorp/vault/api",
     "github.com/hashicorp/vault/helper/certutil",
     "github.com/hashicorp/vault/helper/cidrutil",
     "github.com/hashicorp/vault/helper/logging",
@@ -486,8 +443,6 @@
     "github.com/hashicorp/vault/logical",
     "github.com/hashicorp/vault/logical/framework",
     "github.com/hashicorp/vault/logical/plugin",
-    "github.com/mitchellh/pointerstructure",
-    "github.com/patrickmn/go-cache",
     "golang.org/x/oauth2",
     "gopkg.in/square/go-jose.v2",
     "gopkg.in/square/go-jose.v2/jwt",

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/README.md
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/README.md
@@ -5,10 +5,6 @@ This plugin allows for JWTs (including OIDC tokens) to authenticate with Vault.
 
 **Please note**: We take Vault's security and our users' trust very seriously. If you believe you have found a security issue in Vault, _please responsibly disclose_ by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
 
-## IMPORTANT
-
-This plugin is in pre-release state. It is not well tested (in fact, not tested at all) and there is no documentation currently available.
-
 ## Quick Links
     - Vault Website: https://www.vaultproject.io
     - JWT Auth Docs: https://www.vaultproject.io/docs/auth/jwt.html

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/backend.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/backend.go
@@ -3,10 +3,12 @@ package jwtauth
 import (
 	"context"
 	"sync"
+	"time"
 
 	oidc "github.com/coreos/go-oidc"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
+	cache "github.com/patrickmn/go-cache"
 )
 
 const (
@@ -16,7 +18,7 @@ const (
 
 // Factory is used by framework
 func Factory(ctx context.Context, c *logical.BackendConfig) (logical.Backend, error) {
-	b := backend(c)
+	b := backend()
 	if err := b.Setup(ctx, c); err != nil {
 		return nil, err
 	}
@@ -29,14 +31,16 @@ type jwtAuthBackend struct {
 	l            sync.RWMutex
 	provider     *oidc.Provider
 	cachedConfig *jwtConfig
+	oidcStates   *cache.Cache
 
 	providerCtx       context.Context
 	providerCtxCancel context.CancelFunc
 }
 
-func backend(c *logical.BackendConfig) *jwtAuthBackend {
+func backend() *jwtAuthBackend {
 	b := new(jwtAuthBackend)
 	b.providerCtx, b.providerCtxCancel = context.WithCancel(context.Background())
+	b.oidcStates = cache.New(oidcStateTimeout, 1*time.Minute)
 
 	b.Backend = &framework.Backend{
 		AuthRenew:   b.pathLoginRenew,
@@ -46,6 +50,11 @@ func backend(c *logical.BackendConfig) *jwtAuthBackend {
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
 				"login",
+				"oidc/auth_url",
+				"oidc/callback",
+
+				// Uncomment to mount simple UI handler for local development
+				// "ui",
 			},
 			SealWrapStorage: []string{
 				"config",
@@ -57,7 +66,11 @@ func backend(c *logical.BackendConfig) *jwtAuthBackend {
 				pathRoleList(b),
 				pathRole(b),
 				pathConfig(b),
+
+				// Uncomment to mount simple UI handler for local development
+				// pathUI(b),
 			},
+			pathOIDC(b),
 		),
 		Clean: b.cleanup,
 	}

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/backend.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/backend.go
@@ -3,12 +3,10 @@ package jwtauth
 import (
 	"context"
 	"sync"
-	"time"
 
 	oidc "github.com/coreos/go-oidc"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
-	cache "github.com/patrickmn/go-cache"
 )
 
 const (
@@ -18,7 +16,7 @@ const (
 
 // Factory is used by framework
 func Factory(ctx context.Context, c *logical.BackendConfig) (logical.Backend, error) {
-	b := backend()
+	b := backend(c)
 	if err := b.Setup(ctx, c); err != nil {
 		return nil, err
 	}
@@ -31,16 +29,14 @@ type jwtAuthBackend struct {
 	l            sync.RWMutex
 	provider     *oidc.Provider
 	cachedConfig *jwtConfig
-	oidcStates   *cache.Cache
 
 	providerCtx       context.Context
 	providerCtxCancel context.CancelFunc
 }
 
-func backend() *jwtAuthBackend {
+func backend(c *logical.BackendConfig) *jwtAuthBackend {
 	b := new(jwtAuthBackend)
 	b.providerCtx, b.providerCtxCancel = context.WithCancel(context.Background())
-	b.oidcStates = cache.New(oidcStateTimeout, 1*time.Minute)
 
 	b.Backend = &framework.Backend{
 		AuthRenew:   b.pathLoginRenew,
@@ -50,11 +46,6 @@ func backend() *jwtAuthBackend {
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
 				"login",
-				"oidc/auth_url",
-				"oidc/callback",
-
-				// Uncomment to mount simple UI handler for local development
-				// "ui",
 			},
 			SealWrapStorage: []string{
 				"config",
@@ -66,11 +57,7 @@ func backend() *jwtAuthBackend {
 				pathRoleList(b),
 				pathRole(b),
 				pathConfig(b),
-
-				// Uncomment to mount simple UI handler for local development
-				// pathUI(b),
 			},
-			pathOIDC(b),
 		),
 		Clean: b.cleanup,
 	}

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_config.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"context"
@@ -21,19 +22,23 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: `config`,
 		Fields: map[string]*framework.FieldSchema{
-			"oidc_discovery_url": &framework.FieldSchema{
+			"oidc_discovery_url": {
 				Type:        framework.TypeString,
 				Description: `OIDC Discovery URL, without any .well-known component (base path). Cannot be used with "jwt_validation_pubkeys".`,
 			},
-			"oidc_discovery_ca_pem": &framework.FieldSchema{
+			"oidc_discovery_ca_pem": {
 				Type:        framework.TypeString,
 				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate conections to the OIDC Discovery URL. If not set, system certificates are used.",
 			},
-			"jwt_validation_pubkeys": &framework.FieldSchema{
+			"jwt_validation_pubkeys": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "oidc_discovery_url".`,
 			},
-			"bound_issuer": &framework.FieldSchema{
+			"jwt_supported_algs": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: `A list of supported signing algorithms. Defaults to RS256.`,
+			},
+			"bound_issuer": {
 				Type:        framework.TypeString,
 				Description: "The value against which to match the 'iss' claim in a JWT. Optional.",
 			},
@@ -99,6 +104,7 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 			"oidc_discovery_url":     config.OIDCDiscoveryURL,
 			"oidc_discovery_ca_pem":  config.OIDCDiscoveryCAPEM,
 			"jwt_validation_pubkeys": config.JWTValidationPubKeys,
+			"jwt_supported_algs":     config.JWTSupportedAlgs,
 			"bound_issuer":           config.BoundIssuer,
 		},
 	}
@@ -111,6 +117,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		OIDCDiscoveryURL:     d.Get("oidc_discovery_url").(string),
 		OIDCDiscoveryCAPEM:   d.Get("oidc_discovery_ca_pem").(string),
 		JWTValidationPubKeys: d.Get("jwt_validation_pubkeys").([]string),
+		JWTSupportedAlgs:     d.Get("jwt_supported_algs").([]string),
 		BoundIssuer:          d.Get("bound_issuer").(string),
 	}
 
@@ -121,7 +128,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse("exactly one of 'oidc_discovery_url' and 'jwt_validation_pubkeys' must be set"), nil
 
 	case config.OIDCDiscoveryURL != "":
-		_, err := b.createProvider(ctx, config)
+		_, err := b.createProvider(config)
 		if err != nil {
 			return logical.ErrorResponse(errwrap.Wrapf("error checking discovery URL: {{err}}", err).Error()), nil
 		}
@@ -130,6 +137,15 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		for _, v := range config.JWTValidationPubKeys {
 			if _, err := certutil.ParsePublicKeyPEM([]byte(v)); err != nil {
 				return logical.ErrorResponse(errwrap.Wrapf("error parsing public key: {{err}}", err).Error()), nil
+			}
+		}
+
+	case len(config.JWTSupportedAlgs) != 0:
+		for _, a := range config.JWTSupportedAlgs {
+			switch a {
+			case oidc.RS256, oidc.RS384, oidc.RS512, oidc.ES256, oidc.ES384, oidc.ES512, oidc.PS256, oidc.PS384, oidc.PS512:
+			default:
+				return logical.ErrorResponse(fmt.Sprintf("Invalid supported algorithm: %s", a)), nil
 			}
 		}
 
@@ -150,7 +166,7 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	return nil, nil
 }
 
-func (b *jwtAuthBackend) createProvider(ctx context.Context, config *jwtConfig) (*oidc.Provider, error) {
+func (b *jwtAuthBackend) createProvider(config *jwtConfig) (*oidc.Provider, error) {
 	var certPool *x509.CertPool
 	if config.OIDCDiscoveryCAPEM != "" {
 		certPool = x509.NewCertPool()
@@ -168,7 +184,7 @@ func (b *jwtAuthBackend) createProvider(ctx context.Context, config *jwtConfig) 
 	tc := &http.Client{
 		Transport: tr,
 	}
-	oidcCtx := context.WithValue(ctx, oauth2.HTTPClient, tc)
+	oidcCtx := context.WithValue(b.providerCtx, oauth2.HTTPClient, tc)
 
 	provider, err := oidc.NewProvider(oidcCtx, config.OIDCDiscoveryURL)
 	if err != nil {
@@ -182,6 +198,7 @@ type jwtConfig struct {
 	OIDCDiscoveryURL     string   `json:"oidc_discovery_url"`
 	OIDCDiscoveryCAPEM   string   `json:"oidc_discovery_ca_pem"`
 	JWTValidationPubKeys []string `json:"jwt_validation_pubkeys"`
+	JWTSupportedAlgs     []string `json:"jwt_supported_algs"`
 	BoundIssuer          string   `json:"bound_issuer"`
 
 	ParsedJWTPubKeys []interface{} `json:"-"`

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_config.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_config.go
@@ -30,19 +30,6 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate conections to the OIDC Discovery URL. If not set, system certificates are used.",
 			},
-			"oidc_client_id": {
-				Type:        framework.TypeString,
-				Description: "The OAuth Client ID configured with your OIDC provider.",
-			},
-			"oidc_client_secret": {
-				Type:             framework.TypeString,
-				Description:      "The OAuth Client Secret configured with your OIDC provider.",
-				DisplaySensitive: true,
-			},
-			"default_role": {
-				Type:        framework.TypeString,
-				Description: "The default role to use if none is provided during login. If not set, a role is required during login.",
-			},
 			"jwt_validation_pubkeys": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "oidc_discovery_url".`,
@@ -57,17 +44,9 @@ func pathConfig(b *jwtAuthBackend) *framework.Path {
 			},
 		},
 
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.pathConfigRead,
-				Summary:  "Read the current JWT authentication backend configuration.",
-			},
-
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback:    b.pathConfigWrite,
-				Summary:     "Configure the JWT authentication backend.",
-				Description: confHelpDesc,
-			},
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.pathConfigRead,
+			logical.UpdateOperation: b.pathConfigWrite,
 		},
 
 		HelpSynopsis:    confHelpSyn,
@@ -124,8 +103,6 @@ func (b *jwtAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 		Data: map[string]interface{}{
 			"oidc_discovery_url":     config.OIDCDiscoveryURL,
 			"oidc_discovery_ca_pem":  config.OIDCDiscoveryCAPEM,
-			"oidc_client_id":         config.OIDCClientID,
-			"default_role":           config.DefaultRole,
 			"jwt_validation_pubkeys": config.JWTValidationPubKeys,
 			"jwt_supported_algs":     config.JWTSupportedAlgs,
 			"bound_issuer":           config.BoundIssuer,
@@ -139,9 +116,6 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 	config := &jwtConfig{
 		OIDCDiscoveryURL:     d.Get("oidc_discovery_url").(string),
 		OIDCDiscoveryCAPEM:   d.Get("oidc_discovery_ca_pem").(string),
-		OIDCClientID:         d.Get("oidc_client_id").(string),
-		OIDCClientSecret:     d.Get("oidc_client_secret").(string),
-		DefaultRole:          d.Get("default_role").(string),
 		JWTValidationPubKeys: d.Get("jwt_validation_pubkeys").([]string),
 		JWTSupportedAlgs:     d.Get("jwt_supported_algs").([]string),
 		BoundIssuer:          d.Get("bound_issuer").(string),
@@ -153,18 +127,11 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 		config.OIDCDiscoveryURL != "" && len(config.JWTValidationPubKeys) != 0:
 		return logical.ErrorResponse("exactly one of 'oidc_discovery_url' and 'jwt_validation_pubkeys' must be set"), nil
 
-	case config.OIDCClientID != "" && config.OIDCClientSecret == "",
-		config.OIDCClientID == "" && config.OIDCClientSecret != "":
-		return logical.ErrorResponse("both 'oidc_client_id' and 'oidc_client_secret' must be set for OIDC"), nil
-
 	case config.OIDCDiscoveryURL != "":
 		_, err := b.createProvider(config)
 		if err != nil {
 			return logical.ErrorResponse(errwrap.Wrapf("error checking discovery URL: {{err}}", err).Error()), nil
 		}
-
-	case config.OIDCClientID != "" && config.OIDCDiscoveryURL == "":
-		return logical.ErrorResponse("'oidc_discovery_url' must be set for OIDC"), nil
 
 	case len(config.JWTValidationPubKeys) != 0:
 		for _, v := range config.JWTValidationPubKeys {
@@ -173,16 +140,17 @@ func (b *jwtAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Reque
 			}
 		}
 
+	case len(config.JWTSupportedAlgs) != 0:
+		for _, a := range config.JWTSupportedAlgs {
+			switch a {
+			case oidc.RS256, oidc.RS384, oidc.RS512, oidc.ES256, oidc.ES384, oidc.ES512, oidc.PS256, oidc.PS384, oidc.PS512:
+			default:
+				return logical.ErrorResponse(fmt.Sprintf("Invalid supported algorithm: %s", a)), nil
+			}
+		}
+
 	default:
 		return nil, errors.New("unknown condition")
-	}
-
-	for _, a := range config.JWTSupportedAlgs {
-		switch a {
-		case oidc.RS256, oidc.RS384, oidc.RS512, oidc.ES256, oidc.ES384, oidc.ES512, oidc.PS256, oidc.PS384, oidc.PS512:
-		default:
-			return logical.ErrorResponse(fmt.Sprintf("Invalid supported algorithm: %s", a)), nil
-		}
 	}
 
 	entry, err := logical.StorageEntryJSON(configPath, config)
@@ -229,12 +197,9 @@ func (b *jwtAuthBackend) createProvider(config *jwtConfig) (*oidc.Provider, erro
 type jwtConfig struct {
 	OIDCDiscoveryURL     string   `json:"oidc_discovery_url"`
 	OIDCDiscoveryCAPEM   string   `json:"oidc_discovery_ca_pem"`
-	OIDCClientID         string   `json:"oidc_client_id"`
-	OIDCClientSecret     string   `json:"oidc_client_secret"`
 	JWTValidationPubKeys []string `json:"jwt_validation_pubkeys"`
 	JWTSupportedAlgs     []string `json:"jwt_supported_algs"`
 	BoundIssuer          string   `json:"bound_issuer"`
-	DefaultRole          string   `json:"default_role"`
 
 	ParsedJWTPubKeys []interface{} `json:"-"`
 }

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_login.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_login.go
@@ -29,14 +29,9 @@ func pathLogin(b *jwtAuthBackend) *framework.Path {
 			},
 		},
 
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathLogin,
-				Summary:  pathLoginHelpSyn,
-			},
-			logical.AliasLookaheadOperation: &framework.PathOperation{
-				Callback: b.pathLogin,
-			},
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation:         b.pathLogin,
+			logical.AliasLookaheadOperation: b.pathLogin,
 		},
 
 		HelpSynopsis:    pathLoginHelpSyn,
@@ -45,19 +40,13 @@ func pathLogin(b *jwtAuthBackend) *framework.Path {
 }
 
 func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	config, err := b.config(ctx, req.Storage)
-	if err != nil {
-		return nil, err
-	}
-	if config == nil {
-		return logical.ErrorResponse("could not load configuration"), nil
+	token := d.Get("jwt").(string)
+	if len(token) == 0 {
+		return logical.ErrorResponse("missing token"), nil
 	}
 
 	roleName := d.Get("role").(string)
-	if roleName == "" {
-		roleName = config.DefaultRole
-	}
-	if roleName == "" {
+	if len(roleName) == 0 {
 		return logical.ErrorResponse("missing role"), nil
 	}
 
@@ -66,16 +55,19 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse("role %q could not be found", roleName), nil
-	}
-
-	token := d.Get("jwt").(string)
-	if len(token) == 0 {
-		return logical.ErrorResponse("missing token"), nil
+		return logical.ErrorResponse("role could not be found"), nil
 	}
 
 	if req.Connection != nil && !cidrutil.RemoteAddrIsOk(req.Connection.RemoteAddr, role.BoundCIDRs) {
 		return logical.ErrorResponse("request originated from invalid CIDR"), nil
+	}
+
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return logical.ErrorResponse("could not load configuration"), nil
 	}
 
 	// Here is where things diverge. If it is using OIDC Discovery, validate
@@ -138,37 +130,119 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		}
 
 	case config.OIDCDiscoveryURL != "":
-		allClaims, err = b.verifyOIDCToken(ctx, config, role, token)
+		provider, err := b.getProvider(ctx, config)
 		if err != nil {
-			return logical.ErrorResponse(err.Error()), nil
+			return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
+		}
+
+		verifier := provider.Verifier(&oidc.Config{
+			SkipClientIDCheck:    true,
+			SupportedSigningAlgs: config.JWTSupportedAlgs,
+		})
+
+		idToken, err := verifier.Verify(ctx, token)
+		if err != nil {
+			return logical.ErrorResponse(errwrap.Wrapf("error validating signature: {{err}}", err).Error()), nil
+		}
+
+		if err := idToken.Claims(&allClaims); err != nil {
+			return logical.ErrorResponse(errwrap.Wrapf("unable to successfully parse all claims from token: {{err}}", err).Error()), nil
+		}
+
+		if role.BoundSubject != "" && role.BoundSubject != idToken.Subject {
+			return logical.ErrorResponse("sub claim does not match bound subject"), nil
+		}
+		if len(role.BoundAudiences) != 0 {
+			var found bool
+			for _, v := range role.BoundAudiences {
+				if strutil.StrListContains(idToken.Audience, v) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return logical.ErrorResponse("aud claim does not match any bound audience"), nil
+			}
 		}
 
 	default:
 		return nil, errors.New("unhandled case during login")
 	}
 
-	alias, groupAliases, err := b.createIdentity(allClaims, role)
-	if err != nil {
-		return logical.ErrorResponse(err.Error()), nil
+	userClaimRaw, ok := allClaims[role.UserClaim]
+	if !ok {
+		return logical.ErrorResponse(fmt.Sprintf("%q claim not found in token", role.UserClaim)), nil
+	}
+	userName, ok := userClaimRaw.(string)
+	if !ok {
+		return logical.ErrorResponse(fmt.Sprintf("%q claim could not be converted to string", role.UserClaim)), nil
 	}
 
-	tokenMetadata := map[string]string{"role": roleName}
-	for k, v := range alias.Metadata {
-		tokenMetadata[k] = v
+	var groupAliases []*logical.Alias
+	if role.GroupsClaim != "" {
+		mapPath, err := parseClaimWithDelimiters(role.GroupsClaim, role.GroupsClaimDelimiterPattern)
+		if err != nil {
+			return logical.ErrorResponse(errwrap.Wrapf("error parsing delimiters for groups claim: {{err}}", err).Error()), nil
+		}
+		if len(mapPath) < 1 {
+			return logical.ErrorResponse("unexpected length 0 of claims path after parsing groups claim against delimiters"), nil
+		}
+		var claimKey string
+		claimMap := allClaims
+		for i, key := range mapPath {
+			if i == len(mapPath)-1 {
+				claimKey = key
+				break
+			}
+			nextMapRaw, ok := claimMap[key]
+			if !ok {
+				return logical.ErrorResponse(fmt.Sprintf("map via key %q not found while navigating group claim delimiters", key)), nil
+			}
+			nextMap, ok := nextMapRaw.(map[string]interface{})
+			if !ok {
+				return logical.ErrorResponse(fmt.Sprintf("key %q does not reference a map while navigating group claim delimiters", key)), nil
+			}
+			claimMap = nextMap
+		}
+
+		groupsClaimRaw, ok := claimMap[claimKey]
+		if !ok {
+			return logical.ErrorResponse(fmt.Sprintf("%q claim not found in token", role.GroupsClaim)), nil
+		}
+		groups, ok := groupsClaimRaw.([]interface{})
+		if !ok {
+			return logical.ErrorResponse(fmt.Sprintf("%q claim could not be converted to string list", role.GroupsClaim)), nil
+		}
+		for _, groupRaw := range groups {
+			group, ok := groupRaw.(string)
+			if !ok {
+				return logical.ErrorResponse(fmt.Sprintf("value %v in groups claim could not be parsed as string", groupRaw)), nil
+			}
+			if group == "" {
+				continue
+			}
+			groupAliases = append(groupAliases, &logical.Alias{
+				Name: group,
+			})
+		}
 	}
 
 	resp := &logical.Response{
 		Auth: &logical.Auth{
-			Policies:     role.Policies,
-			DisplayName:  alias.Name,
-			Period:       role.Period,
-			NumUses:      role.NumUses,
-			Alias:        alias,
+			Policies:    role.Policies,
+			DisplayName: userName,
+			Period:      role.Period,
+			NumUses:     role.NumUses,
+			Alias: &logical.Alias{
+				Name: userName,
+			},
 			GroupAliases: groupAliases,
 			InternalData: map[string]interface{}{
 				"role": roleName,
 			},
-			Metadata: tokenMetadata,
+			Metadata: map[string]string{
+				"role": roleName,
+			},
 			LeaseOptions: logical.LeaseOptions{
 				Renewable: true,
 				TTL:       role.TTL,
@@ -201,120 +275,6 @@ func (b *jwtAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 	resp.Auth.MaxTTL = role.MaxTTL
 	resp.Auth.Period = role.Period
 	return resp, nil
-}
-
-func (b *jwtAuthBackend) verifyOIDCToken(ctx context.Context, config *jwtConfig, role *jwtRole, rawToken string) (map[string]interface{}, error) {
-	allClaims := make(map[string]interface{})
-
-	provider, err := b.getProvider(ctx, config)
-	if err != nil {
-		return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
-	}
-
-	oidcConfig := &oidc.Config{
-		SupportedSigningAlgs: config.JWTSupportedAlgs,
-	}
-
-	if role.RoleType == "oidc" {
-		oidcConfig.ClientID = config.OIDCClientID
-	} else {
-		oidcConfig.SkipClientIDCheck = true
-	}
-	verifier := provider.Verifier(oidcConfig)
-
-	idToken, err := verifier.Verify(ctx, rawToken)
-	if err != nil {
-		return nil, errwrap.Wrapf("error validating signature: {{err}}", err)
-	}
-
-	if err := idToken.Claims(&allClaims); err != nil {
-		return nil, errwrap.Wrapf("unable to successfully parse all claims from token: {{err}}", err)
-	}
-
-	if role.BoundSubject != "" && role.BoundSubject != idToken.Subject {
-		return nil, errors.New("sub claim does not match bound subject")
-	}
-	if len(role.BoundAudiences) > 0 {
-		var found bool
-		for _, v := range role.BoundAudiences {
-			if strutil.StrListContains(idToken.Audience, v) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, errors.New("aud claim does not match any bound audience")
-		}
-	}
-
-	if len(role.BoundClaims) > 0 {
-		for claim, expValue := range role.BoundClaims {
-			actValue := getClaim(b.Logger(), allClaims, claim)
-			if actValue == nil {
-				return nil, fmt.Errorf("claim is missing: %s", claim)
-			}
-
-			if expValue != actValue {
-				return nil, fmt.Errorf("claim '%s' does not match associated bound claim", claim)
-			}
-		}
-	}
-
-	return allClaims, nil
-}
-
-// createIdentity creates an alias and set of groups aliass based on the role
-// definition and received claims.
-func (b *jwtAuthBackend) createIdentity(allClaims map[string]interface{}, role *jwtRole) (*logical.Alias, []*logical.Alias, error) {
-	userClaimRaw, ok := allClaims[role.UserClaim]
-	if !ok {
-		return nil, nil, fmt.Errorf("claim %q not found in token", role.UserClaim)
-	}
-	userName, ok := userClaimRaw.(string)
-	if !ok {
-		return nil, nil, fmt.Errorf("claim %q could not be converted to string", role.UserClaim)
-	}
-
-	metadata, err := extractMetadata(b.Logger(), allClaims, role.ClaimMappings)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	alias := &logical.Alias{
-		Name:     userName,
-		Metadata: metadata,
-	}
-
-	var groupAliases []*logical.Alias
-
-	if role.GroupsClaim == "" {
-		return alias, groupAliases, nil
-	}
-
-	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
-
-	if groupsClaimRaw == nil {
-		return nil, nil, fmt.Errorf("%q claim not found in token", role.GroupsClaim)
-	}
-	groups, ok := groupsClaimRaw.([]interface{})
-
-	if !ok {
-		return nil, nil, fmt.Errorf("%q claim could not be converted to string list", role.GroupsClaim)
-	}
-	for _, groupRaw := range groups {
-		group, ok := groupRaw.(string)
-		if !ok {
-			return nil, nil, fmt.Errorf("value %v in groups claim could not be parsed as string", groupRaw)
-		}
-		if group == "" {
-			continue
-		}
-		groupAliases = append(groupAliases, &logical.Alias{
-			Name: group,
-		})
-	}
-
-	return alias, groupAliases, nil
 }
 
 const (

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_login.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_login.go
@@ -29,9 +29,14 @@ func pathLogin(b *jwtAuthBackend) *framework.Path {
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation:         b.pathLogin,
-			logical.AliasLookaheadOperation: b.pathLogin,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathLogin,
+				Summary:  pathLoginHelpSyn,
+			},
+			logical.AliasLookaheadOperation: &framework.PathOperation{
+				Callback: b.pathLogin,
+			},
 		},
 
 		HelpSynopsis:    pathLoginHelpSyn,
@@ -40,13 +45,19 @@ func pathLogin(b *jwtAuthBackend) *framework.Path {
 }
 
 func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	token := d.Get("jwt").(string)
-	if len(token) == 0 {
-		return logical.ErrorResponse("missing token"), nil
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return logical.ErrorResponse("could not load configuration"), nil
 	}
 
 	roleName := d.Get("role").(string)
-	if len(roleName) == 0 {
+	if roleName == "" {
+		roleName = config.DefaultRole
+	}
+	if roleName == "" {
 		return logical.ErrorResponse("missing role"), nil
 	}
 
@@ -55,19 +66,16 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse("role could not be found"), nil
+		return logical.ErrorResponse("role %q could not be found", roleName), nil
+	}
+
+	token := d.Get("jwt").(string)
+	if len(token) == 0 {
+		return logical.ErrorResponse("missing token"), nil
 	}
 
 	if req.Connection != nil && !cidrutil.RemoteAddrIsOk(req.Connection.RemoteAddr, role.BoundCIDRs) {
 		return logical.ErrorResponse("request originated from invalid CIDR"), nil
-	}
-
-	config, err := b.config(ctx, req.Storage)
-	if err != nil {
-		return nil, err
-	}
-	if config == nil {
-		return logical.ErrorResponse("could not load configuration"), nil
 	}
 
 	// Here is where things diverge. If it is using OIDC Discovery, validate
@@ -130,119 +138,37 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		}
 
 	case config.OIDCDiscoveryURL != "":
-		provider, err := b.getProvider(ctx, config)
+		allClaims, err = b.verifyOIDCToken(ctx, config, role, token)
 		if err != nil {
-			return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
-		}
-
-		verifier := provider.Verifier(&oidc.Config{
-			SkipClientIDCheck:    true,
-			SupportedSigningAlgs: config.JWTSupportedAlgs,
-		})
-
-		idToken, err := verifier.Verify(ctx, token)
-		if err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("error validating signature: {{err}}", err).Error()), nil
-		}
-
-		if err := idToken.Claims(&allClaims); err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("unable to successfully parse all claims from token: {{err}}", err).Error()), nil
-		}
-
-		if role.BoundSubject != "" && role.BoundSubject != idToken.Subject {
-			return logical.ErrorResponse("sub claim does not match bound subject"), nil
-		}
-		if len(role.BoundAudiences) != 0 {
-			var found bool
-			for _, v := range role.BoundAudiences {
-				if strutil.StrListContains(idToken.Audience, v) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return logical.ErrorResponse("aud claim does not match any bound audience"), nil
-			}
+			return logical.ErrorResponse(err.Error()), nil
 		}
 
 	default:
 		return nil, errors.New("unhandled case during login")
 	}
 
-	userClaimRaw, ok := allClaims[role.UserClaim]
-	if !ok {
-		return logical.ErrorResponse(fmt.Sprintf("%q claim not found in token", role.UserClaim)), nil
-	}
-	userName, ok := userClaimRaw.(string)
-	if !ok {
-		return logical.ErrorResponse(fmt.Sprintf("%q claim could not be converted to string", role.UserClaim)), nil
+	alias, groupAliases, err := b.createIdentity(allClaims, role)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	var groupAliases []*logical.Alias
-	if role.GroupsClaim != "" {
-		mapPath, err := parseClaimWithDelimiters(role.GroupsClaim, role.GroupsClaimDelimiterPattern)
-		if err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("error parsing delimiters for groups claim: {{err}}", err).Error()), nil
-		}
-		if len(mapPath) < 1 {
-			return logical.ErrorResponse("unexpected length 0 of claims path after parsing groups claim against delimiters"), nil
-		}
-		var claimKey string
-		claimMap := allClaims
-		for i, key := range mapPath {
-			if i == len(mapPath)-1 {
-				claimKey = key
-				break
-			}
-			nextMapRaw, ok := claimMap[key]
-			if !ok {
-				return logical.ErrorResponse(fmt.Sprintf("map via key %q not found while navigating group claim delimiters", key)), nil
-			}
-			nextMap, ok := nextMapRaw.(map[string]interface{})
-			if !ok {
-				return logical.ErrorResponse(fmt.Sprintf("key %q does not reference a map while navigating group claim delimiters", key)), nil
-			}
-			claimMap = nextMap
-		}
-
-		groupsClaimRaw, ok := claimMap[claimKey]
-		if !ok {
-			return logical.ErrorResponse(fmt.Sprintf("%q claim not found in token", role.GroupsClaim)), nil
-		}
-		groups, ok := groupsClaimRaw.([]interface{})
-		if !ok {
-			return logical.ErrorResponse(fmt.Sprintf("%q claim could not be converted to string list", role.GroupsClaim)), nil
-		}
-		for _, groupRaw := range groups {
-			group, ok := groupRaw.(string)
-			if !ok {
-				return logical.ErrorResponse(fmt.Sprintf("value %v in groups claim could not be parsed as string", groupRaw)), nil
-			}
-			if group == "" {
-				continue
-			}
-			groupAliases = append(groupAliases, &logical.Alias{
-				Name: group,
-			})
-		}
+	tokenMetadata := map[string]string{"role": roleName}
+	for k, v := range alias.Metadata {
+		tokenMetadata[k] = v
 	}
 
 	resp := &logical.Response{
 		Auth: &logical.Auth{
-			Policies:    role.Policies,
-			DisplayName: userName,
-			Period:      role.Period,
-			NumUses:     role.NumUses,
-			Alias: &logical.Alias{
-				Name: userName,
-			},
+			Policies:     role.Policies,
+			DisplayName:  alias.Name,
+			Period:       role.Period,
+			NumUses:      role.NumUses,
+			Alias:        alias,
 			GroupAliases: groupAliases,
 			InternalData: map[string]interface{}{
 				"role": roleName,
 			},
-			Metadata: map[string]string{
-				"role": roleName,
-			},
+			Metadata: tokenMetadata,
 			LeaseOptions: logical.LeaseOptions{
 				Renewable: true,
 				TTL:       role.TTL,
@@ -275,6 +201,120 @@ func (b *jwtAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 	resp.Auth.MaxTTL = role.MaxTTL
 	resp.Auth.Period = role.Period
 	return resp, nil
+}
+
+func (b *jwtAuthBackend) verifyOIDCToken(ctx context.Context, config *jwtConfig, role *jwtRole, rawToken string) (map[string]interface{}, error) {
+	allClaims := make(map[string]interface{})
+
+	provider, err := b.getProvider(ctx, config)
+	if err != nil {
+		return nil, errwrap.Wrapf("error getting provider for login operation: {{err}}", err)
+	}
+
+	oidcConfig := &oidc.Config{
+		SupportedSigningAlgs: config.JWTSupportedAlgs,
+	}
+
+	if role.RoleType == "oidc" {
+		oidcConfig.ClientID = config.OIDCClientID
+	} else {
+		oidcConfig.SkipClientIDCheck = true
+	}
+	verifier := provider.Verifier(oidcConfig)
+
+	idToken, err := verifier.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, errwrap.Wrapf("error validating signature: {{err}}", err)
+	}
+
+	if err := idToken.Claims(&allClaims); err != nil {
+		return nil, errwrap.Wrapf("unable to successfully parse all claims from token: {{err}}", err)
+	}
+
+	if role.BoundSubject != "" && role.BoundSubject != idToken.Subject {
+		return nil, errors.New("sub claim does not match bound subject")
+	}
+	if len(role.BoundAudiences) > 0 {
+		var found bool
+		for _, v := range role.BoundAudiences {
+			if strutil.StrListContains(idToken.Audience, v) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.New("aud claim does not match any bound audience")
+		}
+	}
+
+	if len(role.BoundClaims) > 0 {
+		for claim, expValue := range role.BoundClaims {
+			actValue := getClaim(b.Logger(), allClaims, claim)
+			if actValue == nil {
+				return nil, fmt.Errorf("claim is missing: %s", claim)
+			}
+
+			if expValue != actValue {
+				return nil, fmt.Errorf("claim '%s' does not match associated bound claim", claim)
+			}
+		}
+	}
+
+	return allClaims, nil
+}
+
+// createIdentity creates an alias and set of groups aliass based on the role
+// definition and received claims.
+func (b *jwtAuthBackend) createIdentity(allClaims map[string]interface{}, role *jwtRole) (*logical.Alias, []*logical.Alias, error) {
+	userClaimRaw, ok := allClaims[role.UserClaim]
+	if !ok {
+		return nil, nil, fmt.Errorf("claim %q not found in token", role.UserClaim)
+	}
+	userName, ok := userClaimRaw.(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("claim %q could not be converted to string", role.UserClaim)
+	}
+
+	metadata, err := extractMetadata(b.Logger(), allClaims, role.ClaimMappings)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	alias := &logical.Alias{
+		Name:     userName,
+		Metadata: metadata,
+	}
+
+	var groupAliases []*logical.Alias
+
+	if role.GroupsClaim == "" {
+		return alias, groupAliases, nil
+	}
+
+	groupsClaimRaw := getClaim(b.Logger(), allClaims, role.GroupsClaim)
+
+	if groupsClaimRaw == nil {
+		return nil, nil, fmt.Errorf("%q claim not found in token", role.GroupsClaim)
+	}
+	groups, ok := groupsClaimRaw.([]interface{})
+
+	if !ok {
+		return nil, nil, fmt.Errorf("%q claim could not be converted to string list", role.GroupsClaim)
+	}
+	for _, groupRaw := range groups {
+		group, ok := groupRaw.(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("value %v in groups claim could not be parsed as string", groupRaw)
+		}
+		if group == "" {
+			continue
+		}
+		groupAliases = append(groupAliases, &logical.Alias{
+			Name: group,
+		})
+	}
+
+	return alias, groupAliases, nil
 }
 
 const (

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_login.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_login.go
@@ -19,11 +19,11 @@ func pathLogin(b *jwtAuthBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: `login$`,
 		Fields: map[string]*framework.FieldSchema{
-			"role": &framework.FieldSchema{
+			"role": {
 				Type:        framework.TypeLowerCaseString,
 				Description: "The role to log in against.",
 			},
-			"jwt": &framework.FieldSchema{
+			"jwt": {
 				Type:        framework.TypeString,
 				Description: "The signed JWT to validate.",
 			},
@@ -136,7 +136,8 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 		}
 
 		verifier := provider.Verifier(&oidc.Config{
-			SkipClientIDCheck: true,
+			SkipClientIDCheck:    true,
+			SupportedSigningAlgs: config.JWTSupportedAlgs,
 		})
 
 		idToken, err := verifier.Verify(ctx, token)
@@ -179,7 +180,32 @@ func (b *jwtAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d 
 
 	var groupAliases []*logical.Alias
 	if role.GroupsClaim != "" {
-		groupsClaimRaw, ok := allClaims[role.GroupsClaim]
+		mapPath, err := parseClaimWithDelimiters(role.GroupsClaim, role.GroupsClaimDelimiterPattern)
+		if err != nil {
+			return logical.ErrorResponse(errwrap.Wrapf("error parsing delimiters for groups claim: {{err}}", err).Error()), nil
+		}
+		if len(mapPath) < 1 {
+			return logical.ErrorResponse("unexpected length 0 of claims path after parsing groups claim against delimiters"), nil
+		}
+		var claimKey string
+		claimMap := allClaims
+		for i, key := range mapPath {
+			if i == len(mapPath)-1 {
+				claimKey = key
+				break
+			}
+			nextMapRaw, ok := claimMap[key]
+			if !ok {
+				return logical.ErrorResponse(fmt.Sprintf("map via key %q not found while navigating group claim delimiters", key)), nil
+			}
+			nextMap, ok := nextMapRaw.(map[string]interface{})
+			if !ok {
+				return logical.ErrorResponse(fmt.Sprintf("key %q does not reference a map while navigating group claim delimiters", key)), nil
+			}
+			claimMap = nextMap
+		}
+
+		groupsClaimRaw, ok := claimMap[claimKey]
 		if !ok {
 			return logical.ErrorResponse(fmt.Sprintf("%q claim not found in token", role.GroupsClaim)), nil
 		}

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_role.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_role.go
@@ -7,19 +7,25 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	sockaddr "github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
 
+var reservedMetadata = []string{"role"}
+
 func pathRoleList(b *jwtAuthBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: "role/?",
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.pathRoleList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback:    b.pathRoleList,
+				Summary:     strings.TrimSpace(roleHelp["role-list"][0]),
+				Description: strings.TrimSpace(roleHelp["role-list"][1]),
+			},
 		},
 		HelpSynopsis:    strings.TrimSpace(roleHelp["role-list"][0]),
 		HelpDescription: strings.TrimSpace(roleHelp["role-list"][1]),
@@ -34,6 +40,10 @@ func pathRole(b *jwtAuthBackend) *framework.Path {
 			"name": {
 				Type:        framework.TypeLowerCaseString,
 				Description: "Name of the role.",
+			},
+			"role_type": {
+				Type:        framework.TypeString,
+				Description: "Type of the role, either 'jwt' or 'oidc'.",
 			},
 			"policies": {
 				Type:        framework.TypeCommaStringSlice,
@@ -68,6 +78,14 @@ TTL will be set to the value of this parameter.`,
 				Type:        framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of 'aud' claims that are valid for login; any match is sufficient`,
 			},
+			"bound_claims": {
+				Type:        framework.TypeMap,
+				Description: `Map of claims/values which must match for login`,
+			},
+			"claim_mappings": {
+				Type:        framework.TypeKVPairs,
+				Description: `Mappings of claims (key) that will be copied to a metadata field (value)`,
+			},
 			"user_claim": {
 				Type:        framework.TypeString,
 				Description: `The claim to use for the Identity entity alias name`,
@@ -76,22 +94,43 @@ TTL will be set to the value of this parameter.`,
 				Type:        framework.TypeString,
 				Description: `The claim to use for the Identity group alias names`,
 			},
-			"groups_claim_delimiter_pattern": {
-				Type:        framework.TypeString,
-				Description: `A pattern of delimiters used to allow the groups_claim to live outside of the top-level JWT structure. For instance, a "groups_claim" of "meta/user.name/groups" with this field set to "//" will expect nested structures named "meta", "user.name", and "groups". If this field was set to "/./" the groups information would expect to be via nested structures of "meta", "user", "name", and "groups".`,
-			},
 			"bound_cidrs": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of IP CIDRS that are allowed to 
 authenticate against this role`,
 			},
+			"oidc_scopes": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: `Comma-separated list of OIDC scopes`,
+			},
+			"allowed_redirect_uris": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: `Comma-separated list of allowed values for redirect_uri`,
+			},
 		},
 		ExistenceCheck: b.pathRoleExistenceCheck,
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathRoleCreateUpdate,
-			logical.UpdateOperation: b.pathRoleCreateUpdate,
-			logical.ReadOperation:   b.pathRoleRead,
-			logical.DeleteOperation: b.pathRoleDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathRoleRead,
+				Summary:  "Read an existing role.",
+			},
+
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback:    b.pathRoleCreateUpdate,
+				Summary:     strings.TrimSpace(roleHelp["role"][0]),
+				Description: strings.TrimSpace(roleHelp["role"][1]),
+			},
+
+			logical.CreateOperation: &framework.PathOperation{
+				Callback:    b.pathRoleCreateUpdate,
+				Summary:     strings.TrimSpace(roleHelp["role"][0]),
+				Description: strings.TrimSpace(roleHelp["role"][1]),
+			},
+
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathRoleDelete,
+				Summary:  "Delete an existing role.",
+			},
 		},
 		HelpSynopsis:    strings.TrimSpace(roleHelp["role"][0]),
 		HelpDescription: strings.TrimSpace(roleHelp["role"][1]),
@@ -99,6 +138,8 @@ authenticate against this role`,
 }
 
 type jwtRole struct {
+	RoleType string `json:"role_type"`
+
 	// Policies that are to be required by the token to access this role
 	Policies []string `json:"policies"`
 
@@ -119,12 +160,15 @@ type jwtRole struct {
 	Period time.Duration `json:"period"`
 
 	// Role binding properties
-	BoundAudiences              []string                      `json:"bound_audiences"`
-	BoundSubject                string                        `json:"bound_subject"`
-	BoundCIDRs                  []*sockaddr.SockAddrMarshaler `json:"bound_cidrs"`
-	UserClaim                   string                        `json:"user_claim"`
-	GroupsClaim                 string                        `json:"groups_claim"`
-	GroupsClaimDelimiterPattern string                        `json:"groups_claim_delimiter_pattern"`
+	BoundAudiences      []string                      `json:"bound_audiences"`
+	BoundSubject        string                        `json:"bound_subject"`
+	BoundClaims         map[string]interface{}        `json:"bound_claims"`
+	ClaimMappings       map[string]string             `json:"claim_mappings"`
+	BoundCIDRs          []*sockaddr.SockAddrMarshaler `json:"bound_cidrs"`
+	UserClaim           string                        `json:"user_claim"`
+	GroupsClaim         string                        `json:"groups_claim"`
+	OIDCScopes          []string                      `json:"oidc_scopes"`
+	AllowedRedirectURIs []string                      `json:"allowed_redirect_uris"`
 }
 
 // role takes a storage backend and the name and returns the role's storage
@@ -182,17 +226,20 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 	// Create a map of data to be returned
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"policies":                       role.Policies,
-			"num_uses":                       role.NumUses,
-			"period":                         int64(role.Period.Seconds()),
-			"ttl":                            int64(role.TTL.Seconds()),
-			"max_ttl":                        int64(role.MaxTTL.Seconds()),
-			"bound_audiences":                role.BoundAudiences,
-			"bound_subject":                  role.BoundSubject,
-			"bound_cidrs":                    role.BoundCIDRs,
-			"user_claim":                     role.UserClaim,
-			"groups_claim":                   role.GroupsClaim,
-			"groups_claim_delimiter_pattern": role.GroupsClaimDelimiterPattern,
+			"role_type":             role.RoleType,
+			"policies":              role.Policies,
+			"num_uses":              role.NumUses,
+			"period":                int64(role.Period.Seconds()),
+			"ttl":                   int64(role.TTL.Seconds()),
+			"max_ttl":               int64(role.MaxTTL.Seconds()),
+			"bound_audiences":       role.BoundAudiences,
+			"bound_subject":         role.BoundSubject,
+			"bound_cidrs":           role.BoundCIDRs,
+			"bound_claims":          role.BoundClaims,
+			"claim_mappings":        role.ClaimMappings,
+			"user_claim":            role.UserClaim,
+			"groups_claim":          role.GroupsClaim,
+			"allowed_redirect_uris": role.AllowedRedirectURIs,
 		},
 	}
 
@@ -235,6 +282,15 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		}
 		role = new(jwtRole)
 	}
+
+	roleType := data.Get("role_type").(string)
+	if roleType == "" {
+		roleType = "oidc"
+	}
+	if roleType != "jwt" && roleType != "oidc" {
+		return logical.ErrorResponse("invalid 'role_type': %s", roleType), nil
+	}
+	role.RoleType = roleType
 
 	if policiesRaw, ok := data.GetOk("policies"); ok {
 		role.Policies = policyutil.ParsePolicies(policiesRaw)
@@ -287,6 +343,29 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		role.BoundCIDRs = parsedCIDRs
 	}
 
+	if boundClaimsRaw, ok := data.GetOk("bound_claims"); ok {
+		role.BoundClaims = boundClaimsRaw.(map[string]interface{})
+	}
+
+	if claimMappingsRaw, ok := data.GetOk("claim_mappings"); ok {
+		claimMappings := claimMappingsRaw.(map[string]string)
+
+		// sanity check mappings for duplicates and collision with reserved names
+		targets := make(map[string]bool)
+		for _, metadataKey := range claimMappings {
+			if strutil.StrListContains(reservedMetadata, metadataKey) {
+				return logical.ErrorResponse("metadata key '%s' is reserved and may not be a mapping destination", metadataKey), nil
+			}
+
+			if targets[metadataKey] {
+				return logical.ErrorResponse("multiple keys are mapped to metadata key '%s'", metadataKey), nil
+			}
+			targets[metadataKey] = true
+		}
+
+		role.ClaimMappings = claimMappings
+	}
+
 	if userClaim, ok := data.GetOk("user_claim"); ok {
 		role.UserClaim = userClaim.(string)
 	}
@@ -298,21 +377,24 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		role.GroupsClaim = groupsClaim.(string)
 	}
 
-	if groupsClaimDelimiterPattern, ok := data.GetOk("groups_claim_delimiter_pattern"); ok {
-		role.GroupsClaimDelimiterPattern = groupsClaimDelimiterPattern.(string)
+	if oidcScopes, ok := data.GetOk("oidc_scopes"); ok {
+		role.OIDCScopes = oidcScopes.([]string)
 	}
 
-	// Validate claim/delims
-	if role.GroupsClaim != "" {
-		if _, err := parseClaimWithDelimiters(role.GroupsClaim, role.GroupsClaimDelimiterPattern); err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("error validating delimiters for groups claim: {{err}}", err).Error()), nil
+	allowedRedirectURIs := data.Get("allowed_redirect_uris").([]string)
+	if roleType == "oidc" && len(allowedRedirectURIs) == 0 {
+		return logical.ErrorResponse("'allowed_redirect_uris' must be set"), nil
+	}
+	role.AllowedRedirectURIs = allowedRedirectURIs
+
+	// OIDC verifcation will enforce that the audience match the configured client_id.
+	// For other methods, require at least one bound constraint.
+	if roleType != "oidc" {
+		if len(role.BoundAudiences) == 0 &&
+			len(role.BoundCIDRs) == 0 &&
+			role.BoundSubject == "" {
+			return logical.ErrorResponse("must have at least one bound constraint when creating/updating a role"), nil
 		}
-	}
-
-	if len(role.BoundAudiences) == 0 &&
-		len(role.BoundCIDRs) == 0 &&
-		role.BoundSubject == "" {
-		return logical.ErrorResponse("must have at least one bound constraint when creating/updating a role"), nil
 	}
 
 	// Check that the TTL value provided is less than the MaxTTL.
@@ -338,32 +420,6 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 	}
 
 	return resp, nil
-}
-
-// parseClaimWithDelimiters parses a given claim string and ensures that we can
-// separate it out into a "map path"
-func parseClaimWithDelimiters(claim, delimiters string) ([]string, error) {
-	if delimiters == "" {
-		return []string{claim}, nil
-	}
-	var ret []string
-	for _, runeVal := range delimiters {
-		idx := strings.IndexRune(claim, runeVal)
-		switch idx {
-		case -1:
-			return nil, fmt.Errorf("could not find instance of %q delimiter in claim", string(runeVal))
-		case 0:
-			return nil, fmt.Errorf("instance of %q delimiter in claim is at beginning of claim string", string(runeVal))
-		case len(claim) - 1:
-			return nil, fmt.Errorf("instance of %q delimiter in claim is at end of claim string", string(runeVal))
-		default:
-			ret = append(ret, claim[:idx])
-			claim = claim[idx+1:]
-		}
-	}
-	ret = append(ret, claim)
-
-	return ret, nil
 }
 
 // roleStorageEntry stores all the options that are set on an role

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_role.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/path_role.go
@@ -7,25 +7,19 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/errwrap"
 	sockaddr "github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/policyutil"
-	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-var reservedMetadata = []string{"role"}
-
 func pathRoleList(b *jwtAuthBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: "role/?",
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ListOperation: &framework.PathOperation{
-				Callback:    b.pathRoleList,
-				Summary:     strings.TrimSpace(roleHelp["role-list"][0]),
-				Description: strings.TrimSpace(roleHelp["role-list"][1]),
-			},
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathRoleList,
 		},
 		HelpSynopsis:    strings.TrimSpace(roleHelp["role-list"][0]),
 		HelpDescription: strings.TrimSpace(roleHelp["role-list"][1]),
@@ -40,10 +34,6 @@ func pathRole(b *jwtAuthBackend) *framework.Path {
 			"name": {
 				Type:        framework.TypeLowerCaseString,
 				Description: "Name of the role.",
-			},
-			"role_type": {
-				Type:        framework.TypeString,
-				Description: "Type of the role, either 'jwt' or 'oidc'.",
 			},
 			"policies": {
 				Type:        framework.TypeCommaStringSlice,
@@ -78,14 +68,6 @@ TTL will be set to the value of this parameter.`,
 				Type:        framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of 'aud' claims that are valid for login; any match is sufficient`,
 			},
-			"bound_claims": {
-				Type:        framework.TypeMap,
-				Description: `Map of claims/values which must match for login`,
-			},
-			"claim_mappings": {
-				Type:        framework.TypeKVPairs,
-				Description: `Mappings of claims (key) that will be copied to a metadata field (value)`,
-			},
 			"user_claim": {
 				Type:        framework.TypeString,
 				Description: `The claim to use for the Identity entity alias name`,
@@ -94,43 +76,22 @@ TTL will be set to the value of this parameter.`,
 				Type:        framework.TypeString,
 				Description: `The claim to use for the Identity group alias names`,
 			},
+			"groups_claim_delimiter_pattern": {
+				Type:        framework.TypeString,
+				Description: `A pattern of delimiters used to allow the groups_claim to live outside of the top-level JWT structure. For instance, a "groups_claim" of "meta/user.name/groups" with this field set to "//" will expect nested structures named "meta", "user.name", and "groups". If this field was set to "/./" the groups information would expect to be via nested structures of "meta", "user", "name", and "groups".`,
+			},
 			"bound_cidrs": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of IP CIDRS that are allowed to 
 authenticate against this role`,
 			},
-			"oidc_scopes": {
-				Type:        framework.TypeCommaStringSlice,
-				Description: `Comma-separated list of OIDC scopes`,
-			},
-			"allowed_redirect_uris": {
-				Type:        framework.TypeCommaStringSlice,
-				Description: `Comma-separated list of allowed values for redirect_uri`,
-			},
 		},
 		ExistenceCheck: b.pathRoleExistenceCheck,
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.pathRoleRead,
-				Summary:  "Read an existing role.",
-			},
-
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback:    b.pathRoleCreateUpdate,
-				Summary:     strings.TrimSpace(roleHelp["role"][0]),
-				Description: strings.TrimSpace(roleHelp["role"][1]),
-			},
-
-			logical.CreateOperation: &framework.PathOperation{
-				Callback:    b.pathRoleCreateUpdate,
-				Summary:     strings.TrimSpace(roleHelp["role"][0]),
-				Description: strings.TrimSpace(roleHelp["role"][1]),
-			},
-
-			logical.DeleteOperation: &framework.PathOperation{
-				Callback: b.pathRoleDelete,
-				Summary:  "Delete an existing role.",
-			},
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.CreateOperation: b.pathRoleCreateUpdate,
+			logical.UpdateOperation: b.pathRoleCreateUpdate,
+			logical.ReadOperation:   b.pathRoleRead,
+			logical.DeleteOperation: b.pathRoleDelete,
 		},
 		HelpSynopsis:    strings.TrimSpace(roleHelp["role"][0]),
 		HelpDescription: strings.TrimSpace(roleHelp["role"][1]),
@@ -138,8 +99,6 @@ authenticate against this role`,
 }
 
 type jwtRole struct {
-	RoleType string `json:"role_type"`
-
 	// Policies that are to be required by the token to access this role
 	Policies []string `json:"policies"`
 
@@ -160,15 +119,12 @@ type jwtRole struct {
 	Period time.Duration `json:"period"`
 
 	// Role binding properties
-	BoundAudiences      []string                      `json:"bound_audiences"`
-	BoundSubject        string                        `json:"bound_subject"`
-	BoundClaims         map[string]interface{}        `json:"bound_claims"`
-	ClaimMappings       map[string]string             `json:"claim_mappings"`
-	BoundCIDRs          []*sockaddr.SockAddrMarshaler `json:"bound_cidrs"`
-	UserClaim           string                        `json:"user_claim"`
-	GroupsClaim         string                        `json:"groups_claim"`
-	OIDCScopes          []string                      `json:"oidc_scopes"`
-	AllowedRedirectURIs []string                      `json:"allowed_redirect_uris"`
+	BoundAudiences              []string                      `json:"bound_audiences"`
+	BoundSubject                string                        `json:"bound_subject"`
+	BoundCIDRs                  []*sockaddr.SockAddrMarshaler `json:"bound_cidrs"`
+	UserClaim                   string                        `json:"user_claim"`
+	GroupsClaim                 string                        `json:"groups_claim"`
+	GroupsClaimDelimiterPattern string                        `json:"groups_claim_delimiter_pattern"`
 }
 
 // role takes a storage backend and the name and returns the role's storage
@@ -226,20 +182,17 @@ func (b *jwtAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 	// Create a map of data to be returned
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"role_type":             role.RoleType,
-			"policies":              role.Policies,
-			"num_uses":              role.NumUses,
-			"period":                int64(role.Period.Seconds()),
-			"ttl":                   int64(role.TTL.Seconds()),
-			"max_ttl":               int64(role.MaxTTL.Seconds()),
-			"bound_audiences":       role.BoundAudiences,
-			"bound_subject":         role.BoundSubject,
-			"bound_cidrs":           role.BoundCIDRs,
-			"bound_claims":          role.BoundClaims,
-			"claim_mappings":        role.ClaimMappings,
-			"user_claim":            role.UserClaim,
-			"groups_claim":          role.GroupsClaim,
-			"allowed_redirect_uris": role.AllowedRedirectURIs,
+			"policies":                       role.Policies,
+			"num_uses":                       role.NumUses,
+			"period":                         int64(role.Period.Seconds()),
+			"ttl":                            int64(role.TTL.Seconds()),
+			"max_ttl":                        int64(role.MaxTTL.Seconds()),
+			"bound_audiences":                role.BoundAudiences,
+			"bound_subject":                  role.BoundSubject,
+			"bound_cidrs":                    role.BoundCIDRs,
+			"user_claim":                     role.UserClaim,
+			"groups_claim":                   role.GroupsClaim,
+			"groups_claim_delimiter_pattern": role.GroupsClaimDelimiterPattern,
 		},
 	}
 
@@ -282,15 +235,6 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		}
 		role = new(jwtRole)
 	}
-
-	roleType := data.Get("role_type").(string)
-	if roleType == "" {
-		roleType = "oidc"
-	}
-	if roleType != "jwt" && roleType != "oidc" {
-		return logical.ErrorResponse("invalid 'role_type': %s", roleType), nil
-	}
-	role.RoleType = roleType
 
 	if policiesRaw, ok := data.GetOk("policies"); ok {
 		role.Policies = policyutil.ParsePolicies(policiesRaw)
@@ -343,29 +287,6 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		role.BoundCIDRs = parsedCIDRs
 	}
 
-	if boundClaimsRaw, ok := data.GetOk("bound_claims"); ok {
-		role.BoundClaims = boundClaimsRaw.(map[string]interface{})
-	}
-
-	if claimMappingsRaw, ok := data.GetOk("claim_mappings"); ok {
-		claimMappings := claimMappingsRaw.(map[string]string)
-
-		// sanity check mappings for duplicates and collision with reserved names
-		targets := make(map[string]bool)
-		for _, metadataKey := range claimMappings {
-			if strutil.StrListContains(reservedMetadata, metadataKey) {
-				return logical.ErrorResponse("metadata key '%s' is reserved and may not be a mapping destination", metadataKey), nil
-			}
-
-			if targets[metadataKey] {
-				return logical.ErrorResponse("multiple keys are mapped to metadata key '%s'", metadataKey), nil
-			}
-			targets[metadataKey] = true
-		}
-
-		role.ClaimMappings = claimMappings
-	}
-
 	if userClaim, ok := data.GetOk("user_claim"); ok {
 		role.UserClaim = userClaim.(string)
 	}
@@ -377,24 +298,21 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 		role.GroupsClaim = groupsClaim.(string)
 	}
 
-	if oidcScopes, ok := data.GetOk("oidc_scopes"); ok {
-		role.OIDCScopes = oidcScopes.([]string)
+	if groupsClaimDelimiterPattern, ok := data.GetOk("groups_claim_delimiter_pattern"); ok {
+		role.GroupsClaimDelimiterPattern = groupsClaimDelimiterPattern.(string)
 	}
 
-	allowedRedirectURIs := data.Get("allowed_redirect_uris").([]string)
-	if roleType == "oidc" && len(allowedRedirectURIs) == 0 {
-		return logical.ErrorResponse("'allowed_redirect_uris' must be set"), nil
-	}
-	role.AllowedRedirectURIs = allowedRedirectURIs
-
-	// OIDC verifcation will enforce that the audience match the configured client_id.
-	// For other methods, require at least one bound constraint.
-	if roleType != "oidc" {
-		if len(role.BoundAudiences) == 0 &&
-			len(role.BoundCIDRs) == 0 &&
-			role.BoundSubject == "" {
-			return logical.ErrorResponse("must have at least one bound constraint when creating/updating a role"), nil
+	// Validate claim/delims
+	if role.GroupsClaim != "" {
+		if _, err := parseClaimWithDelimiters(role.GroupsClaim, role.GroupsClaimDelimiterPattern); err != nil {
+			return logical.ErrorResponse(errwrap.Wrapf("error validating delimiters for groups claim: {{err}}", err).Error()), nil
 		}
+	}
+
+	if len(role.BoundAudiences) == 0 &&
+		len(role.BoundCIDRs) == 0 &&
+		role.BoundSubject == "" {
+		return logical.ErrorResponse("must have at least one bound constraint when creating/updating a role"), nil
 	}
 
 	// Check that the TTL value provided is less than the MaxTTL.
@@ -420,6 +338,32 @@ func (b *jwtAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.
 	}
 
 	return resp, nil
+}
+
+// parseClaimWithDelimiters parses a given claim string and ensures that we can
+// separate it out into a "map path"
+func parseClaimWithDelimiters(claim, delimiters string) ([]string, error) {
+	if delimiters == "" {
+		return []string{claim}, nil
+	}
+	var ret []string
+	for _, runeVal := range delimiters {
+		idx := strings.IndexRune(claim, runeVal)
+		switch idx {
+		case -1:
+			return nil, fmt.Errorf("could not find instance of %q delimiter in claim", string(runeVal))
+		case 0:
+			return nil, fmt.Errorf("instance of %q delimiter in claim is at beginning of claim string", string(runeVal))
+		case len(claim) - 1:
+			return nil, fmt.Errorf("instance of %q delimiter in claim is at end of claim string", string(runeVal))
+		default:
+			ret = append(ret, claim[:idx])
+			claim = claim[idx+1:]
+		}
+	}
+	ret = append(ret, claim)
+
+	return ret, nil
 }
 
 // roleStorageEntry stores all the options that are set on an role

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -570,6 +570,12 @@
 			"versionExact": "v0.11.1"
 		},
 		{
+			"checksumSHA1": "9OCfD9jnPcOy6y9j+iyNon6tiZk=",
+			"path": "github.com/hashicorp/vault-plugin-auth-jwt",
+			"revision": "a61556be673093888dc8119ee7c16ee964419f25",
+			"revisionTime": "2019-02-14T18:54:57Z"
+		},
+		{
 			"checksumSHA1": "+B4wuJNerIUKNAVzld7CmMaNW5A=",
 			"path": "github.com/hashicorp/vault/api",
 			"revision": "8575f8fedcf8f5a6eb2b4701cb527b99574b5286",
@@ -648,6 +654,12 @@
 			"path": "github.com/mitchellh/mapstructure",
 			"revision": "53818660ed4955e899c0bcafa97299a388bd7c8e",
 			"revisionTime": "2017-03-07T20:11:23Z"
+		},
+		{
+			"checksumSHA1": "31atAEqGt+z8hZgyVZZokEeM6dM=",
+			"path": "github.com/mitchellh/pointerstructure",
+			"revision": "f2329fcfa9e280bdb5a3f2544aec815a508ad72f",
+			"revisionTime": "2017-02-05T20:42:03Z"
 		},
 		{
 			"checksumSHA1": "vBpuqNfSTZcAR/0tP8tNYacySGs=",
@@ -858,6 +870,10 @@
 			"revisionTime": "2017-04-03T20:32:25Z",
 			"version": "v1.6.1",
 			"versionExact": "v1.6.1"
+		},
+		{
+			"path": "vendor/github.com/hashicorp/vault-plugin-auth-jwt",
+			"revision": ""
 		}
 	],
 	"rootPath": "github.com/terraform-providers/terraform-provider-vault"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -656,12 +656,6 @@
 			"revisionTime": "2017-03-07T20:11:23Z"
 		},
 		{
-			"checksumSHA1": "31atAEqGt+z8hZgyVZZokEeM6dM=",
-			"path": "github.com/mitchellh/pointerstructure",
-			"revision": "f2329fcfa9e280bdb5a3f2544aec815a508ad72f",
-			"revisionTime": "2017-02-05T20:42:03Z"
-		},
-		{
 			"checksumSHA1": "vBpuqNfSTZcAR/0tP8tNYacySGs=",
 			"path": "github.com/mitchellh/reflectwalk",
 			"revision": "92573fe8d000a145bfebc03a16bc22b34945867f",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -570,10 +570,10 @@
 			"versionExact": "v0.11.1"
 		},
 		{
-			"checksumSHA1": "9OCfD9jnPcOy6y9j+iyNon6tiZk=",
+			"checksumSHA1": "6B+p22t7wBR52hepGYd3t1JnDME=",
 			"path": "github.com/hashicorp/vault-plugin-auth-jwt",
-			"revision": "a61556be673093888dc8119ee7c16ee964419f25",
-			"revisionTime": "2019-02-14T18:54:57Z"
+			"revision": "a608a5ad1c249797e266cb8fcb4eac336aa72bef",
+			"revisionTime": "2019-01-28T23:42:21Z"
 		},
 		{
 			"checksumSHA1": "+B4wuJNerIUKNAVzld7CmMaNW5A=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -870,10 +870,6 @@
 			"revisionTime": "2017-04-03T20:32:25Z",
 			"version": "v1.6.1",
 			"versionExact": "v1.6.1"
-		},
-		{
-			"path": "vendor/github.com/hashicorp/vault-plugin-auth-jwt",
-			"revision": ""
 		}
 	],
 	"rootPath": "github.com/terraform-providers/terraform-provider-vault"

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -69,6 +69,13 @@ The following arguments are supported:
   for the Identity group aliases created due to a successful login. The claim
   value must be a list of strings.
 
+* `groups_claim_delimiter_pattern` - (Optional) A pattern of delimiters 
+  used to allow the groups_claim to live outside of the top-level JWT structure. 
+  For instance, a groups_claim of meta/user.name/groups with this field 
+  set to // will expect nested structures named meta, user.name, and groups. 
+  If this field was set to /./ the groups information would expect to be 
+  via nested structures of meta, user, name, and groups.
+
 * `backend` - (Optional) The unique name of the auth backend to configure.
   Defaults to `jwt`.
 


### PR DESCRIPTION
Add support for groups_claim_delimiter_pattern parameters within vault_jwt_auth_backend_role resource.
Sync version of vendor/github.com/hashicorp/vault-plugin-auth-jwt with https://github.com/hashicorp/vault-plugin-auth-jwt.