### PR TITLE
document auto_renew attribute

### DIFF
--- a/website/docs/r/pki_secret_backend_cert.html.md
+++ b/website/docs/r/pki_secret_backend_cert.html.md
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `min_seconds_remaining` - (Optional) Generate a new certificate when the expiration is within this number of seconds, default is 604800 (7 days)
 
+* `auto_renew` - (Optional) If set to `true`, certs will be renewed if the expiration is within `min_seconds_remaining`. Default `false`
+
 ## Attributes Reference
 
 In addition to the fields above, the following attributes are exported:

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -87,6 +87,8 @@ The following arguments are supported:
 
 * `min_seconds_remaining` - (Optional) Generate a new certificate when the expiration is within this number of seconds, default is 604800 (7 days)
 
+* `auto_renew` - (Optional) If set to `true`, certs will be renewed if the expiration is within `min_seconds_remaining`. Default `false`
+
 ## Attributes Reference
 
 In addition to the fields above, the following attributes are exported:


### PR DESCRIPTION
Follow-up to #386. Documents the `auto_renew` attribute.

Addresses https://github.com/terraform-providers/terraform-provider-vault/issues/353#issuecomment-516623427