### PR TITLE
Fixed missing `name` argument in the update function

### DIFF
--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -87,6 +87,9 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 		"canonical_id":   resp.Data["canonical_id"],
 	}
 
+	if name, ok := d.GetOk("name"); ok {
+		data["name"] = name
+	}
 	if mountAccessor, ok := d.GetOk("mount_accessor"); ok {
 		data["mount_accessor"] = mountAccessor
 	}

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -86,7 +86,8 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 		"mount_accessor": resp.Data["mount_accessor"],
 		"canonical_id":   resp.Data["canonical_id"],
 	}
-
+	
+	// Added this because the change in the `name` attribute didn't update it in vault. This caused issue inside vault, also forced TF to find changes on every apply.
 	if name, ok := d.GetOk("name"); ok {
 		data["name"] = name
 	}

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -130,6 +130,11 @@ func ldapAuthBackendResource() *schema.Resource {
 					return strings.Trim(v.(string), "/")
 				},
 			},
+			"case_sensitive_names": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 
 			"accessor": {
 				Type:        schema.TypeString,
@@ -236,6 +241,9 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("use_token_groups"); ok {
 		data["use_token_groups"] = v.(bool)
 	}
+	if v, ok := d.GetOkExists("case_sensitive_names"); ok {
+		data["case_sensitive_names"] = v.(bool)
+	}
 
 	log.Printf("[DEBUG] Writing LDAP config %q", path)
 	_, err := client.Logical().Write(path, data)
@@ -299,6 +307,7 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("groupdn", resp.Data["groupdn"])
 	d.Set("groupattr", resp.Data["groupattr"])
 	d.Set("use_token_groups", resp.Data["use_token_groups"])
+	d.Set("case_sensitive_names", resp.Data["case_sensitive_names"])
 
 	// `bindpass` cannot be read out from the API
 	// So... if they drift, they drift.

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -141,6 +141,27 @@ func ldapAuthBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "The accessor of the LDAP auth backend",
 			},
+
+			"token_ttl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"token_max_ttl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"token_explicit_max_ttl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"token_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -244,6 +265,18 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOkExists("case_sensitive_names"); ok {
 		data["case_sensitive_names"] = v.(bool)
 	}
+	if v, ok := d.GetOkExists("token_ttl"); ok {
+		data["token_ttl"] = v.(string)
+	}
+	if v, ok := d.GetOkExists("token_max_ttl"); ok {
+		data["token_max_ttl"] = v.(string)
+	}
+	if v, ok := d.GetOkExists("token_explicit_max_ttl"); ok {
+		data["token_explicit_max_ttl"] = v.(string)
+	}
+	if v, ok := d.GetOkExists("token_type"); ok {
+		data["token_type"] = v.(string)
+	}
 
 	log.Printf("[DEBUG] Writing LDAP config %q", path)
 	_, err := client.Logical().Write(path, data)
@@ -308,6 +341,10 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("groupattr", resp.Data["groupattr"])
 	d.Set("use_token_groups", resp.Data["use_token_groups"])
 	d.Set("case_sensitive_names", resp.Data["case_sensitive_names"])
+	d.Set("token_ttl", resp.Data["token_ttl"])
+	d.Set("token_max_ttl", resp.Data["token_max_ttl"])
+	d.Set("token_explicit_max_ttl", resp.Data["token_explicit_max_ttl"])
+	d.Set("token_type", resp.Data["token_type"])
 
 	// `bindpass` cannot be read out from the API
 	// So... if they drift, they drift.


### PR DESCRIPTION
The update function was pulling in changes for the **mount_accessor** and the identity group's **canonical_id**, but wasn't looking for the changes in the name of the alias.

It can be updated in place, so I've added it to the function.