### PR TITLE
Added support for jwt_supported_algs

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -69,6 +69,13 @@ func jwtAuthBackendResource() *schema.Resource {
 				Description: "The value against which to match the iss claim in a JWT",
 			},
 
+			"jwt_supported_algs": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "A list of supported signing algorithms. Defaults to [RS256]",
+			},
+
 			"accessor": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -149,6 +156,7 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("bound_issuer", config.Data["bound_issuer"])
 	d.Set("oidc_discovery_url", config.Data["oidc_discovery_url"])
 	d.Set("jwt_validation_pubkeys", config.Data["jwt_validation_pubkeys"])
+	d.Set("jwt_supported_algs", config.Data["jwt_supported_algs"])
 
 	return nil
 
@@ -167,6 +175,7 @@ func jwtAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	oidcDiscoveryUrl, oidcDiscoveryUrlExists := d.GetOk("oidc_discovery_url")
 	jwtValidationPubKeys, jwtValidationPubKeysExists := d.GetOk("jwt_validation_pubkeys")
+	jwtSupportedAlgs, jwtSupportedAlgsExists := d.GetOk("jwt_supported_algs")
 
 	if oidcDiscoveryUrlExists == jwtValidationPubKeysExists {
 		return errors.New("exactly one of oidc_discovery_url and jwt_validation_pubkeys should be provided")
@@ -178,6 +187,10 @@ func jwtAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if jwtValidationPubKeysExists {
 		configuration["jwt_validation_pubkeys"] = jwtValidationPubKeys
+	}
+
+	if jwtSupportedAlgsExists {
+		configuration["jwt_supported_algs"] = jwtSupportedAlgs
 	}
 
 	_, err := client.Logical().Write(jwtConfigEndpoint(path), configuration)

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `jwt_validation_pubkeys` - (Optional) A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used in combination with `oidc_discovery_url`
 
+* `jwt_supported_algs` - (Optional) A list of supported signing algorithms. Vault 1.1.0 defaults to [RS256] but future or past versions of Vault may differ
+
 ## Attributes Reference
 
 No additional attributes are exposed by this resource.


### PR DESCRIPTION
# Overview
As of vault 1.0.3, you can configure the list of supported algorithms in a jwt auth backend.  This PR adds this support to terraform-provider-vault.

# Manual Testing
## Config not set:
```
resource "vault_jwt_auth_backend" "my_jwt_auth" {
  path               = "jwt"
  oidc_discovery_url = "https://myserver.com"
  bound_issuer       = "https://myserver.com"
}
```
```
$ vault read auth/jwt/config
Key                       Value
---                       -----
bound_issuer              https://myserver.com
jwt_supported_algs        []
jwt_validation_pubkeys    []
oidc_discovery_ca_pem     n/a
oidc_discovery_url        https://myserver.com
```

## Config with one option:
```
resource "vault_jwt_auth_backend" "my_jwt_auth" {
  path               = "jwt"
  oidc_discovery_url = "https://myserver.com"
  bound_issuer       = "https://myserver.com"
  jwt_supported_algs = ["RS512"]
}
```
```
$ vault read auth/jwt/config
Key                       Value
---                       -----
bound_issuer              https://myserver.com
jwt_supported_algs        [RS512]
jwt_validation_pubkeys    []
oidc_discovery_ca_pem     n/a
oidc_discovery_url        https://myserver.com
```

## Config with two options:
```
resource "vault_jwt_auth_backend" "my_jwt_auth" {
  path               = "jwt"
  oidc_discovery_url = "https://myserver.com"
  bound_issuer       = "https://myserver.com"
  jwt_supported_algs = ["RS256","RS512"]
}
```
```
$ vault read auth/jwt/config
Key                       Value
---                       -----
bound_issuer              https://myserver.com
jwt_supported_algs        [RS256 RS512]
jwt_validation_pubkeys    []
oidc_discovery_ca_pem     n/a
oidc_discovery_url        https://myserver.com
```

# Unit Testing
```
$ make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
                xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-vault github.com/terraform-providers/terraform-provider-vault/util github.com/terraform-providers/terraform-provider-vault/vault
?       github.com/terraform-providers/terraform-provider-vault [no test files]
ok      github.com/terraform-providers/terraform-provider-vault/util    0.022s
ok      github.com/terraform-providers/terraform-provider-vault/vault   0.044s
```