### PR TITLE
Fix some issues with `vault_identity_group` 

### DIFF
--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -45,7 +45,7 @@ func identityGroupResource() *schema.Resource {
 			},
 
 			"policies": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -54,7 +54,7 @@ func identityGroupResource() *schema.Resource {
 			},
 
 			"member_group_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -63,7 +63,7 @@ func identityGroupResource() *schema.Resource {
 			},
 
 			"member_entity_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -82,15 +82,15 @@ func identityGroupResource() *schema.Resource {
 
 func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
 	if policies, ok := d.GetOk("policies"); ok {
-		data["policies"] = policies
+		data["policies"] = policies.(*schema.Set).List()
 	}
 
 	if memberEntityIDs, ok := d.GetOk("member_entity_ids"); ok {
-		data["member_entity_ids"] = memberEntityIDs
+		data["member_entity_ids"] = memberEntityIDs.(*schema.Set).List()
 	}
 
 	if memberGroupIDs, ok := d.GetOk("member_group_ids"); ok {
-		data["member_group_ids"] = memberGroupIDs
+		data["member_group_ids"] = memberGroupIDs.(*schema.Set).List()
 	}
 
 	if metadata, ok := d.GetOk("metadata"); ok {

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -65,6 +65,7 @@ func identityGroupResource() *schema.Resource {
 			"member_entity_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -93,10 +94,7 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 		data["policies"] = policies.(*schema.Set).List()
 	}
 
-	if memberEntityIDs, ok := d.GetOk("member_entity_ids"); ok {
-		if d.Get("type").(string) == "external" {
-			return fmt.Errorf("cannot set 'member_entity_ids' on external groups")
-		}
+	if memberEntityIDs, ok := d.GetOk("member_entity_ids"); ok && d.Get("type").(string) == "internal" {
 		data["member_entity_ids"] = memberEntityIDs.(*schema.Set).List()
 	}
 

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -170,7 +170,7 @@ func identityGroupRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	for _, k := range []string{"name", "type", "metadata", "member_entity_ids", "member_group_ids"} {
+	for _, k := range []string{"name", "type", "metadata", "policies", "member_entity_ids", "member_group_ids"} {
 		d.Set(k, resp.Data[k])
 	}
 	return nil

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -69,6 +69,14 @@ func identityGroupResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Description: "Entity IDs to be assigned as group members.",
+				// Suppress the diff if group type is "external" because we cannot manage
+				// group members
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("type").(string) == "external" {
+						return true
+					}
+					return false
+				},
 			},
 
 			"id": {
@@ -87,7 +95,7 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 
 	if memberEntityIDs, ok := d.GetOk("member_entity_ids"); ok {
 		if d.Get("type").(string) == "external" {
-			return fmt.Errorf("cannot set `member_entity_ids` on external groups")
+			return fmt.Errorf("cannot set 'member_entity_ids' on external groups")
 		}
 		data["member_entity_ids"] = memberEntityIDs.(*schema.Set).List()
 	}

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -29,13 +29,13 @@ func identityGroupAliasResource() *schema.Resource {
 			"mount_accessor": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Mount accessor to which this alias belongs toMount accessor to which this alias belongs to.",
+				Description: "Mount accessor to which this alias belongs to.",
 			},
 
 			"canonical_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "ID of the group to which this is an alias.uType of the group, internal or external. Defaults to internal.",
+				Description: "ID of the group to which this is an alias.",
 			},
 
 			"id": {

--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -45,8 +46,9 @@ func TestAccIdentityGroupUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccIdentityGroupCheckAttrs(group),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "metadata.version", "2"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.0", "dev"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.1", "test"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "2"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.1785148924", "test"),
 				),
 			},
 		},
@@ -139,10 +141,18 @@ func testAccIdentityGroupCheckAttrs(group string) resource.TestCheckFunc {
 					if count != len(apiData) {
 						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
 					}
+
 					for i := 0; i < count; i++ {
-						stateData := instanceState.Attributes[stateAttr+"."+strconv.Itoa(i)]
-						if stateData != apiData[i] {
-							return fmt.Errorf("expected item %d of %s (%s in state) of %q to be %q, got %q", i, apiAttr, stateAttr, path, stateData, apiData[i])
+						found := false
+						for stateKey, stateValue := range instanceState.Attributes {
+							if strings.HasPrefix(stateKey, stateAttr) {
+								if apiData[i] == stateValue {
+									found = true
+								}
+							}
+						}
+						if !found {
+							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
 						}
 					}
 					match = true


### PR DESCRIPTION
- `policies` were not updated properly from reading the resource from Vault
- Update fields `policies`, `member_group_ids`, and `member_entity_ids` to be of `schema.TypeSet` instead. These lists should contain unique items and the order should not matter when calculating the diff
- Handle `member_entity_ids` for external groups (otherwise we get errors like `error updating IdentityGroup "a6c92cfa-d0b0-8d61-7122-a59cf1123a45": cannot set 'member_entity_ids' on external groups`)

Other fixes:

-  Fix typo in `vault_identity_group_alias`

Can't really write tests for the diff suppression without "logging in" with a real auth backend. It works in my local tests, though.

Before:

```
  ~ vault_identity_group.admins
      member_entity_ids.#: "1" => "0"
      member_entity_ids.0: "2b83bd73-954c-7b4d-b102-bec997008baf" => ""

  ~ vault_identity_group.users
      member_entity_ids.#: "1" => "0"
      member_entity_ids.0: "2b83bd73-954c-7b4d-b102-bec997008baf" => ""

```
After:

```
No changes. Infrastructure is up-to-date.

```