### PR TITLE
docs: vault_token_auth_backend_role does not support token_policies attribute

### DIFF
--- a/website/docs/r/token_auth_backend_role.html.md
+++ b/website/docs/r/token_auth_backend_role.html.md
@@ -55,8 +55,6 @@ These arguments are common across several Authentication Token resources since V
 * `token_max_ttl` - (Optional) The maximum lifetime for generated tokens in number of seconds.
   Its current value will be referenced at renewal time.
 
-* `token_policies` - (Optional) List of policies to encode onto generated tokens. Depending
-  on the auth method, this list may be supplemented by user/group/other values.
 
 * `token_bound_cidrs` - (Optional) List of CIDR blocks; if set, specifies blocks of IP
   addresses which can authenticate successfully, and ties the resulting token to these blocks


### PR DESCRIPTION
According to https://www.vaultproject.io/api/auth/token/index.html#create-update-token-role the `vault_token_auth_backend_role` does not support the new Vault 1.2+ `token_policies` attribute. Attempting to use this will result in Terraform attempting to re-add this attribute to the resource on every `apply`.

Users should use `allowed_policies` attribute instead.

```hcl
resource "vault_token_auth_backend_role" "gke-foobar" {
   role_name    = "gke-foobari"
   token_period = 259200 # 720h/1month
   renewable    = true
   token_policies   = ["gke-foobar"]
 }
```

```console
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.vault-common.vault_token_auth_backend_role.gke-foobar will be updated in-place
  ~ resource "vault_token_auth_backend_role" "gke-foobar" {
        disallowed_policies     = []
        id                      = "auth/token/roles/gke-foobar"
        orphan                  = false
        renewable               = true
        role_name               = "gke-foobar"
        token_bound_cidrs       = []
        token_explicit_max_ttl  = 0
        token_max_ttl           = 0
        token_no_default_policy = false
        token_num_uses          = 0
        token_period            = 86400
      ~ token_policies          = [
          + "gke-foobar",
        ]
        token_ttl               = 0
        token_type              = "default-service"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```