### PR TITLE
Add sidebar menu link to vault_policy_document document

### DIFF
--- a/website/vault.erb
+++ b/website/vault.erb
@@ -38,6 +38,10 @@
                             <a href="/docs/providers/vault/d/kubernetes_auth_backend_role.html">vault_kubernetes_auth_backend_role</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-datasource-policy-document") %>>
+                            <a href="/docs/providers/vault/d/policy_document.html">vault_policy_document</a>
+                        </li>
+                        
                     </ul>
                 </li>
 


### PR DESCRIPTION
Issue #452 

The menu link for `vault-policy-document` document has been missing from the vault provider document since added into **vault provider 1.6**