### PR TITLE
Add import for okta backend group resource

### DIFF
--- a/vault/resource_okta_auth_backend_group_test.go
+++ b/vault/resource_okta_auth_backend_group_test.go
@@ -2,12 +2,13 @@ package vault
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/hashicorp/vault/api"
-	"strconv"
-	"testing"
 )
 
 // This is light on testing as most of the code is covered by `resource_okta_auth_backend_test.go`
@@ -25,6 +26,11 @@ func TestOktaAuthBackendGroup(t *testing.T) {
 					testOktaAuthBackendGroup_InitialCheck,
 					testOktaAuthBackend_GroupsCheck(path, "foo", []string{"one", "two", "default"}),
 				),
+			},
+			{
+				ResourceName:      "vault_okta_auth_backend_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/okta_auth_backend_group.html.md
+++ b/website/docs/r/okta_auth_backend_group.html.md
@@ -39,3 +39,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 No additional attributes are exposed by this resource.
+
+## Import
+
+Okta authentication backend groups can be imported using the format `backend/groupName` e.g.
+
+```
+$ terraform import vault_okta_auth_backend_group.foo okta/foo
+```


### PR DESCRIPTION
This supports import for the okta backend group resource.

This also fixes the Read, which I referenced from the same LDAP resource:
https://github.com/terraform-providers/terraform-provider-vault/blob/cbaa5be01887b22395ff305d8d3d358b64c30c83/vault/resource_ldap_auth_backend_group.go#L90-L126

The Read needed to use the ID, and set all attributes in the Resource.

Addresses https://github.com/terraform-providers/terraform-provider-vault/issues/511.