### PR TITLE
[WIP] Add support for using TLS Auth and AppRole auth backends to obtain a Vault token.

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -25,7 +25,7 @@ func Provider() terraform.ResourceProvider {
 			"token": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("VAULT_TOKEN", ""),
+				DefaultFunc:   schema.EnvDefaultFunc("VAULT_TOKEN", nil),
 				ConflictsWith: []string{"approle_auth", "client_auth.login_with_tls_auth"},
 				Description:   "Token to use to authenticate to Vault.",
 			},

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -231,7 +231,7 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func providerToken(d *schema.ResourceData) (string, error) {
+func tokenFromConfigToken(d *schema.ResourceData, _ *api.Client) (string, error) {
 	if token := d.Get("token").(string); token != "" {
 		return token, nil
 	}
@@ -284,8 +284,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	client.SetMaxRetries(d.Get("max_retries").(int))
 
-	// Try an get the token from the config or token helper
-	token, err := providerToken(d)
+	token, err := tokenFromConfigToken(d, client)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Client authentication credentials.",
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cert_file": {
@@ -200,10 +201,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	clientAuthI := d.Get("client_auth").([]interface{})
-	if len(clientAuthI) > 1 {
-		return nil, fmt.Errorf("client_auth block may appear only once")
-	}
-
 	clientAuthCert := ""
 	clientAuthKey := ""
 	if len(clientAuthI) == 1 {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -397,7 +397,7 @@ func TestAccProviderToken(t *testing.T) {
 			}
 
 			// Get and check the provider token.
-			token, err := providerToken(d)
+			token, err := tokenFromConfigToken(d, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -397,7 +397,7 @@ func TestAccProviderToken(t *testing.T) {
 			}
 
 			// Get and check the provider token.
-			token, err := tokenFromConfigToken(d, nil)
+			token, err := tokenFromTokenProviders(d, nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR is a work in progress. It is functionally complete and should be correct -- I have tested the provider with these changes -- but I am holding off on adding tests and updating docs until I get feedback from the project maintainer that this is likely to be merged.

---

While Vault allows a [number of authentication methods](https://www.vaultproject.io/docs/auth/) to generate tokens for authentication, the terraform-vault-provider itself only supports tokens directly for authentication. This PR adds support for obtaining Vault tokens using TLS Auth and AppRole auth backends configured in the provider itself, in addition to direct token authentication.

I'm new both to Go and this project and so I'm not sure if the approach I've taken here with the `tokenProvider` struct is the best, and so I would appreciate feedback from the maintainers on whether there's an approach better aligned with Terraform or Go here.

This should close https://github.com/terraform-providers/terraform-provider-vault/issues/351, https://github.com/terraform-providers/terraform-provider-vault/issues/428, and https://github.com/terraform-providers/terraform-provider-vault/issues/346. 