### PR TITLE
implement renewal of pki certs with min_seconds_remaining argument

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-getter v0.0.0-20190326194518-69dec094fde6 // indirect
 	github.com/hashicorp/go-hclog v0.8.0 // indirect
 	github.com/hashicorp/go-plugin v1.0.0 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/hashicorp/go-retryablehttp v0.5.1 h1:Vsx5XKPqPs3M6sM4U4GWyUqFS8aBiL9U
 github.com/hashicorp/go-retryablehttp v0.5.1/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90 h1:VBj0QYQ0u2MCJzBfeYXGexnAl17GsH1yidnoxCqqD9E=
 github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90/go.mod h1:o4zcYY1e0GEZI6eSEr+43QDYmuGglw1qSO6qdHUHCgg=
+github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82kpwzSwCI=
+github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-safetemp v0.0.0-20180326211150-b1a1dbde6fdc/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -132,5 +133,129 @@ resource "vault_pki_secret_backend_cert" "test" {
   name = "${vault_pki_secret_backend_role.test.name}"
   common_name = "cert.test.my.domain"
   ttl = "720h"
+  min_seconds_remaining = 60
 }`, rootPath, intermediatePath)
+}
+
+func TestPkiSecretBackendCert_renew(t *testing.T) {
+	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testPkiSecretBackendCertDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPkiSecretBackendCertConfig_renew(rootPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "backend", rootPath),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "ttl", "1h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "min_seconds_remaining", "3595"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_cert.test", "expiration"),
+				),
+			},
+			{
+				Config:   testPkiSecretBackendCertConfig_renew(rootPath),
+				PlanOnly: true,
+			},
+			{
+				Config: testPkiSecretBackendCertConfig_renew(rootPath),
+				Check: resource.ComposeTestCheckFunc(
+					testPkiSecretBackendCertWaitUntilRenewal("vault_pki_secret_backend_cert.test"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "backend", rootPath),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "ttl", "1h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "min_seconds_remaining", "3595"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_cert.test", "expiration"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testPkiSecretBackendCertConfig_renew(rootPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "backend", rootPath),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "ttl", "1h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_cert.test", "min_seconds_remaining", "3595"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_cert.test", "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func testPkiSecretBackendCertConfig_renew(rootPath string) string {
+	return fmt.Sprintf(`
+resource "vault_pki_secret_backend" "test-root" {
+  path = "%s"
+  description = "test root"
+  default_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds = "8640000"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test" {
+  depends_on = [ "vault_pki_secret_backend.test-root" ]
+  backend = "${vault_pki_secret_backend.test-root.path}"
+  type = "internal"
+  common_name = "my.domain"
+  ttl = "86400"
+  format = "pem"
+  private_key_format = "der"
+  key_type = "rsa"
+  key_bits = 4096
+  ou = "test"
+  organization = "test"
+  country = "test"
+  locality = "test"
+  province = "test"
+}
+
+resource "vault_pki_secret_backend_role" "test" {
+  depends_on = [ "vault_pki_secret_backend_root_cert.test" ]
+  backend = "${vault_pki_secret_backend.test-root.path}"
+  name = "test"
+  allowed_domains  = ["test.my.domain"]
+  allow_subdomains = true
+  max_ttl = "3600"
+  key_usage = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+}
+
+resource "vault_pki_secret_backend_cert" "test" {
+  depends_on = [ "vault_pki_secret_backend_role.test" ]
+  backend = "${vault_pki_secret_backend.test-root.path}"
+  name = "${vault_pki_secret_backend_role.test.name}"
+  common_name = "cert.test.my.domain"
+  ttl = "1h"
+  auto_renew = true
+  min_seconds_remaining = "3595"
+}`, rootPath)
+}
+
+func testPkiSecretBackendCertWaitUntilRenewal(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		expiration, err := strconv.Atoi(rs.Primary.Attributes["expiration"])
+		if err != nil {
+			return fmt.Errorf("Invalid expiration value: %s", err)
+		}
+
+		minSecondsRemain, err := strconv.Atoi(rs.Primary.Attributes["min_seconds_remaining"])
+		if err != nil {
+			return fmt.Errorf("Invalid min_seconds_remaining value: %s", err)
+		}
+
+		secondsUntilRenewal := (expiration - (int(time.Now().Unix()) + minSecondsRemain))
+		time.Sleep(time.Duration(secondsUntilRenewal+1) * time.Second)
+
+		return nil
+	}
 }

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
+
+	"strconv"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/vault/api"
-	"strconv"
 )
 
 func TestPkiSecretBackendSign_basic(t *testing.T) {
@@ -160,4 +162,155 @@ o3DybUeUmknYjl109rdSf+76nuREICHatxXgN3xCMFuBaN4WLO+ksd6Y1Ys=
 EOT
   common_name = "cert.test.my.domain"
 }`, rootPath, intermediatePath)
