### PR TITLE
Use Mutex to lock Identity Group Updates

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/helper/logging"
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/vault/api"
@@ -25,6 +26,12 @@ const (
 	// We aim to deprecate items in this category.
 	UnknownPath = "unknown"
 )
+
+// This is a global MutexKV for use within this provider.
+// Use this when you need to have multiple resources or even multiple instances
+// of the same resource write to the same path in Vault.
+// The key of the mutex should be the path in Vault.
+var vaultMutexKV = mutexkv.NewMutexKV()
 
 func Provider() terraform.ResourceProvider {
 	dataSourcesMap, err := parse(DataSourceRegistry)

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -130,6 +130,9 @@ func identityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	path := identityGroupPath
 
+	vaultMutexKV.Lock(path)
+	defer vaultMutexKV.Unlock(path)
+
 	data := map[string]interface{}{
 		"name": name,
 		"type": typeValue,
@@ -157,6 +160,9 @@ func identityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Updating IdentityGroup %q", id)
 	path := identityGroupIDPath(id)
+
+	vaultMutexKV.Lock(path)
+	defer vaultMutexKV.Unlock(path)
 
 	data := map[string]interface{}{}
 

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -68,6 +68,9 @@ func identityGroupPoliciesCreate(d *schema.ResourceData, meta interface{}) error
 
 	path := identityGroupPath
 
+	vaultMutexKV.Lock(path)
+	defer vaultMutexKV.Unlock(path)
+
 	data := map[string]interface{}{
 		"id": groupId,
 	}
@@ -94,6 +97,9 @@ func identityGroupPoliciesUpdate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Updating IdentityGroupPolicies %q", id)
 	path := identityGroupIDPath(id)
+
+	vaultMutexKV.Lock(path)
+	defer vaultMutexKV.Unlock(path)
 
 	presentPolicies, err := readIdentityGroupPolicies(client, id)
 	if err != nil {


### PR DESCRIPTION
Use the same mutex mechanism used in #488 to lock Identity groups updates.