### PR TITLE
[WIP] Allow specifying an alternative token env var name

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -44,9 +45,14 @@ func Provider() terraform.ResourceProvider {
 			},
 			"token": {
 				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_TOKEN", ""),
+				Optional:    true,
 				Description: "Token to use to authenticate to Vault.",
+			},
+			"token_env_var": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "VAULT_TOKEN",
+				Description: "Environment variable containing the token.",
 			},
 			"ca_cert_file": {
 				Type:        schema.TypeString,
@@ -452,6 +458,11 @@ var (
 func providerToken(d *schema.ResourceData) (string, error) {
 	if token := d.Get("token").(string); token != "" {
 		return token, nil
+	}
+	if envVar := d.Get("token_env_var").(string); envVar != "" {
+		if token := os.Getenv(envVar); token != "" {
+			return token, nil
+		}
 	}
 	// Use ~/.vault-token, or the configured token helper.
 	tokenHelper, err := config.DefaultTokenHelper()


### PR DESCRIPTION
**NOTE**: I'm submitting just the code changes for feedback on the approach before updating tests and docs. Please let me know any feedback you have!

---

To support multiple Vault providers without writing tokens to disk in Terraform configuration, this commit adds a new setting to the Vault `provider` block: `token_env_var`. When set, the provider will attempt to load a Vault token from the environment variable with the given name, instead of only looking at `VAULT_TOKEN`.

This new setting will allow multiple disparate Vault servers to be managed in a single Terraform run without ever writing the tokens to disk by setting the explicit `token` value in the provider configuration. This change allows wrapper scripts to generate needed tokens via whatever authentication method is appropriate, without the provider needing to support every possible combination of authentication methods.

Example:

    provider "vault" {
      alias         = "west"
      address       = "https://vault-west.example.com"
      token_env_var = "WEST_VAULT_TOKEN"
    }

    provider "vault" {
      alias         = "east"
      address       = "https://vault-east.example.com"
      token_env_var = "EAST_VAULT_TOKEN"
    }

    resource "vault_generic_secret" "west-secret" {
      provider  = "vault.west"
      path      = "secret/creds"
      data_json = jsonencode(map(
                   "username", "dbuser",
                   "password", local.west-password,
                  ))
    }

    resource "vault_generic_secret" "east-secret" {
      provider  = "vault.east"
      path      = "secret/creds"
      data_json = jsonencode(map(
                   "username", "dbuser",
                   "password", local.east-password,
                  ))
    }