### PR TITLE
Fix tests for AWS secret engine roles

### DIFF
--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -95,7 +95,7 @@ resource "vault_aws_secret_backend" "aws" {
 resource "vault_aws_secret_backend_role" "role" {
     backend = "${vault_aws_secret_backend.aws.path}"
     name = "test"
-	credential_type = "federation_token"
+    credential_type = "federation_token"
     policy_document = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
 }
 

--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -48,12 +48,12 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 			{
 				Config: testAccDataSourceAWSAccessCredentialsConfig_sts(mountPath, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
-					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
+					//resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
+					//resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
 					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "security_token"),
-					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
-					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
-					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(mountPath),
+					//resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
+					//resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
+					//testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(mountPath),
 				),
 			},
 		},
@@ -72,7 +72,8 @@ resource "vault_aws_secret_backend" "aws" {
 resource "vault_aws_secret_backend_role" "role" {
     backend = "${vault_aws_secret_backend.aws.path}"
     name = "test"
-    policy = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
+    credential_type = "iam_user"
+    policy_document = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
 }
 
 data "vault_aws_access_credentials" "test" {
@@ -94,7 +95,8 @@ resource "vault_aws_secret_backend" "aws" {
 resource "vault_aws_secret_backend_role" "role" {
     backend = "${vault_aws_secret_backend.aws.path}"
     name = "test"
-    policy = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
+	credential_type = "federation_token"
+    policy_document = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
 }
 
 data "vault_aws_access_credentials" "test" {

--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -48,12 +48,12 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 			{
 				Config: testAccDataSourceAWSAccessCredentialsConfig_sts(mountPath, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					//resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
-					//resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
 					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "security_token"),
-					//resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
-					//resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
-					//testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(mountPath),
+					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
+					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(mountPath),
 				),
 			},
 		},

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -48,7 +48,7 @@ func awsSecretBackendRoleResource() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"policy_document", "policy", "policy_arns"},
 				Description:   "ARN for an existing IAM policy the role should use.",
-				Deprecated: `Use "policy_arns".`,
+				Deprecated:    `Use "policy_arns".`,
 			},
 			"policy_document": {
 				Type:             schema.TypeString,
@@ -63,12 +63,12 @@ func awsSecretBackendRoleResource() *schema.Resource {
 				ConflictsWith:    []string{"policy_arns", "policy_arn", "policy_document"},
 				Description:      "IAM policy the role should use in JSON format.",
 				DiffSuppressFunc: util.JsonDiffSuppress,
-				Deprecated: `Use "policy_document".`,
+				Deprecated:       `Use "policy_document".`,
 			},
 			"credential_type": {
-				Type:          schema.TypeString,
-				Required:      true,
-				Description:   "Role credential type.",
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Role credential type.",
 			},
 		},
 	}
@@ -85,7 +85,7 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 	if !ok {
 		policyARN := d.Get("policy_arn").(string)
 		if policyARN != "" {
-			policyARNs = append (policyARNs, policyARN)
+			policyARNs = append(policyARNs, policyARN)
 		}
 	}
 	for _, arnIfc := range policyARNsIfc.([]interface{}) {

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -37,10 +37,10 @@ func awsSecretBackendRoleResource() *schema.Resource {
 			"policy_arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"policy"},
+				ConflictsWith: []string{"policy_document"},
 				Description:   "ARN for an existing IAM policy the role should use.",
 			},
-			"policy": {
+			"policy_document": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ConflictsWith:    []string{"policy_arn"},
@@ -57,7 +57,7 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
 	policyARN := d.Get("policy_arn").(string)
-	policy := d.Get("policy").(string)
+	policy := d.Get("policy_document").(string)
 
 	if policy == "" && policyARN == "" {
 		return fmt.Errorf("either policy or policy_arn must be set.")
@@ -65,10 +65,10 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	data := map[string]interface{}{}
 	if policy != "" {
-		data["policy"] = policy
+		data["policy_document"] = policy
 	}
 	if policyARN != "" {
-		data["arn"] = policyARN
+		data["policy_arn"] = policyARN
 	}
 	log.Printf("[DEBUG] Creating role %q on AWS backend %q", name, backend)
 	_, err := client.Logical().Write(backend+"/roles/"+name, data)
@@ -101,8 +101,8 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	d.Set("policy", secret.Data["policy"])
-	d.Set("policy_arn", secret.Data["arn"])
+	d.Set("policy_document", secret.Data["policy_document"])
+	d.Set("policy_arn", secret.Data["policy_arn"])
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
 	d.Set("name", pathPieces[len(pathPieces)-1])
 	return nil

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -47,6 +47,11 @@ func awsSecretBackendRoleResource() *schema.Resource {
 				Description:      "IAM policy the role should use in JSON format.",
 				DiffSuppressFunc: util.JsonDiffSuppress,
 			},
+			"credential_type": {
+				Type:          schema.TypeString,
+				Required:      true,
+				Description:   "Role credential type.",
+			},
 		},
 	}
 }
@@ -70,6 +75,7 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 	if policyARN != "" {
 		data["policy_arn"] = policyARN
 	}
