### PR TITLE
 Update resource_namespace.go

### DIFF
--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -64,6 +64,9 @@ func namespaceRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
 	path := d.Get("path").(string)
+	if path == "" {
+		path = d.Id()
+	}
 
 	resp, err := client.Logical().Read("sys/namespaces/" + path)
 
@@ -78,6 +81,7 @@ func namespaceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(resp.Data["id"].(string))
+	d.Set("path", path)
 
 	return nil
 }


### PR DESCRIPTION
Namespace import fail because of wrong API path:
```
URL: GET https://VAULT_ADDR/v1/sys/namespaces
Code: 405. Errors:

* 1 error occurred:
	* unsupported operation
```
When import resource, func `namespaceRead` get empty path from `d.Get("path")`, so use `d.Id()` as path.
Set path as `Id`, received as import argument.
If call from `namespaceWrite`, we just reset path as was in resource definition.
