### PR TITLE
Allow vault_ldap_auth resources to be imported

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -21,6 +21,9 @@ func ldapAuthBackendResource() *schema.Resource {
 		Read:   ldapAuthBackendRead,
 		Delete: ldapAuthBackendDelete,
 		Exists: ldapAuthBackendExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"url": {

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -258,6 +258,8 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
 
+	d.Set("path", path)
+
 	authMount := auths[strings.Trim(path, "/")+"/"]
 	if authMount == nil {
 		return fmt.Errorf("auth mount %s not present", path)

--- a/vault/resource_ldap_auth_backend_group.go
+++ b/vault/resource_ldap_auth_backend_group.go
@@ -19,6 +19,9 @@ func ldapAuthBackendGroupResource() *schema.Resource {
 		Read:   ldapAuthBackendGroupResourceRead,
 		Delete: ldapAuthBackendGroupResourceDelete,
 		Exists: ldapAuthBackendGroupResourceExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"groupname": {

--- a/vault/resource_ldap_auth_backend_group.go
+++ b/vault/resource_ldap_auth_backend_group.go
@@ -3,11 +3,17 @@ package vault
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/hashicorp/vault/api"
+)
+
+var (
+	ldapAuthBackendGroupBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/groups/.+$")
+	ldapAuthBackendGroupNameFromPathRegex    = regexp.MustCompile("^auth/.+/groups/(.+)$")
 )
 
 func ldapAuthBackendGroupResource() *schema.Resource {
@@ -84,6 +90,16 @@ func ldapAuthBackendGroupResourceRead(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*api.Client)
 	path := d.Id()
 
+	backend, err := ldapAuthBackendGroupBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for LDAP auth backend group: %s", path, err)
+	}
+
+	groupname, err := ldapAuthBackendGroupNameFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for LDAP auth backend group: %s", path, err)
+	}
+
 	log.Printf("[DEBUG] Reading LDAP group %q", path)
 	resp, err := client.Logical().Read(path)
 	if err != nil {
@@ -100,6 +116,9 @@ func ldapAuthBackendGroupResourceRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("policies",
 		schema.NewSet(
 			schema.HashString, resp.Data["policies"].([]interface{})))
+
+	d.Set("backend", backend)
+	d.Set("groupname", groupname)
 
 	return nil
 
@@ -131,4 +150,26 @@ func ldapAuthBackendGroupResourceExists(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Checked if LDAP group %q exists", path)
 
 	return resp != nil, nil
+}
+
+func ldapAuthBackendGroupNameFromPath(path string) (string, error) {
+	if !ldapAuthBackendGroupNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no group found")
+	}
+	res := ldapAuthBackendGroupNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}
+
+func ldapAuthBackendGroupBackendFromPath(path string) (string, error) {
+	if !ldapAuthBackendGroupBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := ldapAuthBackendGroupBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
 }

--- a/vault/resource_ldap_auth_backend_group_test.go
+++ b/vault/resource_ldap_auth_backend_group_test.go
@@ -14,6 +14,33 @@ import (
 	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
+func TestLDAPAuthBackendGroup_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
+	groupname := acctest.RandomWithPrefix("tf-test-ldap-group")
+
+	policies := []string{
+		acctest.RandomWithPrefix("policy"),
+		acctest.RandomWithPrefix("policy"),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testLDAPAuthBackendGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testLDAPAuthBackendGroupConfig_basic(backend, groupname, policies),
+				Check:  testLDAPAuthBackendGroupCheck_attrs(backend, groupname),
+			},
+			{
+				ResourceName:      "vault_ldap_auth_backend_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestLDAPAuthBackendGroup_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
 	groupname := acctest.RandomWithPrefix("tf-test-ldap-group")

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -13,6 +13,27 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
+func TestLDAPAuthBackend_import(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-test-ldap-path")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testLDAPAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testLDAPAuthBackendConfig_basic(path),
+				Check:  testLDAPAuthBackendCheck_attrs(path),
+			},
+			{
+				ResourceName:      "vault_ldap_auth_backend.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestLDAPAuthBackend_basic(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-ldap-path")
 

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -26,9 +26,10 @@ func TestLDAPAuthBackend_import(t *testing.T) {
 				Check:  testLDAPAuthBackendCheck_attrs(path),
 			},
 			{
-				ResourceName:      "vault_ldap_auth_backend.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "vault_ldap_auth_backend.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bindpass"},
 			},
 		},
 	})

--- a/vault/resource_ldap_auth_backend_user.go
+++ b/vault/resource_ldap_auth_backend_user.go
@@ -19,6 +19,9 @@ func ldapAuthBackendUserResource() *schema.Resource {
 		Read:   ldapAuthBackendUserResourceRead,
 		Delete: ldapAuthBackendUserResourceDelete,
 		Exists: ldapAuthBackendUserResourceExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"username": {

--- a/vault/resource_ldap_auth_backend_user_test.go
+++ b/vault/resource_ldap_auth_backend_user_test.go
@@ -14,6 +14,41 @@ import (
 	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
+func TestLDAPAuthBackendUser_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
+	username := acctest.RandomWithPrefix("tf-test-ldap-user")
+
+	policies := []string{
+		acctest.RandomWithPrefix("policy"),
+		acctest.RandomWithPrefix("policy"),
+	}
+
+	groups := []string{
+		acctest.RandomWithPrefix("group"),
+		acctest.RandomWithPrefix("group"),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testLDAPAuthBackendUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testLDAPAuthBackendUserConfig_basic(backend, username, policies, groups),
+				Check: resource.ComposeTestCheckFunc(
+					testLDAPAuthBackendUserCheck_attrs(backend, username),
+					testLDAPAuthBackendUserCheck_groups(backend, username, groups),
+				),
+			},
+			{
+				ResourceName:      "vault_ldap_auth_backend_user.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestLDAPAuthBackendUser_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
 	username := acctest.RandomWithPrefix("tf-test-ldap-user")

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -81,3 +81,11 @@ previously stored values.
 In addition to the fields above, the following attributes are exported:
 
 * `accessor` - The accessor for this auth mount.
+
+## Import
+
+LDAP authentication backends can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_ldap_auth_backend.ldap ldap
+```

--- a/website/docs/r/ldap_auth_backend_group.html.md
+++ b/website/docs/r/ldap_auth_backend_group.html.md
@@ -46,3 +46,11 @@ For more details on the usage of each argument consult the [Vault LDAP API docum
 ## Attribute Reference
 
 No additional attributes are exposed by this resource.
+
+## Import
+
+LDAP authentication backend groups can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_ldap_auth_backend_group.foo auth/ldap/groups/foo
+```

--- a/website/docs/r/ldap_auth_backend_user.html.md
+++ b/website/docs/r/ldap_auth_backend_user.html.md
@@ -48,3 +48,11 @@ For more details on the usage of each argument consult the [Vault LDAP API docum
 ## Attribute Reference
 
 No additional attributes are exposed by this resource.
+
+## Import
+
+LDAP authentication backend users can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_ldap_auth_backend_user.foo auth/ldap/users/foo
+```


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-vault/issues/383

Having pushed this, I now see that the `ldap_auth_backend` part of this may become redundant, given https://github.com/terraform-providers/terraform-provider-vault/pull/273