### PR TITLE
Add `vault_gcp_secret_roleset`

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -125,6 +125,7 @@ func Provider() terraform.ResourceProvider {
 			"vault_gcp_auth_backend":                             gcpAuthBackendResource(),
 			"vault_gcp_auth_backend_role":                        gcpAuthBackendRoleResource(),
 			"vault_gcp_secret_backend":                           gcpSecretBackendResource(),
+			"vault_gcp_secret_roleset":                           gcpSecretRolesetResource(),
 			"vault_cert_auth_backend_role":                       certAuthBackendRoleResource(),
 			"vault_generic_secret":                               genericSecretResource(),
 			"vault_jwt_auth_backend":                             jwtAuthBackendResource(),

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -2,13 +2,14 @@ package vault
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/vault/command/config"
-	"github.com/mitchellh/go-homedir"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/vault/command/config"
+	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -75,6 +76,21 @@ func getTestAWSCreds(t *testing.T) (string, string) {
 		t.Skip("AWS_SECRET_ACCESS_KEY not set")
 	}
 	return accessKey, secretKey
+}
+
+func getTestGCPCreds(t *testing.T) (string, string) {
+	credentials := os.Getenv("GOOGLE_CREDENTIALS")
+	project := os.Getenv("GOOGLE_PROJECT")
+
+	if credentials == "" {
+		t.Skip("GOOGLE_CREDENTIALS not set")
+	}
+
+	if project == "" {
+		t.Skip("GOOGLE_PROJECT not set")
+	}
+
+	return credentials, project
 }
 
 func getTestRMQCreds(t *testing.T) (string, string, string) {

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -162,7 +162,7 @@ func gcpSecretRolesetRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", k, path)
 		}
 		if err := d.Set(k, v); err != nil {
-			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", k, path)
+			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q: %q", k, path, err)
 		}
 	}
 
@@ -174,7 +174,7 @@ func gcpSecretRolesetRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "project", path)
 	}
 
-	if err := d.Set("binding", gcpSecretRolesetFlattenBinding(resp.Data["bindings"], d)); err != nil {
+	if err := d.Set("binding", gcpSecretRolesetFlattenBinding(resp.Data["bindings"])); err != nil {
 		return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "binding", path)
 	}
 
