### PR TITLE
Begin deprecating duplicate resource

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -22,6 +22,7 @@ const (
 	// UnknownPath is used for inventorying paths that have no obvious
 	// current endpoint they serve in Vault, and may relate to previous
 	// versions of Vault.
+	// We aim to deprecate items in this category.
 	UnknownPath = "unknown"
 )
 

--- a/vault/resource_pki_secret_backend.go
+++ b/vault/resource_pki_secret_backend.go
@@ -11,11 +11,12 @@ import (
 
 func pkiSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
-		Create: pkiSecretBackendCreate,
-		Read:   pkiSecretBackendRead,
-		Update: pkiSecretBackendUpdate,
-		Delete: pkiSecretBackendDelete,
-		Exists: pkiSecretBackendExists,
+		DeprecationMessage: `This resource duplicates "vault_mount" and will be removed in the next major release.`,
+		Create:             pkiSecretBackendCreate,
+		Read:               pkiSecretBackendRead,
+		Update:             pkiSecretBackendUpdate,
+		Delete:             pkiSecretBackendDelete,
+		Exists:             pkiSecretBackendExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},


### PR DESCRIPTION
The PKI secret resource duplicates the `vault_mount` resource. Rather than support both, we would like to move towards stripping the resource in the next major release of this provider.

This PR adds a deprecation message, the first step in this process, which should make it safe to pull in the next major version.