### PR TITLE
Add max_retries provider argument to set retries on 5xx api client errors.

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -79,6 +79,13 @@ func Provider() terraform.ResourceProvider {
 
 				Description: "Maximum TTL for secret leases requested by this provider",
 			},
+			"max_retries": {
+				Type:     schema.TypeInt,
+				Optional: true,
+
+				DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES", 2),
+				Description: "Maximum number of retries when a 5xx error code is encountered.",
+			},
 			"namespace": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -215,6 +222,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure Vault API: %s", err)
 	}
+
+	client.SetMaxRetries(d.Get("max_retries").(int))
 
 	token, err := providerToken(d)
 	if err != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -118,6 +118,10 @@ variables in order to keep credential information out of the configuration.
   See the section above on *Using Vault credentials in Terraform configuration*
   for the implications of this setting.
 
+* `max_retries` - (Optional) Used as the maximum number of retries when a 5xx
+  error code is encountered. Defaults to 2 retries and may be set via the
+  `VAULT_MAX_RETRIES` environment variable.
+
 * `namespace` - (Optional) Set the namespace to use. May be set via the
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
 
@@ -153,4 +157,3 @@ resource "vault_generic_secret" "example" {
 EOT
 }
 ```
-


### PR DESCRIPTION
Add max_retries provider argument to set retries on 5xx api client errors.
Update documentation to describe max_retries provider argument.

Fixes #354  and allows handling eventual consistency issues with Vault.