### PR TITLE
website: link to transit_secret_backend_key

### DIFF
--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -1,6 +1,6 @@
 ---
 layout: "vault"
-page_title: "Vault: vault_key_secret_backend_key resource"
+page_title: "Vault: vault_transit_secret_backend_key resource"
 sidebar_current: "docs-vault-resource-transit-secret-backend-key"
 description: |-
   Create an Encryption Keyring on a Transit Secret Backend for Vault.
@@ -14,15 +14,15 @@ Creates an Encryption Keyring on a Transit Secret Backend for Vault.
 
 ```hcl
 resource "vault_mount" "transit" {
-  path = "transit"
-  type = "transit"
-  description = "Example description"
+  path                      = "transit"
+  type                      = "transit"
+  description               = "Example description"
   default_lease_ttl_seconds = 3600
-  max_lease_ttl_seconds = 86400
+  max_lease_ttl_seconds     = 86400
 }
 
 resource "vault_transit_secret_backend_key" "key" {
-  backend = "${vault_transit_secret_backend.transit.path}"
+  backend = "${vault_mount.transit.path}"
   name    = "my_key"
 }
 ```

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -311,6 +311,10 @@
                             <a href="/docs/providers/vault/r/rabbitmq_secret_backend_role.html">vault_rabbitmq_secret_backend_role</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-transit-secret-backend-key") %>>
+                            <a href="/docs/providers/vault/r/transit_secret_backend_key.html">vault_transit_secret_backend_key</a>
+                        </li>
+
                     </ul>
                 </li>
 


### PR DESCRIPTION
The documentation on the `vault_transit_secret_backend_key` displays a probably outdated example. It's also missing from the sidebar.

cf #500 