### PR TITLE
Allow identity group alias name to be updated

### DIFF
--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -87,6 +87,9 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 		"canonical_id":   resp.Data["canonical_id"],
 	}
 
+	if name, ok := d.GetOk("name"); ok {
+		data["name"] = name
+	}
 	if mountAccessor, ok := d.GetOk("mount_accessor"); ok {
 		data["mount_accessor"] = mountAccessor
 	}


### PR DESCRIPTION
The identity group alias name is allowed to be updated.
Update the testcase to update the identity group alias fields.