@@ -213,7 +213,7 @@ func gcpSecretRolesetDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func gcpSecretRolesetFlattenBinding(v interface{}, d *schema.ResourceData) interface{} {
+func gcpSecretRolesetFlattenBinding(v interface{}) interface{} {
 	if v == nil {
 		return v
 	}

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -1,0 +1,349 @@
+package vault
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	gcpSecretRolesetBackendFromPathRegex = regexp.MustCompile("^(.+)/roleset/.+$")
+	gcpSecretRolesetNameFromPathRegex    = regexp.MustCompile("^.+/roleset/(.+)$")
+)
+
+type Binding struct {
+	Resource string
+	Roles    []string
+}
+
+func gcpSecretRolesetResource() *schema.Resource {
+	return &schema.Resource{
+		Create: gcpSecretRolesetCreate,
+		Read:   gcpSecretRolesetRead,
+		Update: gcpSecretRolesetUpdate,
+		Delete: gcpSecretRolesetDelete,
+		Exists: gcpSecretRolesetExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Path where the GCP secrets engine is mounted.",
+				ForceNew:    true,
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"roleset": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the RoleSet to create",
+				ForceNew:    true,
+			},
+			"secret_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: "Type of secret generated for this role set. Defaults to `access_token`. Accepted values: `access_token`, `service_account_key`",
+			},
+			"project": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the GCP project that this roleset's service account will belong to. ",
+			},
+			"token_scopes": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "List of OAuth scopes to assign to `access_token` secrets generated under this role set (`access_token` role sets only) ",
+			},
+			"binding": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Set:      gcpSecretRolesetBindingHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Resource name",
+						},
+						"roles": {
+							Type:        schema.TypeSet,
+							Required:    true,
+							Description: "List of roles to apply to the resource",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"service_account_email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Email of the service account created by Vault for this Roleset",
+			},
+		},
+	}
+}
+
+func gcpSecretRolesetCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+	roleset := d.Get("roleset").(string)
+
+	path := gcpSecretRolesetPath(backend, roleset)
+
+	log.Printf("[DEBUG] Writing GCP Secrets backend roleset %q", path)
+
+	data := map[string]interface{}{}
+	gcpSecretRolesetUpdateFields(d, data)
+	d.SetId(path)
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error writing GCP Secrets backend roleset %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Wrote GCP Secrets backend rolese %q: %s", path, err)
+
+	return gcpSecretRolesetRead(d, meta)
+}
+
+func gcpSecretRolesetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	backend, err := gcpSecretRolesetBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for GCP secrets backend roleset: %s", path, err)
+	}
+
+	roleset, err := gcpSecretRoleSetdRolesetNameFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for GCP Secrets backend roleset: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading GCP Secrets backend roleset %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading GCP Secrets backend roleset %q: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Read GCP Secrets backend roleset %q", path)
+	if resp == nil {
+		log.Printf("[WARN] GCP Secrets backend roleset %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("backend", backend)
+	d.Set("roleset", roleset)
+
+	for _, k := range []string{"secret_type", "token_scopes", "service_account_email"} {
+		v, ok := resp.Data[k]
+		if !ok {
+			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", k, path)
+		}
+		if err := d.Set(k, v); err != nil {
+			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", k, path)
+		}
+	}
+
+	v, ok := resp.Data["service_account_project"]
+	if !ok {
+		return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "project", path)
+	}
+	if err := d.Set("project", v); err != nil {
+		return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "project", path)
+	}
+
+	if err := d.Set("binding", gcpSecretRolesetFlattenBinding(resp.Data["bindings"], d)); err != nil {
+		return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "binding", path)
+	}
+
+	return nil
+}
+
+func gcpSecretRolesetUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	data := map[string]interface{}{}
+	gcpSecretRolesetUpdateFields(d, data)
+
+	log.Printf("[DEBUG] Updating GCP Secrets backend roleset %q", path)
+
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("Error updating GCP Secrets backend roleset %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated GCP Secrets backend roleset %q", path)
+
+	return gcpSecretRolesetRead(d, meta)
+}
+
+func gcpSecretRolesetDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting GCP secrets backend roleset %q", path)
+	_, err := client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("Error deleting GCP secrets backend roleset %q", path)
+	}
+	log.Printf("[DEBUG] Deleted GCP secrets backend roleset %q", path)
+
+	return nil
+}
+
+func gcpSecretRolesetFlattenBinding(v interface{}, d *schema.ResourceData) interface{} {
+	if v == nil {
+		return v
+	}
+
+	rawBindings := v.((map[string]interface{}))
+	transformed := schema.NewSet(gcpSecretRolesetBindingHash, []interface{}{})
+	for resource, roles := range rawBindings {
+		transformed.Add(map[string]interface{}{
+			"resource": resource,
+			"roles":    schema.NewSet(schema.HashString, roles.([]interface{})),
+		})
+	}
+
+	return transformed
+}
+
+func gcpSecretRolesetUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
+	if v, ok := d.GetOk("secret_type"); ok {
+		data["secret_type"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("project"); ok {
+		data["project"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("token_scopes"); ok {
+		data["token_scopes"] = v.(*schema.Set).List()
+	}
+
+	if v, ok := d.GetOk("binding"); ok {
+		rawBindings := v.(*schema.Set).List()
+
+		bindings := make([]*Binding, len(rawBindings))
+
+		for i, binding := range rawBindings {
+			rawRoles := binding.(map[string]interface{})["roles"].(*schema.Set).List()
+			roles := make([]string, len(rawRoles))
+			for j, role := range rawRoles {
+				roles[j] = role.(string)
+			}
+
+			binding := &Binding{
+				Resource: binding.(map[string]interface{})["resource"].(string),
+				Roles:    roles,
+			}
+			bindings[i] = binding
+		}
+
+		bindingsHCL := renderBindings(bindings)
+		log.Printf("[DEBUG] Rendered GCP Secrets backend roleset bindings HCL:\n%s", bindingsHCL)
+		data["bindings"] = bindingsHCL
+	}
+}
+
+func gcpSecretRolesetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+	path := d.Id()
+	log.Printf("[DEBUG] Checking if %q exists", path)
+	secret, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("error checking if %q exists: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if %q exists", path)
+	return secret != nil, nil
+}
+
+func gcpSecretRolesetBindingHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["resource"].(string)))
+
+	// We need to make sure to sort the strings below so that we always
+	// generate the same hash code no matter what is in the set.
+	if v, ok := m["roles"]; ok {
+		vs := v.(*schema.Set).List()
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	return hashcode.String(buf.String())
+}
+
+func gcpSecretRolesetPath(backend, roleset string) string {
+	return strings.Trim(backend, "/") + "/roleset/" + strings.Trim(roleset, "/")
+}
+
+func gcpSecretRolesetBackendFromPath(path string) (string, error) {
+	if !gcpSecretRolesetBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := gcpSecretRolesetBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}
+
+func gcpSecretRoleSetdRolesetNameFromPath(path string) (string, error) {
+	if !gcpSecretRolesetNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no roleset found")
+	}
+	res := gcpSecretRolesetNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}
+
+func renderBinding(binding *Binding) string {
+	output := fmt.Sprintf("resource \"%s\" {\n", binding.Resource)
+	output = fmt.Sprintf("%s  roles = %s\n", output, policyRenderListOfStrings(binding.Roles))
+	return fmt.Sprintf("%s}\n", output)
+}
+
+func renderBindings(bindings []*Binding) string {
+	var output string
+
+	for i, binding := range bindings {
+		if i == 0 {
+			output = fmt.Sprintf("%s", renderBinding(binding))
+		} else {
+			output = fmt.Sprintf("%s\n\n%s", output, renderBinding(binding))
+		}
+	}
+
+	return output
+}

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -165,11 +165,17 @@ func gcpSecretRolesetRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	v, ok := resp.Data["service_account_project"]
+	// In https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/28, this field is changed to
+	// `project`. We handle cases where it used to be `service_account_project` for backward
+	// compatibility.
+	project, ok := resp.Data["project"]
 	if !ok {
-		return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "project", path)
+		project, ok = resp.Data["service_account_project"]
+		if !ok {
+			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "project", path)
+		}
 	}
