### PR TITLE
Don't require the GCP auth credentials field

### DIFF
--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -24,10 +24,10 @@ func gcpAuthBackendResource() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"credentials": {
 				Type:         schema.TypeString,
-				Required:     true,
 				StateFunc:    NormalizeCredentials,
 				ValidateFunc: ValidateCredentials,
 				Sensitive:    true,
+				Optional:     true,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -22,7 +22,7 @@ resource "vault_gcp_auth_backend" "gcp" {
 
 The following arguments are supported:
 
-* `credentials` - (Required) A JSON string containing the contents of a GCP credentials file.
+* `credentials` - A JSON string containing the contents of a GCP credentials file. If this value is empty, Vault will try to use Application Default Credentials from the machine on which the Vault server is running.
 
 For more details on the usage of each argument consult the [Vault GCP API documentation](https://www.vaultproject.io/api/auth/gcp/index.html#configure).
 


### PR DESCRIPTION
Closes #366 

Per [our docs](https://www.vaultproject.io/api/auth/gcp/index.html#configure), this field isn't required.