### PR TITLE
Always set attribute 'data' if read is disabled

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -65,6 +65,7 @@ func genericSecretResource() *schema.Resource {
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Description: "Map of strings read from Vault.",
+				Sensitive:   true,
 			},
 		},
 	}

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -161,6 +161,7 @@ func genericSecretResourceDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
+	var data map[string]interface{}
 	shouldRead := !d.Get("disable_read").(bool)
 	if !shouldRead {
 		// if disable_read is set to false or unset (we can't know which)
@@ -187,36 +188,42 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 
 		log.Printf("[DEBUG] secret: %#v", secret)
 
+		data = secret.Data
 		jsonData, err := json.Marshal(secret.Data)
 		if err != nil {
 			return fmt.Errorf("error marshaling JSON for %q: %s", path, err)
 		}
 
-		// Since our "data" map can only contain string values, we
-		// will take strings from Data and write them in as-is,
-		// and write everything else in as a JSON serialization of
-		// whatever value we get so that complex types can be
-		// passed around and processed elsewhere if desired.
-		// Note: This is a different map to jsonData, as this can only
-		// contain strings
-		dataMap := map[string]string{}
-		for k, v := range secret.Data {
-			if vs, ok := v.(string); ok {
-				dataMap[k] = vs
-			} else {
-				// Again ignoring error because we know this value
-				// came from JSON in the first place and so must be valid.
-				vBytes, _ := json.Marshal(v)
-				dataMap[k] = string(vBytes)
-			}
-		}
-		d.Set("data", dataMap)
-
 		d.Set("data_json", string(jsonData))
 		d.Set("path", path)
 	} else {
+		// Populate data from data_json from state
+		err := json.Unmarshal([]byte(d.Get("data_json").(string)), &data)
+		if err != nil {
+			return fmt.Errorf("data_json %#v syntax error: %s", d.Get("data_json"), err)
+		}
 		log.Printf("[WARN] vault_generic_secret does not refresh when disable_read is set to true")
 	}
 	d.Set("disable_read", !shouldRead)
+
+	// Since our "data" map can only contain string values, we
+	// will take strings from Data and write them in as-is,
+	// and write everything else in as a JSON serialization of
+	// whatever value we get so that complex types can be
+	// passed around and processed elsewhere if desired.
+	// Note: This is a different map to jsonData, as this can only
+	// contain strings
+	dataMap := map[string]string{}
+	for k, v := range data {
+		if vs, ok := v.(string); ok {
+			dataMap[k] = vs
+		} else {
+			// Again ignoring error because we know this value
+			// came from JSON in the first place and so must be valid.
+			vBytes, _ := json.Marshal(v)
+			dataMap[k] = string(vBytes)
+		}
+	}
+	d.Set("data", dataMap)
 	return nil
 }


### PR DESCRIPTION
Because `data` is computed this sets it explicitly to `nil` so terraform does not detect a change on every plan.

fixes #388