### PR TITLE
Fix typo in sidebar for vault provider

### DIFF
--- a/website/vault.erb
+++ b/website/vault.erb
@@ -268,7 +268,7 @@
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-ssh-secret-backend-role") %>>
-                            <a href="/docs/providers/vault/r/ssh_secret_backend_role.html">ssh_secret_backend_role</a>
+                            <a href="/docs/providers/vault/r/ssh_secret_backend_role.html">vault_ssh_secret_backend_role</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-rabbitmq-secret-backend") %>>


### PR DESCRIPTION
Just saw this typo when looking for this resource in the docs.