### PR TITLE
Add the use_token_groups field to ldap auth

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -106,6 +106,11 @@ func ldapAuthBackendResource() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"use_token_groups": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 
 			"description": {
 				Type:     schema.TypeString,
@@ -225,6 +230,10 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["groupattr"] = v.(string)
 	}
 
+	if v, ok := d.GetOk("use_token_groups"); ok {
+		data["use_token_groups"] = v.(bool)
+	}
+
 	log.Printf("[DEBUG] Writing LDAP config %q", path)
 	_, err := client.Logical().Write(path, data)
 
@@ -284,6 +293,7 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("groupfilter", resp.Data["groupfilter"])
 	d.Set("groupdn", resp.Data["groupdn"])
 	d.Set("groupattr", resp.Data["groupattr"])
+	d.Set("use_token_groups", resp.Data["use_token_groups"])
 
 	// `bindpass` cannot be read out from the API
 	// So... if they drift, they drift.

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -96,21 +96,22 @@ func testLDAPAuthBackendCheck_attrs(path string) resource.TestCheckFunc {
 		}
 
 		attrs := map[string]string{
-			"url":             "url",
-			"starttls":        "starttls",
-			"tls_min_version": "tls_min_version",
-			"tls_max_version": "tls_max_version",
-			"insecure_tls":    "insecure_tls",
-			"certificate":     "certificate",
-			"binddn":          "binddn",
-			"userdn":          "userdn",
-			"userattr":        "userattr",
-			"discoverdn":      "discoverdn",
-			"deny_null_bind":  "deny_null_bind",
-			"upndomain":       "upndomain",
-			"groupfilter":     "groupfilter",
-			"groupdn":         "groupdn",
-			"groupattr":       "groupattr",
+			"url":              "url",
+			"starttls":         "starttls",
+			"tls_min_version":  "tls_min_version",
+			"tls_max_version":  "tls_max_version",
+			"insecure_tls":     "insecure_tls",
+			"certificate":      "certificate",
+			"binddn":           "binddn",
+			"userdn":           "userdn",
+			"userattr":         "userattr",
+			"discoverdn":       "discoverdn",
+			"deny_null_bind":   "deny_null_bind",
+			"upndomain":        "upndomain",
+			"groupfilter":      "groupfilter",
+			"groupdn":          "groupdn",
+			"groupattr":        "groupattr",
+			"use_token_groups": "use_token_groups",
 		}
 
 		for stateAttr, apiAttr := range attrs {

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -63,6 +63,8 @@ The following arguments are supported:
 
 * `groupattr` - (Optional) LDAP attribute to follow on objects returned by groupfilter
 
+* `use_token_auth` - (Optional) Use the Active Directory tokenGroups constructed attribute of the user to find the group memberships
+
 * `path` - (Optional) Path to mount the LDAP auth backend under
 
 * `description` - (Optional) Description for the LDAP auth backend mount


### PR DESCRIPTION
Adding the `use_token_groups` field allowing the user to configure this property with terraform.


Source in vault config: https://github.com/hashicorp/vault/blob/v1.1.0/helper/ldaputil/config.go#L134