### PR TITLE
Run acceptance tests through CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,44 @@
 version: 2
 jobs:
   build:
-    docker:
-    - image: circleci/golang:1.11
-    working_directory: /go/src/github.com/terraform-providers/terraform-provider-vault
+    machine: true
+    working_directory: ~/src/github.com/terraform-providers/terraform-provider-vault
     steps:
     - checkout
     - run:
+        name: "Update Go"
+        command: |
+          sudo rm -rf /usr/local/go
+          wget https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+          sudo tar -xvf go1.12.5.linux-amd64.tar.gz
+          sudo mv go /usr/local
+    - run:
+        name: "Start Vault OSS"
+        command: |
+          docker run --detach --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' --name=vault -p 8200:8200 vault:latest
+          sleep 5
+          docker port vault
+          docker logs vault
+    - run:
+        name: "Set Env Vars"
+        command: |
+          echo 'export VAULT_TOKEN="root"' >> $BASH_ENV
+          echo 'export VAULT_ADDR="http://localhost:8200"' >> $BASH_ENV
+          echo 'export TF_ACC="1"' >> $BASH_ENV
+          echo 'GO111MODULE=on' >> $BASH_ENV
+          echo 'export GOBIN=$GOPATH/bin' >> $BASH_ENV
+    - run:
+        name: "Move to GOPATH"
+        command: |
+          mkdir -p $GOPATH/src/github.com/terraform-providers/terraform-provider-vault
+          mv /home/circleci/src/github.com/terraform-providers/terraform-provider-vault/* $GOPATH/src/github.com/terraform-providers/terraform-provider-vault
+    - run:
         name: "Run Tests"
-        command: go test -v ./...
+        command: |
+          cd $GOPATH/src/github.com/terraform-providers/terraform-provider-vault
+          go test -v ./...
     - run:
         name: "Run Build"
-        command: go build
+        command: |
+          cd $GOPATH/src/github.com/terraform-providers/terraform-provider-vault
+          go build


### PR DESCRIPTION
This updates Circle CI to run a Vault docker container and use it for acceptance tests. This should help contributors know sooner when their code has broken a test, and will help maintainers know when it's safe to merge code.