### PR TITLE
Implement "accessor" attribute on vault_okta_auth_backend

### DIFF
--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -192,6 +192,12 @@ func oktaAuthBackendResource() *schema.Resource {
 				},
 				Set: resourceOktaUserHash,
 			},
+
+			"accessor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The mount accessor related to the auth mount.",
+			},
 		},
 	}
 }
@@ -205,14 +211,19 @@ func oktaAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Writing auth %s to Vault", authType)
 
-	err := client.Sys().EnableAuth(path, authType, desc)
+	// client.Sys().EnableAuth() is deprecated.
+	//err := client.Sys().EnableAuth(path, authType, desc)
+	err := client.Sys().EnableAuthWithOptions(path, &api.EnableAuthOptions{
+		Type:        authType,
+		Description: desc,
+	})
 
 	if err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}
+	log.Printf("[INFO] Enabled okta auth backend at '%s'", path)
 
 	d.SetId(path)
-
 	return oktaAuthBackendUpdate(d, meta)
 }
 
@@ -249,6 +260,13 @@ func oktaAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
+
+	mount, err := authMountInfoGet(client, path)
+	if err != nil {
+		return fmt.Errorf("error reading okta oth mount from '%q': %s", path, err)
+	}
+
+	d.Set("accessor", mount.Accessor)
 
 	log.Printf("[DEBUG] Reading groups for mount %s from Vault", path)
 	groups, err := oktaReadAllGroups(client, path)

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -117,6 +117,10 @@ func testOktaAuthBackend_InitialCheck(s *terraform.State) error {
 		return fmt.Errorf("incorrect ttl: %s", config.Data["ttl"])
 	}
 
+	if instanceState.Attributes["accessor"] != authMount.Accessor {
+		return fmt.Errorf("incorrect accessor: %s", instanceState.Attributes["accessor"])
+	}
+
 	return nil
 }
 

--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -76,4 +76,6 @@ If this is not supplied only locally configured groups will be enabled.
 
 ## Attributes Reference
 
-No additional attributes are exposed by this resource.
+In addition to all arguments above, the following attributes are exported:
+
+* `accessor` - The mount accessor related to the auth mount. It is useful for integration with [Identity Secrets Engine](https://www.vaultproject.io/docs/secrets/identity/index.html).


### PR DESCRIPTION
The okta backend needed a smidge of love. Both ldap and github auth backends implemented the "accessor" attribute, and okta should have one too.

Story:
As a consumer of Vault Identities backends, I like to set aliases on my groups to bind them to groups from an auth provider. These aliases require that you know the `accessor` of an auth mount to properly bind the identity. With the github auth mount, you can simply use the interpolation syntax: 

`${vault_github_auth_backend.mybackend.accessor}`

However since okta hasn't exposed this attribute, I've had to use more hacky ways of programmatically fetching the accessor (like reading `sys/mfa/method/okta/myorg.okta.com` and getting the `mount_accessor` from the returned data). 

If this gets merged, it can be done just like `github` and `ldap` and I can reference the accessor directly from the auth mount resource. `${vault_okta_auth_backend.myokta.accessor}`

Output from unit tests:
```
=== RUN   TestOktaAuthBackendGroup
--- PASS: TestOktaAuthBackendGroup (0.16s)
=== RUN   TestOktaAuthBackend
--- PASS: TestOktaAuthBackend (0.18s)
=== RUN   TestOktaAuthBackendUser
--- PASS: TestOktaAuthBackendUser (0.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	9.954s
```

Documentation added for new attribute as well.