### PR TITLE
Add cidr blocks ssh otp

### DIFF
--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -71,6 +71,10 @@ func sshSecretBackendRoleResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"cidr_list": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"allowed_extensions": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -136,6 +140,10 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("allowed_domains"); ok {
 		data["allowed_domains"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("cidr_list"); ok {
+		data["cidr_list"] = v.(string)
 	}
 
 	if v, ok := d.GetOk("allowed_extensions"); ok {
@@ -221,6 +229,7 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("allow_user_key_ids", role.Data["allow_user_key_ids"])
 	d.Set("allowed_critical_options", role.Data["allowed_critical_options"])
 	d.Set("allowed_domains", role.Data["allowed_domains"])
+	d.Set("cidr_list", role.Data["cidr_list"])
 	d.Set("allowed_extensions", role.Data["allowed_extensions"])
 	d.Set("default_extensions", role.Data["default_extensions"])
 	d.Set("default_critical_options", role.Data["default_critical_options"])

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -24,6 +24,15 @@ resource "vault_ssh_secret_backend_role" "foo" {
     key_type                = "ca"
     allow_user_certificates = true
 }
+
+resource "vault_ssh_secret_backend_role" "bar" {
+    name          = "otp-role"
+    backend       = "${vault_mount.example.path}"
+    key_type      = "otp"
+    default_user  = "default"
+    allowed_users = "default,baz"
+    cidr_list     = "0.0.0.0/0"
+}
 ```
 
 ## Argument Reference
@@ -49,6 +58,8 @@ The following arguments are supported:
 * `allowed_critical_options` - (Optional) Specifies a comma-separated list of critical options that certificates can have when signed.
 
 * `allowed_domains` - (Optional) The list of domains for which a client can request a host certificate.
+
+* `cidr_list` - (Optional) The comma-separated string of CIDR blocks for which this role is applicable.
 
 * `allowed_extensions` - (Optional) Specifies a comma-separated list of extensions that certificates can have when signed.
 


### PR DESCRIPTION
This adds support for specifying CIDR blocks when using the OTP key type.

Test output:
```bash
$ make testacc TESTARGS='-run=TestAccSSHSecretBackendRole*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccSSHSecretBackendRole* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	0.036s [no tests to run]
=== RUN   TestAccSSHSecretBackendRole_basic
--- PASS: TestAccSSHSecretBackendRole_basic (6.70s)
=== RUN   TestAccSSHSecretBackendRoleOTP_basic
--- PASS: TestAccSSHSecretBackendRoleOTP_basic (2.56s)
=== RUN   TestAccSSHSecretBackendRole_import
--- PASS: TestAccSSHSecretBackendRole_import (3.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	12.424s
```