### PR TITLE
Add token_type to vault_auth_backend resource

### DIFF
--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -73,6 +73,15 @@ func authBackendResource() *schema.Resource {
 				Description: "Specifies whether to show this mount in the UI-specific listing endpoint",
 			},
 
+			"token_type": {
+				Type:        schema.TypeString,
+				Required:    false,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the token type",
+			},
+
 			"local": {
 				Type:        schema.TypeBool,
 				ForceNew:    true,
@@ -102,6 +111,7 @@ func authBackendWrite(d *schema.ResourceData, meta interface{}) error {
 			DefaultLeaseTTL:   fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
 			MaxLeaseTTL:       fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
 			ListingVisibility: d.Get("listing_visibility").(string),
+			TokenType:         d.Get("token_type").(string),
 		},
 		Local: d.Get("local").(bool),
 	}
@@ -155,6 +165,7 @@ func authBackendRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("default_lease_ttl_seconds", auth.Config.DefaultLeaseTTL)
 			d.Set("max_lease_ttl_seconds", auth.Config.MaxLeaseTTL)
 			d.Set("listing_visibility", auth.Config.ListingVisibility)
+			d.Set("token_type", auth.Config.TokenType)
 			d.Set("local", auth.Local)
 			d.Set("accessor", auth.Accessor)
 			return nil

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -59,6 +59,7 @@ resource "vault_auth_backend" "test" {
 	description = "Test auth backend"
 	default_lease_ttl_seconds = 3600
 	max_lease_ttl_seconds = 86400
+	token_type = "service"
 	listing_visibility = "unauth"
 	local = true
 }`, path)
@@ -102,6 +103,10 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 			return fmt.Errorf("unexpected auth max_lease_ttl_seconds")
 		}
 
+		if instanceState.Attributes["token_type"] != "service" {
+			return fmt.Errorf("unexpected auth token_type")
+		}
+
 		if instanceState.Attributes["listing_visibility"] != "unauth" {
 			return fmt.Errorf("unexpected auth listing_visibility")
 		}
@@ -132,6 +137,9 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 				}
 				if serverAuth.Config.MaxLeaseTTL != 86400 {
 					return fmt.Errorf("unexpected auth max_lease_ttl_seconds")
+				}
+				if serverAuth.Config.TokenType != "service" {
+					return fmt.Errorf("unexpected auth token_type")
 				}
 				if serverAuth.Config.ListingVisibility != "unauth" {
 					return fmt.Errorf("unexpected auth listing_visibility")

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 * `listing_visibility` - (Optional) Speficies whether to show this mount in the UI-specific listing endpoint.
 
+* `token_type` - (Optional) Specifies the token type.
+
 * `local` - (Optional) Specifies if the auth method is local only.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR adds `token_type` to the generic `vault_auth_backend`. It will use the backend default unless specified in the `resource` block. I do not see any issues referencing this problem in particular, but we have a use case requiring batch tokens for an AWS auth backend.