### PR TITLE
Fix name for all references to organization_units.

### DIFF
--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -62,7 +62,7 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
-		"allowed_organization_units": {
+		"allowed_organizational_units": {
 			Type: schema.TypeSet,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -190,8 +190,8 @@ func certAuthResourceWrite(d *schema.ResourceData, meta interface{}) error {
 		data["allowed_uri_sans"] = v.(*schema.Set).List()
 	}
 
-	if v, ok := d.GetOk("allowed_organization_units"); ok {
-		data["allowed_organization_units"] = v.(*schema.Set).List()
+	if v, ok := d.GetOk("allowed_organizational_units"); ok {
+		data["allowed_organizational_units"] = v.(*schema.Set).List()
 	}
 
 	if v, ok := d.GetOk("required_extensions"); ok {
@@ -260,8 +260,8 @@ func certAuthResourceUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["allowed_uri_sans"] = v.(*schema.Set).List()
 	}
 
-	if v, ok := d.GetOk("allowed_organization_units"); ok {
-		data["allowed_organization_units"] = v.(*schema.Set).List()
+	if v, ok := d.GetOk("allowed_organizational_units"); ok {
+		data["allowed_organizational_units"] = v.(*schema.Set).List()
 	}
 
 	if v, ok := d.GetOk("required_extensions"); ok {
@@ -435,12 +435,12 @@ func certAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
-	if resp.Data["allowed_organization_units"] != nil {
-		d.Set("allowed_organization_units",
+	if resp.Data["allowed_organizational_units"] != nil {
+		d.Set("allowed_organizational_units",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_organization_units"].([]interface{})))
+				schema.HashString, resp.Data["allowed_organizational_units"].([]interface{})))
 	} else {
-		d.Set("allowed_organization_units",
+		d.Set("allowed_organizational_units",
 			schema.NewSet(
 				schema.HashString, []interface{}{}))
 	}

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -208,19 +208,19 @@ func testCertAuthBackendCheck_attrs(backend, name string) resource.TestCheckFunc
 		}
 
 		attrs := map[string]string{
-			"name":                       "display_name",
-			"allowed_names":              "allowed_names",
-			"allowed_dns_sans":           "allowed_dns_sans",
-			"allowed_email_sans":         "allowed_email_sans",
-			"allowed_uri_sans":           "allowed_uri_sans",
-			"allowed_organization_units": "allowed_organization_units",
-			"required_extensions":        "required_extensions",
-			"token_period":               "token_period",
-			"token_policies":             "token_policies",
-			"certificate":                "certificate",
-			"token_ttl":                  "token_ttl",
-			"token_max_ttl":              "token_max_ttl",
-			"token_bound_cidrs":          "token_bound_cidrs",
+			"name":                         "display_name",
+			"allowed_names":                "allowed_names",
+			"allowed_dns_sans":             "allowed_dns_sans",
+			"allowed_email_sans":           "allowed_email_sans",
+			"allowed_uri_sans":             "allowed_uri_sans",
+			"allowed_organizational_units": "allowed_organizational_units",
+			"required_extensions":          "required_extensions",
+			"token_period":                 "token_period",
+			"token_policies":               "token_policies",
+			"certificate":                  "certificate",
+			"token_ttl":                    "token_ttl",
+			"token_max_ttl":                "token_max_ttl",
+			"token_bound_cidrs":            "token_bound_cidrs",
 		}
 
 		for stateAttr, apiAttr := range attrs {

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `allowed_uri_sans` - (Optional) Allowed URIs for authenticated client certificates
 
-* `allowed_organization_units` - (Optional) Allowed organization units for authenticated client certificates
+* `allowed_organizational_units` - (Optional) Allowed organization units for authenticated client certificates
 
 * `required_extensions` - (Optional) TLS extensions required on client certificates
 


### PR DESCRIPTION
Retry of #397 as it was closed:

The allowed_organization_units field on a cert_auth_backend_role resource in Terraform is labelled incorrectly when it should be allowed_organizational_units. This change adapts to the difference and ensures the value is actually set and read properly from vault.

The intent behind the existing tests is unclear to me and certainly doesn't complain before or after the change in this PR.

All references to the incorrectly named field have bee changed.