+	data["credential_type"] = d.Get("credential_type").(string)
 	log.Printf("[DEBUG] Creating role %q on AWS backend %q", name, backend)
 	_, err := client.Logical().Write(backend+"/roles/"+name, data)
 	if err != nil {
@@ -103,6 +109,7 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("policy_document", secret.Data["policy_document"])
 	d.Set("policy_arn", secret.Data["policy_arn"])
+	d.Set("credential_type", secret.Data["credential_type"])
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
 	d.Set("name", pathPieces[len(pathPieces)-1])
 	return nil

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -31,9 +31,9 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
 			},
 			{
@@ -42,9 +42,9 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
 				),
 			},
 		},
@@ -66,9 +66,9 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
 			},
 			{
@@ -77,7 +77,7 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "vault_aws_secret_backend_role.test_policy_arn",
+				ResourceName:      "vault_aws_secret_backend_role.test_policy_arns",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -100,9 +100,9 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
 			},
 			{
@@ -111,9 +111,9 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
 				),
 			},
 		},
@@ -153,10 +153,10 @@ resource "vault_aws_secret_backend_role" "test_policy_inline" {
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
-resource "vault_aws_secret_backend_role" "test_policy_arn" {
+resource "vault_aws_secret_backend_role" "test_policy_arns" {
   name = "%s-policy-arn"
-  policy_arn = "%s"
-  credential_type = "assumed_role"
+  policy_arns = ["%s"]
+  credential_type = "iam_user"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 `, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic)
@@ -177,10 +177,10 @@ resource "vault_aws_secret_backend_role" "test_policy_inline" {
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
-resource "vault_aws_secret_backend_role" "test_policy_arn" {
+resource "vault_aws_secret_backend_role" "test_policy_arns" {
   name = "%s-policy-arn"
-  policy_arn = "%s"
-  credential_type = "assumed_role"
+  policy_arns = ["%s"]
+  credential_type = "iam_user"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 `, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated)

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -149,12 +149,14 @@ resource "vault_aws_secret_backend" "test" {
 resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
   policy_document = %q
+  credential_type = "assumed_role"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
 resource "vault_aws_secret_backend_role" "test_policy_arn" {
   name = "%s-policy-arn"
   policy_arn = "%s"
+  credential_type = "assumed_role"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 `, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic)
@@ -171,12 +173,14 @@ resource "vault_aws_secret_backend" "test" {
 resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
   policy_document = %q
+  credential_type = "assumed_role"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
 resource "vault_aws_secret_backend_role" "test_policy_arn" {
   name = "%s-policy-arn"
   policy_arn = "%s"
+  credential_type = "assumed_role"
   backend = "${vault_aws_secret_backend.test.path}"
 }
 `, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated)

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -30,7 +30,7 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
@@ -41,7 +41,7 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
@@ -65,7 +65,7 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
@@ -99,7 +99,7 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
@@ -110,7 +110,7 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
@@ -148,7 +148,7 @@ resource "vault_aws_secret_backend" "test" {
 
 resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
-  policy = %q
+  policy_document = %q
   backend = "${vault_aws_secret_backend.test.path}"
 }
 
@@ -170,7 +170,7 @@ resource "vault_aws_secret_backend" "test" {
 
 resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
-  policy = %q
+  policy_document = %q
   backend = "${vault_aws_secret_backend.test.path}"
 }
 

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -29,8 +29,9 @@ resource "vault_aws_secret_backend" "aws" {
 resource "vault_aws_secret_backend_role" "role" {
   backend = "${vault_aws_secret_backend.aws.path}"
   name    = "deploy"
+  credential_type = "assumed_role"
 
-  policy = <<EOT
+  policy_document = <<EOT
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -55,11 +56,15 @@ with no leading or trailing `/`s.
 * `name` - (Required) The name to identify this role within the backend.
 Must be unique within the backend.
 
-* `policy` - (Optional) The JSON-formatted policy to associate with this
-role. Either `policy` or `policy_arn` must be specified.
+* `policy_document` - (Optional) The JSON-formatted policy to associate with this
+role. Either `policy_document` or `policy_arns` must be specified.
 
-* `policy_arn` - (Optional) The ARN for a pre-existing policy to associate
-with this role. Either `policy` or `policy_arn` must be specified.
+* `policy_arns` - (Optional) The ARN for a pre-existing policy to associate
+with this role. Either `policy_document` or `policy_arns` must be specified.
+
+* `credential_type` - (Required) Specifies the type of credential to be used when 
+retrieving credentials from the role. Must be one of `iam_user`, `assumed_role`, or 
+`federation_token`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The following tests are failing:
```
TestAccAWSAuthBackendLogin_ec2Identity
TestAccAWSAuthBackendLogin_pkcs7
TestAccAWSSecretBackendRole_basic
TestAccAWSSecretBackendRole_import
TestAccAWSSecretBackendRole_nested
TestAccDataSourceAWSAccessCredentials_basic 
TestAccDataSourceAWSAccessCredentials_sts
```
This PR fixes the last 5, and perhaps the first 2 as well.