### PR TITLE
Add list type for bound claims of vault_jwt_auth_backend_role

### DIFF
--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -286,7 +286,7 @@ func TestAccJWTAuthBackendRoleOIDC_full(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"bound_claims.%", "2"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
-						"bound_claims.department", "engineering"),
+						"bound_claims.department", "engineering,admin"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"bound_claims.sector", "7g"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
@@ -503,7 +503,7 @@ resource "vault_jwt_auth_backend_role" "role" {
   num_uses = 12
   max_ttl = 7200
   bound_claims = {
-    department = "engineering",
+    department = "engineering,admin"
     sector = "7g"
   }
   claim_mappings = {


### PR DESCRIPTION
Fix #408 

Bound Claims of Vault JWT Auth Backend Role supports both string and list of strings:
https://www.vaultproject.io/api/auth/jwt/index.html#bound_claims
Implementation in `vault-plugin-auth-jwt`: https://github.com/hashicorp/vault-plugin-auth-jwt/blob/363f5913f469fff63ab979d498ea07a57a5d2639/claims.go#L92

This PR allows user to pass a comma-separated string list, while still backward compatible with single string. For example:

```hcl
resource "vault_jwt_auth_backend_role" "ops-web" {
  ...

  bound_claims = {
    department = "Engineering"
    division   = "Europe"
    email      = "fred@example.com,julie@example.com"
  }

...
}
```