### PR TITLE
Remove default TTLs for vault_gcp_secret_backend

### DIFF
--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -59,13 +59,13 @@ func gcpSecretBackendResource() *schema.Resource {
 			"default_lease_ttl_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     "3600",
+				Default:     "",
 				Description: "Default lease duration for secrets in seconds",
 			},
 			"max_lease_ttl_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     "86400",
+				Default:     "",
 				Description: "Maximum possible lease duration for secrets in seconds",
 			},
 		},

--- a/vault/resource_gcp_secret_backend_test.go
+++ b/vault/resource_gcp_secret_backend_test.go
@@ -24,7 +24,7 @@ func TestGCPSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", path),
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "description", "test description"),
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "default_lease_ttl_seconds", "3600"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "max_lease_ttl_seconds", "86400"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "max_lease_ttl_seconds", "0"),
 				),
 			},
 			{
@@ -74,7 +74,6 @@ resource "vault_gcp_secret_backend" "test" {
 EOF
   description = "test description"
   default_lease_ttl_seconds = 3600
-  max_lease_ttl_seconds = 86400
 }`, path)
 }
 

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -43,10 +43,10 @@ not begin or end with a `/`. Defaults to `gcp`.
 * `description` - (Optional) A human-friendly description for this backend.
 
 * `default_lease_ttl_seconds` - (Optional) The default TTL for credentials
-issued by this backend. Defaults to '3600'.
+issued by this backend. Defaults to '0'.
 
 * `max_lease_ttl_seconds` - (Optional) The maximum TTL that can be requested
-for credentials issued by this backend. Defaults to '86400'.
+for credentials issued by this backend. Defaults to '0'.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The default in Vault API docs are "" which refers to the system TTL
settings. The resource should not attempt to set its own defaults, which
is going to be surprising for users

https://www.vaultproject.io/api/system/mounts.html#enable-secrets-engine