-	if err := d.Set("project", v); err != nil {
+	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", "project", path)
 	}
 

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -158,11 +158,10 @@ func gcpSecretRolesetRead(d *schema.ResourceData, meta interface{}) error {
 
 	for _, k := range []string{"secret_type", "token_scopes", "service_account_email"} {
 		v, ok := resp.Data[k]
-		if !ok {
-			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q", k, path)
-		}
-		if err := d.Set(k, v); err != nil {
-			return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q: %q", k, path, err)
+		if ok {
+			if err := d.Set(k, v); err != nil {
+				return fmt.Errorf("error reading %s for GCP Secrets backend roleset %q: %q", k, path, err)
+			}
 		}
 	}
 
@@ -239,7 +238,7 @@ func gcpSecretRolesetUpdateFields(d *schema.ResourceData, data map[string]interf
 		data["project"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("token_scopes"); ok {
+	if v, ok := d.GetOk("token_scopes"); ok && d.Get("secret_type").(string) == "access_token" {
 		data["token_scopes"] = v.(*schema.Set).List()
 	}
 

--- a/vault/resource_gcp_secret_roleset_test.go
+++ b/vault/resource_gcp_secret_roleset_test.go
@@ -1,0 +1,222 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+// This test requires that you pass credentials for a user or service account having the IAM rights
+// listed at https://www.vaultproject.io/docs/secrets/gcp/index.html for the project you are testing
+// on. The credentials must also allow setting IAM permissions on the project being tested.
+func TestGCPSecretRoleset(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-gcp")
+	roleset := acctest.RandomWithPrefix("tf-test")
+	credentials, project := getTestGCPCreds(t)
+
+	initialRole := "roles/viewer"
+	initialConfig, initialHash := testGCPSecretRoleset_config(backend, roleset, credentials, project, initialRole)
+
+	updatedRole := "roles/browser"
+	updatedConfig, updatedHash := testGCPSecretRoleset_config(backend, roleset, credentials, project, updatedRole)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testGCPSecretRolesetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testGCPSecretRoleset_attrs(backend, roleset),
+					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "roleset", roleset),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "secret_type", "access_token"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "project", project),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.2400041053", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "binding.#", "1"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.resource", initialHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.#", initialHash), "1"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.3993311253", initialHash), initialRole),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testGCPSecretRoleset_attrs(backend, roleset),
+					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "roleset", roleset),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "secret_type", "access_token"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "project", project),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.2400041053", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "binding.#", "1"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.resource", updatedHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.#", updatedHash), "1"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.2133424675", updatedHash), updatedRole),
+				),
+			},
+		},
+	})
+}
+
+func testGCPSecretRoleset_attrs(backend, roleset string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_gcp_secret_roleset.test"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		endpoint := instanceState.ID
+
+		if endpoint != backend+"/roleset/"+roleset {
+			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/roleset/"+roleset, endpoint)
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		resp, err := client.Logical().Read(endpoint)
+		if err != nil {
+			return fmt.Errorf("%q doesn't exist", endpoint)
+		}
+
+		attrs := map[string]string{
+			"secret_type":           "secret_type",
+			"project":               "service_account_project",
+			"token_scopes":          "token_scopes",
+			"service_account_email": "service_account_email",
+		}
+		for stateAttr, apiAttr := range attrs {
+			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+				continue
+			}
+			var match bool
+			switch resp.Data[apiAttr].(type) {
+			case json.Number:
+				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
+				if err != nil {
+					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
+				}
+				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
+				if err != nil {
+					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
+				}
+				match = apiData == stateData
+			case bool:
+				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
+					match = true
+				} else {
+					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
+					if err != nil {
+						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
+					}
+					match = resp.Data[apiAttr] == stateData
+				}
+			case []interface{}:
+				apiData := resp.Data[apiAttr].([]interface{})
+				length := instanceState.Attributes[stateAttr+".#"]
+				if length == "" {
+					if len(resp.Data[apiAttr].([]interface{})) != 0 {
+						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
+					}
+					match = true
+				} else {
+					count, err := strconv.Atoi(length)
+					if err != nil {
+						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
+					}
+					if count != len(apiData) {
+						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
+					}
+
+					for i := 0; i < count; i++ {
+						found := false
+						for stateKey, stateValue := range instanceState.Attributes {
+							if strings.HasPrefix(stateKey, stateAttr) {
+								if apiData[i] == stateValue {
+									found = true
+								}
+							}
+						}
+						if !found {
+							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
+						}
+					}
+					match = true
+				}
+			default:
+				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+			}
+			if !match {
+				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
+			}
+		}
+		return nil
+	}
+}
+
+func testGCPSecretRolesetDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_gcp_secret_roleset" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for GCP Secrets Roleset %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("GCP Secrets Roleset %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testGCPSecretRoleset_config(backend, roleset, credentials, project, role string) (string, int) {
+	resource := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
+
+	terraform := fmt.Sprintf(`
+resource "vault_gcp_secret_backend" "test" {
+  path = "%s"
+  credentials = "${file("%s")}"
+}
+
+resource "vault_gcp_secret_roleset" "test" {
+  backend = "${vault_gcp_secret_backend.test.path}"
+  roleset = "%s"
+  secret_type = "access_token"
+  project = "%s"
+  token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+  binding {
+	resource = "%s"
+
+	roles = ["%s"]
+  }
+}
+`, backend, credentials, roleset, project, resource, role)
+
+	// Hash the set of bindings
+	binding := make(map[string]interface{})
+	roles := []interface{}{role}
+	binding["resource"] = resource
+	binding["roles"] = schema.NewSet(schema.HashString, roles)
+
+	return terraform, gcpSecretRolesetBindingHash(binding)
+}

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -22,7 +22,7 @@ for more details.
 
 ```hcl
 resource "vault_gcp_secret_backend" "gcp" {
-  credentials = "${file("credentials.json")}
+  credentials = "${file("credentials.json")}"
 }
 ```
 

