### PR TITLE
Minor spelling fixes

### DIFF
--- a/website/docs/r/azure_auth_backend_role.html.md
+++ b/website/docs/r/azure_auth_backend_role.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `role` - (Required) The name of the role.
 
 * `bound_service_principal_ids` - (Optional) If set, defines a constraint on the
-  service principals that can perform the login operation that they should be posess
+  service principals that can perform the login operation that they should be possess
   the ids specified by this field.
 
 * `bound_group_ids` - (Optional) If set, defines a constraint on the groups

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -36,4 +36,4 @@ In addition to the fields above, the following attributes are also exposed:
 
 * `project_id` - The GCP Project ID
 
-* `client_email` - The clients email assosiated with the credentials
+* `client_email` - The clients email associated with the credentials

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -30,7 +30,7 @@ resource "vault_gcp_secret_backend" "gcp" {
 
 The following arguments are supported:
 
-* `credentials` - (Optional) The GCP service account credentails in JSON format.
+* `credentials` - (Optional) The GCP service account credentials in JSON format.
 
 ~> **Important** Because Vault does not support reading the configured
 credentials back from the API, Terraform cannot detect and correct drift


### PR DESCRIPTION
```
docker run \
   -v $(pwd):/scripts \
   --workdir=/scripts \
   nickg/misspell:latest \
   misspell -w -source=text website/
```