### PR TITLE
Skip unsuitable tests

### DIFF
--- a/vault/resource_aws_auth_backend_login_test.go
+++ b/vault/resource_aws_auth_backend_login_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -59,9 +58,8 @@ func TestAccAWSAuthBackendLogin_iamIdentity(t *testing.T) {
 }
 
 func TestAccAWSAuthBackendLogin_pkcs7(t *testing.T) {
-	if os.Getenv(resource.TestEnvVar) == "" {
-		t.Skip(resource.TestEnvVar + " not set.")
-	}
+	t.Skip("skipping because remote environment isn't suitable for testing")
+
 	mountPath := acctest.RandomWithPrefix("tf-test-aws")
 	roleName := acctest.RandomWithPrefix("tf-test")
 	accessKey, secretKey := getTestAWSCreds(t)
@@ -110,9 +108,8 @@ func TestAccAWSAuthBackendLogin_pkcs7(t *testing.T) {
 }
 
 func TestAccAWSAuthBackendLogin_ec2Identity(t *testing.T) {
-	if os.Getenv(resource.TestEnvVar) == "" {
-		t.Skip(resource.TestEnvVar + " not set.")
-	}
+	t.Skip("skipping because remote environment isn't suitable for testing")
+
 	mountPath := acctest.RandomWithPrefix("tf-test-aws")
 	roleName := acctest.RandomWithPrefix("tf-test")
 	accessKey, secretKey := getTestAWSCreds(t)


### PR DESCRIPTION
These tests are failing on a CI server because it doesn't seem to have IAM instance info. It will simply need to be tested in a non-CI environment.