### PR TITLE
Allow people to skip leasing temporary Vault tokens

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -64,13 +64,13 @@ func Provider() terraform.ResourceProvider {
 			"skip_tls_verify": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				DefaultFunc: schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", ""),
 				Description: "Set this to true only if the target Vault server is an insecure development instance.",
 			},
 			"skip_leased_token": {
 				Type:          schema.TypeBool,
 				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", ""),
+				Default:       false,
 				Description:   "Set this to true to skip creating a temporary leased token.",
 				ConflictsWith: []string{"max_lease_ttl_seconds"},
 			},

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -111,17 +111,13 @@ variables in order to keep credential information out of the configuration.
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
-* `skip_leased_token` - (Optional) Set this to `true` to disable creating a
-  leased Vault token when the provider is configured. Defaults to `false`.
-  **NOTE:** This should only be used it Vault token rotation/leasing is being
-  handled before Terraform runs.
-
 * `max_lease_ttl_seconds` - (Optional) Used as the duration for the
   intermediate Vault token Terraform issues itself, which in turn limits
   the duration of secret leases issued by Vault. Defaults to 20 minutes
   and may be set via the `TERRAFORM_VAULT_MAX_TTL` environment variable.
   See the section above on *Using Vault credentials in Terraform configuration*
-  for the implications of this setting.
+  for the implications of this setting. Set to `0` to skip using a leased
+  token.
 
 * `namespace` - (Optional) Set the namespace to use. May be set via the
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -111,6 +111,11 @@ variables in order to keep credential information out of the configuration.
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
+* `skip_leased_token` - (Optional) Set this to `true` to disable creating a
+  leased Vault token when the provider is configured. Defaults to `false`.
+  **NOTE:** This should only be used it Vault token rotation/leasing is being
+  handled before Terraform runs.
+
 * `max_lease_ttl_seconds` - (Optional) Used as the duration for the
   intermediate Vault token Terraform issues itself, which in turn limits
   the duration of secret leases issued by Vault. Defaults to 20 minutes


### PR DESCRIPTION
We don't currently allow teams to manage token rotation or token leasing. It's handled for them before Terraform runs. This allows people to turn leasing off when leasing/rotation is handled outside of Terraform before it runs.