### PR TITLE
Fix some issues with updating fields for several resources

### DIFF
--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -255,7 +255,7 @@ func gcpAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 	for _, k := range []string{"ttl", "max_ttl", "project_id", "bound_projects", "period", "policies", "add_group_aliases", "max_jwt_exp", "bound_service_accounts", "bound_zones", "bound_regions", "bound_instance_groups", "bound_labels"} {
 		if v, ok := resp.Data[k]; ok {
 			if err := d.Set(k, v); err != nil {
-				return fmt.Errorf("error reading %s for GCP Auth Backend Role %q", k, path)
+				return fmt.Errorf("error reading %s for GCP Auth Backend Role %q: %q", k, path, err)
 			}
 		}
 	}

--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -254,7 +254,9 @@ func gcpAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	for _, k := range []string{"ttl", "max_ttl", "project_id", "bound_projects", "period", "policies", "add_group_aliases", "max_jwt_exp", "bound_service_accounts", "bound_zones", "bound_regions", "bound_instance_groups", "bound_labels"} {
 		if v, ok := resp.Data[k]; ok {
-			d.Set(k, v)
+			if err := d.Set(k, v); err != nil {
+				return fmt.Errorf("error reading %s for GCP Auth Backend Role %q", k, path)
+			}
 		}
 	}
 

--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -72,6 +72,7 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 			"add_group_aliases": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"max_jwt_exp": {
 				Type:     schema.TypeString,
@@ -165,7 +166,7 @@ func gcpRoleUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
 		data["bound_service_accounts"] = v.(*schema.Set).List()
 	}
 
-	if v, ok := d.GetOk("add_group_aliases"); ok {
+	if v, ok := d.GetOkExists("add_group_aliases"); ok {
 		data["add_group_aliases"] = v.(bool)
 	}
 
@@ -173,7 +174,7 @@ func gcpRoleUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
 		data["max_jwt_exp"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("allow_gce_inference"); ok {
+	if v, ok := d.GetOkExists("allow_gce_inference"); ok {
 		data["allow_gce_inference"] = v.(bool)
 	}
 

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -186,7 +186,11 @@ func identityGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for _, k := range []string{"name", "type", "metadata", "policies", "member_entity_ids", "member_group_ids"} {
-		d.Set(k, resp.Data[k])
+		if v, ok := resp.Data[k]; ok {
+			if err := d.Set(k, v); err != nil {
+				return fmt.Errorf("error reading %s for Identity Group %q: %q", k, path, err)
+			}
+		}
 	}
 	return nil
 }

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -200,7 +200,7 @@ func kubernetesAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 	for _, k := range []string{"bound_cidrs", "bound_service_account_names", "bound_service_account_namespaces", "num_uses", "policies", "ttl", "max_ttl", "period"} {
 		if v, ok := resp.Data[k]; ok {
 			if err := d.Set(k, v); err != nil {
-				return fmt.Errorf("error reading %s for Kubernetes Auth Backend Role %q", k, path)
+				return fmt.Errorf("error reading %s for Kubernetes Auth Backend Role %q: %q", k, path, err)
 			}
 		}
 	}

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -198,7 +198,11 @@ func kubernetesAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("role_name", role)
 
 	for _, k := range []string{"bound_cidrs", "bound_service_account_names", "bound_service_account_namespaces", "num_uses", "policies", "ttl", "max_ttl", "period"} {
-		d.Set(k, resp.Data[k])
+		if v, ok := resp.Data[k]; ok {
+			if err := d.Set(k, v); err != nil {
+				return fmt.Errorf("error reading %s for Kubernetes Auth Backend Role %q", k, path)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This is a follow up to several PRs I made recently:

## Fix incorrect field updating in `gcp_auth_backend_role`
I made a mistake in setting the new `TypeBool` fields.

`GetOk` will return `whether or not the key has been set to a non-zero value at some point` as the second value. If the value is `false`, the second parameter will be `false`. Thus if a field was changed from `true` to `false`, this will never be caught.

## Fix `d.Set`

When using `d.Set` on aggregate types, they can potentially fail. See [Terraform docs](https://www.terraform.io/docs/extend/best-practices/detecting-drift.html#error-checking-aggregate-types).

I've updated some resources to check for these:

- `gcp_auth_backend_role`
- `kubernetes_auth_backend_role`
- `identity_group`