### PR TITLE
Generic sercret data

### DIFF
--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -101,8 +101,14 @@ func testResourceGenericSecret_initialCheck(expectedPath string) resource.TestCh
 			return fmt.Errorf("error reading back secret: %s", err)
 		}
 
+		// Test the JSON
 		if got, want := secret.Data["zip"], "zap"; got != want {
 			return fmt.Errorf("'zip' data is %q; want %q", got, want)
+		}
+
+		// Test the map
+		if got, want := instanceState.Attributes["data.zip"], "zap"; got != want {
+			return fmt.Errorf("data[\"zip\"] contains %s; want %s", got, want)
 		}
 
 		return nil

--- a/website/docs/r/generic_secret.html.md
+++ b/website/docs/r/generic_secret.html.md
@@ -75,7 +75,12 @@ true
 
 ## Attributes Reference
 
-No additional attributes are exported by this resource.
+The following attributes are exported in addition to the above:
+
+* `data` - A mapping whose keys are the top-level data keys returned from
+Vault and whose values are the corresponding values. This map can only
+represent string data, so any non-string values returned from Vault are
+serialized as JSON.
 
 ## Import
 


### PR DESCRIPTION
This makes the `generic_secret` resource export the data as a map (much in the same way as the data source of the same name.

This is useful when we want to obtain information from the resource metadata for use as an input to another resource. Data sources are not suitable in this case, as they have to be available at plan time.

Output of acceptance tests:
```bash
$ make testacc TESTARGS='-run=TestResourceGenericSecret'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestResourceGenericSecret -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	0.021s [no tests to run]
=== RUN   TestResourceGenericSecret
--- PASS: TestResourceGenericSecret (6.99s)
=== RUN   TestResourceGenericSecret_deleted
--- PASS: TestResourceGenericSecret_deleted (5.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	12.264s
```