### PR TITLE
Fixes trailing slash issue for namespaces

### DIFF
--- a/vault/resource_namespace_test.go
+++ b/vault/resource_namespace_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"os"
@@ -9,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/api"
 )
 
 func TestNamespace_basic(t *testing.T) {
@@ -18,15 +20,21 @@ func TestNamespace_basic(t *testing.T) {
 		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")
 	}
 
-	namespacePath := acctest.RandomWithPrefix("test-namespace") + "/"
+	namespacePath := acctest.RandomWithPrefix("test-namespace")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testNamespaceDestroy(namespacePath),
 		Steps: []resource.TestStep{
 			{
 				Config: testNamespaceConfig(namespacePath),
 				Check:  testNamespaceCheckAttrs(),
+			},
+			{
+				Config:      testNamespaceConfig(namespacePath + "/"),
+				Destroy:     false,
+				ExpectError: regexp.MustCompile("vault_namespace\\.test: cannot write to a path ending in '/'"),
 			},
 		},
 	})
@@ -42,6 +50,22 @@ func testNamespaceCheckAttrs() resource.TestCheckFunc {
 		instanceState := resourceState.Primary
 		if instanceState == nil {
 			return fmt.Errorf("resource has no primary instance")
+		}
+
+		return nil
+	}
+}
+
+func testNamespaceDestroy(path string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testProvider.Meta().(*api.Client)
+
+		namespaceRef, err := client.Logical().Read(fmt.Sprintf("/sys/namespaces/%s", path))
+		if err != nil {
+			return fmt.Errorf("error reading back configuration: %s", err)
+		}
+		if namespaceRef != nil {
+			return fmt.Errorf("namespace still exists")
 		}
 
 		return nil

--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -16,7 +16,7 @@ Provides a resource to manage [Namespaces](https://www.vaultproject.io/docs/ente
 
 ```hcl
 resource "vault_namespace" "ns1" {
-  path = "ns1/"
+  path = "ns1"
 }
 ```
 
@@ -24,7 +24,7 @@ resource "vault_namespace" "ns1" {
 
 The following arguments are supported:
 
-* `path` - (Required) The path of the namespace
+* `path` - (Required) The path of the namespace. Must not have a trailing `/`
 
 ## Attributes Reference
 


### PR DESCRIPTION
* Currently the answer from the API returns a trailing slash
* Looking in other resources, we validate against having a trailing slash
* use `filepath.Clean` to trim trailing slash from API response
* Added test to delete resource so test could be run multiple times

Fixes #390 