### PR TITLE
Improve AWS secret backend client configuration

### DIFF
--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -37,12 +37,20 @@ issue new credentials.
 * `secret_key` - (Required) The AWS Secret Key this backend should use to
 issue new credentials.
 
-~> **Important** Because Vault does not support reading the configured
-credentials back from the API, Terraform cannot detect and correct drift
+~> **Important** Vault version 1.2.3 and older does not support reading the configured
+credentials back from the API, With these older versions, Terraform cannot detect and correct drift
 on `access_key` or `secret_key`. Changing the values, however, _will_
-overwrite the previously stored values.
+overwrite the previously stored values. With versions of Vault newer than
+1.2.3, reading the `access_key` only is supported, and so drifts of the
+`access_key` will be detected and corrected, but drifts on the `secret_key`
+will not.
 
 * `region` - (Optional) The AWS region for API calls. Defaults to `us-east-1`.
+
+~> **Important** The same limitation noted above for the `access_key` parameter
+also applies to the `region` parameter. Vault versions 1.2.3 and older will not
+allow Terraform to detect (and thus correct) drift in the `region` parameter,
+while newer versions of Vault will.
 
 * `path` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `aws`.


### PR DESCRIPTION
Now that Vault supports reading the config/root endpoint, we can read
out the AWS access key and region that have been configured to allow
Terraform to detect for and fix drift.

Note that there's a little bit of a nasty hack in here to prevent unexpected but probably innocuous config diffs in the region selected as explained in the comments. This can be removed if it's not a big deal, but I went with keeping maximum backwards compatibility.

Fixes #538

I ran the relevant acceptance tests based off a local build of the most recent Vault master:

```bash
$ AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar make testacc TESTARGS="-count 1 -run TestAccAWSSecretBackend"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count 1 -run TestAccAWSSecretBackend -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    0.045s [no tests to run]
=== RUN   TestAccAWSSecretBackendRole_basic
--- PASS: TestAccAWSSecretBackendRole_basic (0.26s)
=== RUN   TestAccAWSSecretBackendRole_import
--- PASS: TestAccAWSSecretBackendRole_import (0.25s)
=== RUN   TestAccAWSSecretBackendRole_nested
--- PASS: TestAccAWSSecretBackendRole_nested (0.40s)
=== RUN   TestAccAWSSecretBackend_basic
--- PASS: TestAccAWSSecretBackend_basic (0.33s)
=== RUN   TestAccAWSSecretBackend_import
--- PASS: TestAccAWSSecretBackend_import (0.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   1.437s
```