### PR TITLE
Update sidebar with missing documentation changes

### DIFF
--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -17,7 +17,6 @@ information.
 ```hcl
 resource "vault_github_auth_backend" "example" {
   organization = "myorg"
-
 }
 ```
 
@@ -37,10 +36,10 @@ The following arguments are supported:
   This overrides the current stored value, if any.
 
 * `ttl` - (Optional) Duration after which authentication will be expired. 
-  This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+  This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration).
 
 * `max_ttl` - (Optional) Maximum duration after which authentication will be expired.
-  This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+  This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration).
 
 The `tune` block is used to tune the auth backend:
 

--- a/website/docs/r/github_team.html.md
+++ b/website/docs/r/github_team.html.md
@@ -17,7 +17,6 @@ information.
 ```hcl
 resource "vault_github_auth_backend" "example" {
   organization = "myorg"
-
 }
 
 resource "vault_github_team" "tf_devs" {
@@ -34,7 +33,7 @@ The following arguments are supported:
 * `backend` - (Required) Path where the github auth backend is mounted. Defaults to `github` 
   if not specified.
 
-* `team` - (Required) GitHub team name in "slugified" format, for example: Terraform Developers -> `terraform-developers`
+* `team` - (Required) GitHub team name in "slugified" format, for example: Terraform Developers -> `terraform-developers`.
 
 * `policies` - (Optional) A list of policies to be assigned to this team.
 

--- a/website/docs/r/github_user.html.md
+++ b/website/docs/r/github_user.html.md
@@ -17,7 +17,6 @@ information.
 ```hcl
 resource "vault_github_auth_backend" "example" {
   organization = "myorg"
-
 }
 
 resource "vault_github_user" "tf_user" {

--- a/website/docs/r/identity_group_alias.html.md
+++ b/website/docs/r/identity_group_alias.html.md
@@ -37,11 +37,11 @@ resource "vault_identity_group_alias" "group-alias" {
 
 The following arguments are supported:
 
-* `name` - (Required, Forces new resource) Name of the group alias to create
+* `name` - (Required, Forces new resource) Name of the group alias to create.
 
 * `mount_accessor` - (Required) Mount accessor of the authentication backend to which this alias belongs to.
 
-* `canonical_id` - (Required) ID of the group to which this is an alias
+* `canonical_id` - (Required) ID of the group to which this is an alias.
 
 ## Attributes Reference
 

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -130,6 +130,18 @@
                         <li<%= sidebar_current("docs-vault-resource-generic-secret") %>>
                             <a href="/docs/providers/vault/r/generic_secret.html">vault_generic_secret</a>
                         </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-github-auth-backend") %>>
+                            <a href="/docs/providers/vault/r/github_auth_backend.html">vault_github_auth_backend</a>
+                        </li>
+                        
+                        <li<%= sidebar_current("docs-vault-resource-github-team") %>>
+                            <a href="/docs/providers/vault/r/github_team.html">vault_github_team</a>
+                        </li>
+                        
+                        <li<%= sidebar_current("docs-vault-resource-github-user") %>>
+                            <a href="/docs/providers/vault/r/github_user.html">vault_github_user</a>
+                        </li>                        
                           
                         <li<%= sidebar_current("docs-vault-resource-identity-entity") %>>
                             <a href="/docs/providers/vault/r/identity_entity.html">vault_identity_entity</a>
@@ -137,6 +149,14 @@
 
                         <li<%= sidebar_current("docs-vault-resource-identity-entity-alias") %>>
                             <a href="/docs/providers/vault/r/identity_entity_alias.html">vault_identity_entity_alias</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-identity-group") %>>
+                            <a href="/docs/providers/vault/r/identity_group.html">vault_identity_group</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-identity-group-alias") %>>
+                            <a href="/docs/providers/vault/r/identity_group_alias.html">vault_identity_group_alias</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-jwt-auth-backend") %>>


### PR DESCRIPTION
Resolves #324 

Updated documentation sidebar for the following resources:

- vault_identity_group
- vault_identity_group_alias
- github_auth_backend
- github_team
- github_user

Checked other links briefly but didn't notice anything else missing, but may have missed something.