### PR TITLE
RabbitMQ: Uses `vhosts` instead of `vhost`

### DIFF
--- a/website/docs/r/rabbitmq_secret_backend_role.html.md
+++ b/website/docs/r/rabbitmq_secret_backend_role.html.md
@@ -32,7 +32,7 @@ resource "vault_rabbitmq_secret_backend_role" "role" {
   name    = "deploy"
 
   tags = "tag1,tag2"
-  vhost = "{\"/\": {\"configure\":\".*\", \"write\":\".*\", \"read\": \".*\"}}"
+  vhosts = "{\"/\": {\"configure\":\".*\", \"write\":\".*\", \"read\": \".*\"}}"
 }
 ```
 
@@ -48,7 +48,7 @@ Must be unique within the backend.
 
 * `tags` - (Optional) Specifies a comma-separated RabbitMQ management tags.
 
-* `vhost` - (Optional) Specifies a map of virtual hosts to permissions.
+* `vhosts` - (Optional) Specifies a map of virtual hosts to permissions.
 
 ## Attributes Reference
 


### PR DESCRIPTION
It looks like the documentation has a typo over `vhost` 

I have quickly checked in the code if `vhost` or `vhosts` are accepted, and it seems that the typo is just in the documentation. Please check that too as I am not 100% familiar with this provider code.

Related to #335 