### PR TITLE
Vendor the go-rootcerts package

### DIFF
--- a/vendor/github.com/hashicorp/go-rootcerts/go.mod
+++ b/vendor/github.com/hashicorp/go-rootcerts/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-rootcerts
+
+require github.com/mitchellh/go-homedir v1.0.0

--- a/vendor/github.com/hashicorp/go-rootcerts/go.sum
+++ b/vendor/github.com/hashicorp/go-rootcerts/go.sum
@@ -1,0 +1,2 @@
+github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
+github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/hashicorp/go-plugin
 github.com/hashicorp/go-plugin/internal/plugin
 # github.com/hashicorp/go-retryablehttp v0.5.1
 github.com/hashicorp/go-retryablehttp
-# github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
+# github.com/hashicorp/go-rootcerts v1.0.0
 github.com/hashicorp/go-rootcerts
 # github.com/hashicorp/go-safetemp v1.0.0
 github.com/hashicorp/go-safetemp


### PR DESCRIPTION
This PR is simply from running `$ go mod vendor` on master and seeing that we need to vendor this package.