### PR TITLE
Enable mount accessor export for vault_github_auth_backend

### DIFF
--- a/vault/auth_mount.go
+++ b/vault/auth_mount.go
@@ -62,7 +62,7 @@ func authMountTuneSchema() *schema.Schema {
 func authMountInfoGet(client *api.Client, path string) (*api.AuthMount, error) {
 	auths, err := client.Sys().ListAuth()
 	if err != nil {
-		return nil, fmt.Errorf("error reading from Vault: %s", err)
+		return nil, fmt.Errorf("error reading from auth mounts: %s", err)
 	}
 
 	authMount := auths[strings.Trim(path, "/")+"/"]

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -30,6 +30,7 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "organization", "vault"),
 					resource.TestCheckResourceAttr(resName, "ttl", "20m"),
 					resource.TestCheckResourceAttr(resName, "max_ttl", "50m"),
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuth.Accessor),
 				),
 			},
 			{
@@ -41,6 +42,7 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "organization", "other_vault"),
 					resource.TestCheckResourceAttr(resName, "ttl", "40m"),
 					resource.TestCheckResourceAttr(resName, "max_ttl", "1h40m"),
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuth.Accessor),
 				),
 			},
 		},

--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -66,7 +66,9 @@ The `tune` block is used to tune the auth backend:
 
 ## Attributes Reference
 
-No additional attributes are exported by this resource.
+In addition to all arguments above, the following attributes are exported:
+
+* `accessor` - The mount accessor related to the auth mount. It is useful for integration with [Identity Secrets Engine](https://www.vaultproject.io/docs/secrets/identity/index.html).
 
 ## Import
 


### PR DESCRIPTION
This PR adds `accessor` attribute for `vault_github_auth_backend` resource. This is useful to integrate an auth mount with resources such as `vault_identity_entity_group_alias` and `vault_identity_entity_alias`.