### PR TITLE
Don't overwrite vault_namespace path with response value.

### DIFF
--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -75,7 +75,6 @@ func namespaceRead(d *schema.ResourceData, meta interface{}) error {
 	// remove trailing slash
 	namespacePath := filepath.Clean(resp.Data["path"].(string))
 
-	d.Set("path", namespacePath)
 	d.SetId(resp.Data["id"].(string))
 
 	return nil

--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"fmt"
 	"log"
-	"path/filepath"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/vault/api"
@@ -71,9 +70,6 @@ func namespaceRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
-
-	// remove trailing slash
-	namespacePath := filepath.Clean(resp.Data["path"].(string))
 
 	d.SetId(resp.Data["id"].(string))
 

--- a/vault/resource_namespace_test.go
+++ b/vault/resource_namespace_test.go
@@ -110,7 +110,7 @@ func testNestedNamespaceCheckAttrs(expectedPath string) resource.TestCheckFunc {
 			return fmt.Errorf("child namespace resource has no primary instance")
 		}
 
-		actualPath := resourceState.Primary.Attributes["path"]
+		actualPath := instanceState.Attributes["path"]
 		if actualPath != expectedPath {
 			return fmt.Errorf("expected path to be %s, got %s", expectedPath, actualPath)
 		}

--- a/vault/resource_namespace_test.go
+++ b/vault/resource_namespace_test.go
@@ -21,6 +21,7 @@ func TestNamespace_basic(t *testing.T) {
 	}
 
 	namespacePath := acctest.RandomWithPrefix("test-namespace")
+	childPath := acctest.RandomWithPrefix("child-namespace")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,6 +36,10 @@ func TestNamespace_basic(t *testing.T) {
 				Config:      testNamespaceConfig(namespacePath + "/"),
 				Destroy:     false,
 				ExpectError: regexp.MustCompile("vault_namespace\\.test: cannot write to a path ending in '/'"),
+			},
+			{
+				Config: testNestedNamespaceConfig(namespacePath, childPath),
+				Check:  testNestedNamespaceCheckAttrs(childPath),
 			},
 		},
 	})
@@ -79,4 +84,37 @@ resource "vault_namespace" "test" {
 }
 `, path)
 
+}
+
+func testNestedNamespaceConfig(parentPath, childPath string) string {
+	return fmt.Sprintf(`
+provider "vault" {
+	namespace = %q
+}
+
+resource "vault_namespace" "test_child" {
+	path = %q
+}
+`, parentPath, childPath)
+}
+
+func testNestedNamespaceCheckAttrs(expectedPath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_namespace.test_child"]
+		if resourceState == nil {
+			return fmt.Errorf("child namespace resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("child namespace resource has no primary instance")
+		}
+
+		actualPath := resourceState.Primary.Attributes["path"]
+		if actualPath != expectedPath {
+			return fmt.Errorf("expected path to be %s, got %s", expectedPath, actualPath)
+		}
+
+		return nil
+	}
 }


### PR DESCRIPTION
Overwriting the path with the one returned by Vault causes an invalid namespace to be set when using nested namespaces.
ex: `namespace-b` which is inside `namespace-a` will have the path overwritten with `namespace-a/namespace-b/` when the correct value is `namespace-b/`