### PR TITLE
Parent namespace

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -85,6 +85,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
 				Description: "The namespace to use. Available only for Vault Enterprise",
 			},
+			"token-namespace": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The namespace where the provided vault token was created, if different from the value in 'namespace'",
+			},
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -221,9 +226,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, errors.New("no vault token found")
 	}
 
-	namespace := d.Get("namespace").(string)
-	if namespace != "" {
-		client.SetNamespace(namespace)
+	tokenNamespace := d.Get("token-namespace").(string)
+	if tokenNamespace != "" {
+		client.SetNamespace(tokenNamespace)
+	} else {
+		namespace := d.Get("namespace").(string)
+		if namespace != "" {
+			client.SetNamespace(namespace)
+		}
 	}
 
 	// In order to enforce our relatively-short lease TTL, we derive a

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -220,6 +220,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if token == "" {
 		return nil, errors.New("no vault token found")
 	}
+	
+	namespace := d.Get("namespace").(string)
+	if namespace != "" {
+		client.SetNamespace(namespace)
+	}
 
 	// In order to enforce our relatively-short lease TTL, we derive a
 	// temporary child token that inherits all of the policies of the
@@ -250,11 +255,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	policies := childTokenLease.Auth.Policies
 
 	log.Printf("[INFO] Using Vault token with the following policies: %s", strings.Join(policies, ", "))
-
-	namespace := d.Get("namespace").(string)
-	if namespace != "" {
-		client.SetNamespace(namespace)
-	}
 
 	client.SetToken(childToken)
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -220,7 +220,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if token == "" {
 		return nil, errors.New("no vault token found")
 	}
-	
+
 	namespace := d.Get("namespace").(string)
 	if namespace != "" {
 		client.SetNamespace(namespace)


### PR DESCRIPTION
### Description

Add configuration option to provider when the used Vault token was originally created in a different namespace than the namespace provided in the 'namespace' configuration option
This is required for the child token to be created in the same namespace as the parent token (which is required for the correct policies to be used by the child token)