### PR TITLE
aws_auth_backend_client supports nested paths

### DIFF
--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -119,11 +119,11 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
+
+	// set the backend to the original passed path (without config/client at the end)
 	idPieces := strings.Split(d.Id(), "/")
-	if len(idPieces) != 4 {
-		return fmt.Errorf("expected %q to have 4 pieces, has %d", d.Id(), len(idPieces))
-	}
-	d.Set("backend", idPieces[1])
+	d.Set("backend", idPieces[1:len(idPieces)-2])
+
 	d.Set("access_key", secret.Data["access_key"])
 	d.Set("ec2_endpoint", secret.Data["endpoint"])
 	d.Set("iam_endpoint", secret.Data["iam_endpoint"])

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -122,7 +122,7 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 
 	// set the backend to the original passed path (without config/client at the end)
 	idPieces := strings.Split(d.Id(), "/")
-	d.Set("backend", idPieces[1:len(idPieces)-2])
+	d.Set("backend", strings.Join(idPieces[1:len(idPieces)-2], "/"))
 
 	d.Set("access_key", secret.Data["access_key"])
 	d.Set("ec2_endpoint", secret.Data["endpoint"])

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -50,6 +50,25 @@ func TestAccAWSAuthBackendClient_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAuthBackendClient_nested(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws") + "/nested"
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAWSAuthBackendClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendClientConfig_basic(backend),
+				Check:  testAccAWSAuthBackendClientCheck_attrs(backend),
+			},
+			{
+				Config: testAccAWSAuthBackendClientConfig_updated(backend),
+				Check:  testAccAWSAuthBackendClientCheck_attrs(backend),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAuthBackendClientDestroy(s *terraform.State) error {
 	client := testProvider.Meta().(*api.Client)
 


### PR DESCRIPTION
Addresses #459 where the aws_auth_backend_client currently expects that the backend path for the aws auth backend client will not be nested.

Before Fix:
```
--- FAIL: TestAccAWSAuthBackendClient_nested (0.05s)
    testing.go:568: Step 0 error: errors during apply:

        Error: expected "auth/aws-8097158027947488229/nested/config/client" to have 4 pieces, has 5

          on /var/folders/nj/n5hr70hd2dx45qb__6wl10nc0000gp/T/tf-test019218845/main.tf line 8:
          (source code not available)


    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: expected "auth/aws-8097158027947488229/nested/config/client" to have 4 pieces, has 5

        State: <nil>
FAIL
```
After Fix:
```=== RUN   TestAccAWSAuthBackendClient_nested
--- PASS: TestAccAWSAuthBackendClient_nested (0.15s)
PASS
```