--- a/website/docs/r/gcp_secret_roleset.html.md
+++ b/website/docs/r/gcp_secret_roleset.html.md
@@ -1,0 +1,69 @@
+---
+layout: "vault"
+page_title: "Vault: vault_gcp_secret_roleset resource"
+sidebar_current: "docs-vault-resource-gcp-secret-roleset"
+description: |-
+  Creates a Roleset for the GCP Secret Backend for Vault.
+---
+
+# vault\_gcp\_secret\_roleset
+
+Creates a Roleset in the [GCP Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp/index.html) for Vault.
+
+Each Roleset is [tied](https://www.vaultproject.io/docs/secrets/gcp/index.html#service-accounts-are-tied-to-rolesets) to a Service Account, and can have one or more [bindings](https://www.vaultproject.io/docs/secrets/gcp/index.html#roleset-bindings) associated with it.
+
+## Example Usage
+
+```hcl
+locals {
+  project = "my-awesome-project"
+}
+
+resource "vault_gcp_secret_backend" "gcp" {
+  credentials = "${file("credentials.json")}"
+}
+
+resource "vault_gcp_secret_roleset" "agent" {
+  backend      = "${vault_gcp_secret_backend.gcp.path}"
+  roleset      = "project_viewer"
+  secret_type  = "access_token"
+  project      = "${local.project}"
+  token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+  binding {
+    resource = "//cloudresourcemanager.googleapis.com/projects/${local.project}"
+
+    roles = [
+      "roles/viewer",
+    ]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `backend` - (Required, Forces new resource) Path where the GCP Secrets Engine is mounted
+
+* `roleset` - (Required, Forces new resource) Name of the Roleset to create
+
+* `project` - (Required, Forces new resource) Name of the GCP project that this roleset's service account will belong to.
+
+* `secret_type` - (Optional, Forces new resource) Type of secret generated for this role set. Accepted values: `access_token`, `service_account_key`. Defaults to `access_token`.
+
+* `token_scopes` - (Optional, Required for `secret_type = "access_token"`) List of OAuth scopes to assign to `access_token` secrets generated under this role set (`access_token` role sets only).
+
+* `binding` - (Required) Bindings to create for this roleset. This can be specified multiple times for multiple bindings. Structure is documented below.
+
+The `binding` block supports:
+
+* `resource` - (Required) Resource or resource path for which IAM policy information will be bound. The resource path may be specified in a few different [formats](https://www.vaultproject.io/docs/secrets/gcp/index.html#roleset-bindings).
+
+* `roles` - (Required) List of [GCP IAM roles](https://cloud.google.com/iam/docs/understanding-roles) for the resource.
+
+## Attributes Reference
+
+In addition to the fields above, the following attributes are also exposed:
+
+* `service_account_email` Email of the service account created by Vault for this Roleset.


### PR DESCRIPTION
To test this, we need to set `GOOGLE_CREDENTIALS` as a path to the JSON file containing GCP credentials, and `GOOGLE_PROJECT` as the name of the GCP project to run the tests against.

I have tested it locally and the test pass.

The bindings could have been passed to Vault as JSON, but it is currently [bugged](https://github.com/hashicorp/vault-plugin-secrets-gcp/issues/27). 

```
make testacc TESTARGS='-run=TestGCPSecretRoleset'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestGCPSecretRoleset -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestGCPSecretRoleset
--- PASS: TestGCPSecretRoleset (26.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	26.473s
```