### PR TITLE
Fix GCP auth backend role

### DIFF
--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -146,6 +146,14 @@ func gcpRoleUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
 		data["type"] = v.(string)
 	}
 
+	if v, ok := d.GetOk("project_id"); ok {
+		data["project_id"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("bound_projects"); ok {
+		data["bound_projects"] = v.(*schema.Set).List()
+	}
+
 	if v, ok := d.GetOk("ttl"); ok {
 		data["ttl"] = v.(string)
 	}

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -107,7 +107,7 @@ func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckF
 
 		attrs := map[string]string{
 			"type":                   "type",
-			"bound_projects":         "project_id",
+			"bound_projects":         "bound_projects",
 			"ttl":                    "ttl",
 			"max_ttl":                "max_ttl",
 			"period":                 "period",
@@ -206,7 +206,7 @@ resource "vault_gcp_auth_backend_role" "test" {
     role                   = "%s"
     type                   = "iam"
     bound_service_accounts = ["%s"]
-    project_id             = "%s"
+    bound_projects         = ["%s"]
     ttl                    = 300
     max_ttl                = 600
     policies               = ["policy_a", "policy_b"]
@@ -229,7 +229,7 @@ resource "vault_gcp_auth_backend_role" "test" {
     backend                = "${vault_auth_backend.gcp.path}"
     role                   = "%s"
     type                   = "gce"
-    project_id             = "%s"
+    bound_projects         = ["%s"]
     ttl                    = 300
     max_ttl                = 600
     policies               = ["policy_a", "policy_b"]


### PR DESCRIPTION
Add `project_id` and `bound_projects` back to request payload when creating/updating
a GCP auth backend role
Possible fix for #394