### PR TITLE
Fix TTL on PKI certificate create to use string type and not int.

### DIFF
--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -64,7 +64,7 @@ func pkiSecretBackendCertResource() *schema.Resource {
 				},
 			},
 			"ttl": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Description: "Time to leave.",
@@ -156,7 +156,7 @@ func pkiSecretBackendCertCreate(d *schema.ResourceData, meta interface{}) error 
 
 	data := map[string]interface{}{
 		"common_name":          d.Get("common_name").(string),
-		"ttl":                  d.Get("ttl").(int),
+		"ttl":                  d.Get("ttl").(string),
 		"format":               d.Get("format").(string),
 		"private_key_format":   d.Get("private_key_format").(string),
 		"exclude_cn_from_sans": d.Get("exclude_cn_from_sans").(bool),

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/vault/api"
-	"strconv"
 )
 
 func TestPkiSecretBackendCert_basic(t *testing.T) {
@@ -26,6 +26,7 @@ func TestPkiSecretBackendCert_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "backend", intermediatePath),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "ttl", "720h"),
 				),
 			},
 		},
@@ -130,5 +131,6 @@ resource "vault_pki_secret_backend_cert" "test" {
   backend = "${vault_pki_secret_backend.test-intermediate.path}"
   name = "${vault_pki_secret_backend_role.test.name}"
   common_name = "cert.test.my.domain"
+  ttl = "720h"
 }`, rootPath, intermediatePath)
 }


### PR DESCRIPTION
The certificate creation call can uses a string such as 720h for
setting the TTL and shouldn't use an int.

Testing this locally the certificate creates successfully with the
following validity:
```
Not Before: Feb 21 15:25:01 2019 GMT
Not After : Mar 23 15:25:31 2019 GMT
```

Closes #313 