### PR TITLE
[docs] Add 'gcp_auth_backend' resource to website docs

### DIFF
--- a/website/vault.erb
+++ b/website/vault.erb
@@ -127,6 +127,10 @@
                             <a href="/docs/providers/vault/r/gcp_auth_backend_role.html">vault_gcp_auth_backend_role</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-gcp-secret-backend") %>>
+                            <a href="/docs/providers/vault/r/gcp_secret_backend.html">vault_gcp_secret_backend</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-generic-secret") %>>
                             <a href="/docs/providers/vault/r/generic_secret.html">vault_generic_secret</a>
                         </li>


### PR DESCRIPTION
Resource and docs was added via #212, but I missed the sidebar addition...

cc @emilymye @kuwas