+}
+
+func TestPkiSecretBackendSign_renew(t *testing.T) {
+	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testPkiSecretBackendCertDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPkiSecretBackendSignConfig_renew(rootPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "backend", rootPath),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "ttl", "1h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "min_seconds_remaining", "3595"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "expiration"),
+				),
+			},
+			{
+				Config:   testPkiSecretBackendSignConfig_renew(rootPath),
+				PlanOnly: true,
+			},
+			{
+				Config: testPkiSecretBackendSignConfig_renew(rootPath),
+				Check: resource.ComposeTestCheckFunc(
+					testPkiSecretBackendSignWaitUntilRenewal("vault_pki_secret_backend_sign.test"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "backend", rootPath),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "ttl", "1h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "min_seconds_remaining", "3595"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "expiration"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testPkiSecretBackendSignConfig_renew(rootPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "backend", rootPath),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "ttl", "1h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "min_seconds_remaining", "3595"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func testPkiSecretBackendSignConfig_renew(rootPath string) string {
+	return fmt.Sprintf(`
+resource "vault_pki_secret_backend" "test-root" {
+  path = "%s"
+  description = "test root"
+  default_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds = "8640000"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test" {
+  backend = "${vault_pki_secret_backend.test-root.path}"
+  type = "internal"
+  common_name = "my.domain"
+  ttl = "86400"
+  format = "pem"
+  private_key_format = "der"
+  key_type = "rsa"
+  key_bits = 4096
+  ou = "test"
+  organization = "test"
+  country = "test"
+  locality = "test"
+  province = "test"
+}
+
+resource "vault_pki_secret_backend_role" "test" {
+  depends_on = [ "vault_pki_secret_backend_root_cert.test" ]
+  backend = "${vault_pki_secret_backend.test-root.path}"
+  name = "test"
+  allowed_domains  = ["test.my.domain"]
+  allow_subdomains = true
+  max_ttl = "3600"
+  key_usage = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+}
+
+resource "vault_pki_secret_backend_sign" "test" {
+  depends_on = [ "vault_pki_secret_backend_role.test" ]
+  backend = "${vault_pki_secret_backend.test-root.path}"
+  name = "${vault_pki_secret_backend_role.test.name}"
+  csr = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIIEqDCCApACAQAwYzELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUx
+ITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEcMBoGA1UEAwwTY2Vy
+dC50ZXN0Lm15LmRvbWFpbjCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
+AJupYCQ8UVCWII1Zof1c6YcSSaM9hEaDU78cfKP5RoSeH10BvrWRfT+mzCONVpNP
+CW9Iabtvk6hm0ot6ilnndEyVJbc0g7hdDLBX5BM25D+DGZGJRKUz1V+uBrWmXtIt
+Vonj7JTDTe7ViH0GDsB7CvqXFGXO2a2cDYBchLkL6vQiFPshxvUsLtwxuy/qdYgy
+X6ya+AUoZcoQGy1XxNjfH6cPtWSWQGEp1oPR6vL9hU3laTZb3C+VV4jZem+he8/0
+V+qV6fLG92WTXm2hmf8nrtUqqJ+C7mW/RJod+TviviBadIX0OHXW7k5HVsZood01
+te8vMRUNJNiZfa9EMIK5oncbQn0LcM3Wo9VrjpL7jREb/4HCS2gswYGv7hzk9cCS
+kVY4rDucchKbApuI3kfzmO7GFOF5eiSkYZpY/czNn7VVM3WCu6dpOX4+3rhgrZQw
+kY14L930DaLVRUgve/zKVP2D2GHdEOs+MbV7s96UgigT9pXly/yHPj+1sSYqmnaD
+5b7jSeJusmzO/nrwXVGLsnezR87VzHl9Ux9g5s6zh+R+PrZuVxYsLvoUpaasH47O
+gIcBzSb/6pSGZKAUizmYsHsR1k88dAvsQ+FsUDaNokdi9VndEB4QPmiFmjyLV+0I
+1TFoXop4sW11NPz1YCq+IxnYrEaIN3PyhY0GvBJDFY1/AgMBAAGgADANBgkqhkiG
+9w0BAQsFAAOCAgEActuqnqS8Y9UF7e08w7tR3FPzGecWreuvxILrlFEZJxiLPFqL
+It7uJvtypCVQvz6UQzKdBYO7tMpRaWViB8DrWzXNZjLMrg+QHcpveg8C0Ett4scG
+fnvLk6fTDFYrnGvwHTqiHos5i0y3bFLyS1BGwSpdLAykGtvC+VM8mRyw/Y7CPcKN
+77kebY/9xduW1g2uxWLr0x90RuQDv9psPojT+59tRLGSp5Kt0IeD3QtnAZEFE4aN
+vt+Pd69eg3BgZ8ZeDgoqAw3yppvOkpAFiE5pw2qPZaM4SRphl4d2Lek2zNIMyZqv
+do5zh356HOgXtDaSg0POnRGrN/Ua+LMCRTg6GEPUnx9uQb/zt8Zu0hIexDGyykp1
+OGqtWlv/Nc8UYuS38v0BeB6bMPeoqQUjkqs8nHlAEFn0KlgYdtDC+7SdQx6wS4te
+dBKRNDfC4lS3jYJgs55jHqonZgkpSi3bamlxpfpW0ukGBcmq91wRe4bOw/4uD/vf
+UwqMWOdCYcU3mdYNjTWy22ORW3SGFQxMBwpUEURCSoeqWr6aJeQ7KAYkx1PrB5T8
+OTEc13lWf+B0PU9UJuGTsmpIuImPDVd0EVDayr3mT5dDbqTVDbe8ppf2IswABmf0
+o3DybUeUmknYjl109rdSf+76nuREICHatxXgN3xCMFuBaN4WLO+ksd6Y1Ys=
+-----END CERTIFICATE REQUEST-----
+EOT
+  common_name = "cert.test.my.domain"
+  ttl = "1h"
+  auto_renew = true
+  min_seconds_remaining = "3595"
+}`, rootPath)
+}
+
+func testPkiSecretBackendSignWaitUntilRenewal(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		expiration, err := strconv.Atoi(rs.Primary.Attributes["expiration"])
+		if err != nil {
+			return fmt.Errorf("Invalid expiration value: %s", err)
+		}
+
+		minSecondsRemain, err := strconv.Atoi(rs.Primary.Attributes["min_seconds_remaining"])
+		if err != nil {
+			return fmt.Errorf("Invalid min_seconds_remaining value: %s", err)
+		}
+
+		secondsUntilRenewal := (expiration - (int(time.Now().Unix()) + minSecondsRemain))
+		time.Sleep(time.Duration(secondsUntilRenewal+1) * time.Second)
+
+		return nil
+	}
 }

--- a/website/docs/r/pki_secret_backend_cert.html.md
+++ b/website/docs/r/pki_secret_backend_cert.html.md
@@ -22,7 +22,7 @@ for more details.
 ```hcl
 resource "vault_pki_secret_backend_cert" "app" {
   depends_on = [ "vault_pki_secret_backend_role.admin" ]
-  
+
   backend = "${vault_pki_secret_backend.intermediate.path}"
   name = "${vault_pki_secret_backend_role.test.name}"
 
@@ -46,13 +46,15 @@ The following arguments are supported:
 
 * `other_sans` - (Optional) List of other SANs
 
-* `ttl` - (Optional) Time to leave
+* `ttl` - (Optional) Time to live
 
 * `format` - (Optional) The format of data
 
 * `private_key_format` - (Optional) The private key format
 
 * `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
+
+* `min_seconds_remaining` - (Optional) Generate a new certificate when the expiration is within this number of seconds, default is 604800 (7 days)
 
 ## Attributes Reference
 
@@ -69,3 +71,5 @@ In addition to the fields above, the following attributes are exported:
 * `private_key_type` - The private key type
 
 * `serial_number` - The serial number
+
+* `expiration` - The expiration date of the certificate in unix epoch format

--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -22,9 +22,9 @@ for more details.
 ```hcl
 resource "vault_pki_secret_backend_root_cert" "test" {
   depends_on = [ "vault_pki_secret_backend.pki" ]
-  
+
   backend = "${vault_pki_secret_backend.pki.path}"
-  
+
   type = "internal"
   common_name = "Root CA"
   ttl = "315360000"
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `other_sans` - (Optional) List of other SANs
 
-* `ttl` - (Optional) Time to leave
+* `ttl` - (Optional) Time to live
 
 * `format` - (Optional) The format of data
 
@@ -68,10 +68,10 @@ The following arguments are supported:
 
 * `max_path_length` - (Optional) The maximum path length to encode in the generated certificate
 
-* `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs	
+* `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
 
 * `permitted_dns_domains` - (Optional) List of domains for which certificates are allowed to be issued
-			
+
 * `ou` - (Optional) The organization unit
 
 * `organization` - (Optional) The organization

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -15,9 +15,9 @@ Creates an PKI certificate.
 ```hcl
 resource "vault_pki_secret_backend_root_sign_intermediate" "root" {
   depends_on = [ "vault_pki_secret_backend_intermediate_cert_request.intermediate" ]
-  
+
   backend = "${vault_pki_secret_backend.root.path}"
-  
+
   csr = "${vault_pki_secret_backend_intermediate_cert_request.intermediate.csr}"
   common_name = "Intermediate CA"
   exclude_cn_from_sans = true
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `other_sans` - (Optional) List of other SANs
 
-* `ttl` - (Optional) Time to leave
+* `ttl` - (Optional) Time to live
 
 * `format` - (Optional) The format of data
 
@@ -56,12 +56,12 @@ The following arguments are supported:
 
 * `max_path_length` - (Optional) The maximum path length to encode in the generated certificate
 
-* `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs	
+* `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
 
 * `use_csr_values` - (Optional) Preserve CSR values
 
 * `permitted_dns_domains` - (Optional) List of domains for which certificates are allowed to be issued
-			
+
 * `ou` - (Optional) The organization unit
 
 * `organization` - (Optional) The organization

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -22,9 +22,9 @@ for more details.
 ```hcl
 resource "vault_pki_secret_backend_sign" "test" {
   depends_on = [ "vault_pki_secret_backend_role.admin" ]
-  
+
   backend = "${vault_pki_secret_backend.pki.path}"
-  
+
   name = "${vault_pki_secret_backend_role.admin.name}"
   csr = <<EOT
 -----BEGIN CERTIFICATE REQUEST-----
@@ -79,11 +79,13 @@ The following arguments are supported:
 
 * `uri_sans` - (Optional) List of alterative URIs
 
-* `ttl` - (Optional) Time to leave
+* `ttl` - (Optional) Time to live
 
 * `format` - (Optional) The format of data
 
 * `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
+
+* `min_seconds_remaining` - (Optional) Generate a new certificate when the expiration is within this number of seconds, default is 604800 (7 days)
 
 ## Attributes Reference
 
@@ -96,3 +98,5 @@ In addition to the fields above, the following attributes are exported:
 * `ca_chain` - The CA chain
 
 * `serial` - The serial
+
+* `expiration` - The expiration date of the certificate in unix epoch format


### PR DESCRIPTION
This implements renewal for certificates in the `vault_pki_secret_backend_cert` and `vault_pki_secret_backend_sign` resources.  Related issue: https://github.com/terraform-providers/terraform-provider-vault/issues/353

Some notes on the implementation:

* Adds a new optional argument `min_seconds_remaining`. The  default is 7 days (604800s). If the certificate's `expiration` is within this many seconds a new certificate will be fetched from Vault. The reason I chose to go with seconds instead of days was to cover cases where short-lived (perhaps less than a day) certificates are desired. I suppose "hours" might be a reasonable choice here as well. Days would be too long.

* Adds a new computed attribute `expiration` to these resources. This value was already being returned by the Vault API and now it will be stored in TF state.

* Based loosely off of the way in which the acme TF provider handles cert refresh, except they use `min_days_remaining`. This seems fine for certs issued by public CAs but some internal CAs may desire shorter expiration - https://github.com/terraform-providers/terraform-provider-acme/blob/0077b51dadc8b9fc4485e5b2a2844dedb063d9ae/acme/resource_acme_certificate.go#L83-L109

* I bumped the `mitchellh/copystructure` and `mitchellh/reflectwalk` vendor'd deps to `v1.0.0`. I ran into a bug `panic: interface conversion: interface {} is schema.schemaMap, not *schema.schemaMap` when implementing the custom Diff funcs and this was the resolution.