### PR TITLE
Fix tests that pull EC2 instance metadata

### DIFF
--- a/vault/resource_aws_auth_backend_login_test.go
+++ b/vault/resource_aws_auth_backend_login_test.go
@@ -1,5 +1,14 @@
 package vault
 
+/*
+
+These tests are broken:
+
+- TestAccAWSAuthBackendLogin_ec2Identity
+- TestAccAWSAuthBackendLogin_pkcs7
+
+*/
+
 import (
 	"encoding/base64"
 	"encoding/json"
@@ -74,7 +83,6 @@ func TestAccAWSAuthBackendLogin_pkcs7(t *testing.T) {
 	accessKey, secretKey := getTestAWSCreds(t)
 
 	awsConfig := &aws.Config{
-		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
 		HTTPClient:  cleanhttp.DefaultClient(),
 	}
 	sess, err := session.NewSession(awsConfig)
@@ -129,7 +137,6 @@ func TestAccAWSAuthBackendLogin_ec2Identity(t *testing.T) {
 	accessKey, secretKey := getTestAWSCreds(t)
 
 	awsConfig := &aws.Config{
-		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
 		HTTPClient:  cleanhttp.DefaultClient(),
 	}
 	sess, err := session.NewSession(awsConfig)

--- a/vault/resource_aws_auth_backend_login_test.go
+++ b/vault/resource_aws_auth_backend_login_test.go
@@ -9,12 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -24,11 +21,7 @@ func TestAccAWSAuthBackendLogin_iamIdentity(t *testing.T) {
 	roleName := acctest.RandomWithPrefix("tf-test")
 	accessKey, secretKey := getTestAWSCreds(t)
 
-	awsConfig := &aws.Config{
-		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
-		HTTPClient:  cleanhttp.DefaultClient(),
-	}
-	sess, err := session.NewSession(awsConfig)
+	sess, err := session.NewSession(nil)
 	if err != nil {
 		t.Errorf("Error creating AWS session: %s", err)
 	}
@@ -73,10 +66,7 @@ func TestAccAWSAuthBackendLogin_pkcs7(t *testing.T) {
 	roleName := acctest.RandomWithPrefix("tf-test")
 	accessKey, secretKey := getTestAWSCreds(t)
 
-	awsConfig := &aws.Config{
-		HTTPClient:  cleanhttp.DefaultClient(),
-	}
-	sess, err := session.NewSession(awsConfig)
+	sess, err := session.NewSession(nil)
 	if err != nil {
 		t.Errorf("Error creating AWS session: %s", err)
 	}
@@ -127,10 +117,7 @@ func TestAccAWSAuthBackendLogin_ec2Identity(t *testing.T) {
 	roleName := acctest.RandomWithPrefix("tf-test")
 	accessKey, secretKey := getTestAWSCreds(t)
 
-	awsConfig := &aws.Config{
-		HTTPClient:  cleanhttp.DefaultClient(),
-	}
-	sess, err := session.NewSession(awsConfig)
+	sess, err := session.NewSession(nil)
 	if err != nil {
 		t.Errorf("Error creating AWS session: %s", err)
 	}

--- a/vault/resource_aws_auth_backend_login_test.go
+++ b/vault/resource_aws_auth_backend_login_test.go
@@ -1,14 +1,5 @@
 package vault
 
-/*
-
-These tests are broken:
-
-- TestAccAWSAuthBackendLogin_ec2Identity
-- TestAccAWSAuthBackendLogin_pkcs7
-
-*/
-
 import (
 	"encoding/base64"
 	"encoding/json"


### PR DESCRIPTION
The following tests are failing remotely:
```
TestAccAWSAuthBackendLogin_ec2Identity
TestAccAWSAuthBackendLogin_pkcs7
```
They're failing with output like:
```
[TestAccAWSAuthBackendLogin_pkcs7] [Test Output]
=== RUN   TestAccAWSAuthBackendLogin_pkcs7
--- FAIL: TestAccAWSAuthBackendLogin_pkcs7 (0.43s)
    resource_aws_auth_backend_login_test.go:92: Error retrieving IAM info for instance: EC2MetadataRequestError: failed to get EC2 IAM info
        caused by: EC2MetadataError: failed to make EC2Metadata request
        caused by: <?xml version="1.0" encoding="iso-8859-1"?>
        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
                 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
         <head>
          <title>404 - Not Found</title>
         </head>
         <body>
          <h1>404 - Not Found</h1>
         </body>
        </html>
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * vault_aws_auth_backend_login.test: 1 error(s) occurred:
        
        * vault_aws_auth_backend_login.test: error reading from Vault: Error making API request.
        
        URL: PUT http://127.0.0.1:8200/v1/auth/tf-test-aws-redacted/login
        Code: 400. Errors:
        
        * failed to verify instance ID: unable to fetch client for account ID "redacted" -- default client is for account "redacted"
FAIL
```
I believe it's because it's setting creds incorrectly on the call to the EC2 instance metadata service, which [doesn't require creds at all](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-retrieval). By simply not setting creds, the call should succeed.