### PR TITLE
Read Namespace Information from Token

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -194,7 +194,10 @@ func providerToken(d *schema.ResourceData) (string, error) {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	clientConfig := api.DefaultConfig()
-	clientConfig.Address = d.Get("address").(string)
+	addr := d.Get("address").(string)
+	if addr != "" {
+		clientConfig.Address = addr
+	}
 
 	clientAuthI := d.Get("client_auth").([]interface{})
 	if len(clientAuthI) > 1 {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -2,18 +2,17 @@ package vault
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/vault/command/config"
-	homedir "github.com/mitchellh/go-homedir"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/vault/command/config"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 // How to run the acceptance tests for this provider:
@@ -150,8 +149,6 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 		Schema: nsProvider.Schema,
 	}
 	nsProviderData := nsProviderResource.TestResourceData()
-	// We auth to the root namespace, but will configure resources in the test namespace
-	nsProviderData.Set("token_namespace", "/")
 	nsProviderData.Set("namespace", namespacePath)
 	providerConfigure(nsProviderData)
 
@@ -218,8 +215,6 @@ func testResourceAdminPeriodicOrphanTokenCheckAttrs(namespacePath string, t *tes
 			Schema: ns2Provider.Schema,
 		}
 		ns2ProviderData := ns2ProviderResource.TestResourceData()
-		//We use the token created above to auth against the namespace (instead of root)
-		ns2ProviderData.Set("token_namespace", namespacePath)
 		ns2ProviderData.Set("namespace", namespacePath)
 		ns2ProviderData.Set("token", vaultToken)
 		providerConfigure(ns2ProviderData)

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -152,7 +152,9 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 	}
 	nsProviderData := nsProviderResource.TestResourceData()
 	nsProviderData.Set("namespace", namespacePath)
-	providerConfigure(nsProviderData)
+	if _, err := providerConfigure(nsProviderData); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a policy with sudo permissions and an orphaned periodic token within the test namespace
 	resource.Test(t, resource.TestCase{
@@ -219,7 +221,9 @@ func testResourceAdminPeriodicOrphanTokenCheckAttrs(namespacePath string, t *tes
 		ns2ProviderData := ns2ProviderResource.TestResourceData()
 		ns2ProviderData.Set("namespace", namespacePath)
 		ns2ProviderData.Set("token", vaultToken)
-		providerConfigure(ns2ProviderData)
+		if _, err := providerConfigure(ns2ProviderData); err != nil {
+			t.Fatal(err)
+		}
 
 		ns2Path := acctest.RandomWithPrefix("test-namespace2")
 

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -126,7 +126,9 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 		Schema: rootProvider.Schema,
 	}
 	rootProviderData := rootProviderResource.TestResourceData()
-	providerConfigure(rootProviderData)
+	if _, err := providerConfigure(rootProviderData); err != nil {
+		t.Fatal(err)
+	}
 
 	namespacePath := acctest.RandomWithPrefix("test-namespace")
 
@@ -208,7 +210,7 @@ func testResourceAdminPeriodicOrphanTokenCheckAttrs(namespacePath string, t *tes
 			return fmt.Errorf("token resource has no primary instance")
 		}
 
-		vaultToken := tokenResourceState.Primary.Attributes["token"]
+		vaultToken := tokenResourceState.Primary.Attributes["client_token"]
 
 		ns2Provider := Provider().(*schema.Provider)
 		ns2ProviderResource := &schema.Resource{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -133,11 +133,6 @@ variables in order to keep credential information out of the configuration.
 * `namespace` - (Optional) Set the namespace to use. May be set via the
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
 
-* `token_namespace` - (Optional) Set the namespace to authenticate to. Terraform
-  creates a limited child token during runs and if the token you provide is only
-  valid in another namespace, you'll need to specify that namespace with this parameter.
-  *Available only for Vault Enterprise*.
-
 The `client_auth` configuration block accepts the following arguments:
 
 * `cert_file` - (Required) Path to a file on local disk that contains the


### PR DESCRIPTION
This is an alternative approach to #415 where instead of providing the token namespace explicitly, we just read it from the token.  I  believe this is a better approach and will result in a more natural behavior from the provider.