### PR TITLE
Only update aws_auth_backend_client aws creds if they change

### DIFF
--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -76,7 +76,6 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	// applied yet, so we need to apply it again.
 	backend := d.Get("backend").(string)
 	accessKey := d.Get("access_key").(string)
-	secretKey := d.Get("secret_key").(string)
 	ec2Endpoint := d.Get("ec2_endpoint").(string)
 	iamEndpoint := d.Get("iam_endpoint").(string)
 	stsEndpoint := d.Get("sts_endpoint").(string)
@@ -86,11 +85,16 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 
 	data := map[string]interface{}{
 		"access_key":                 accessKey,
-		"secret_key":                 secretKey,
 		"endpoint":                   ec2Endpoint,
 		"iam_endpoint":               iamEndpoint,
 		"sts_endpoint":               stsEndpoint,
 		"iam_server_id_header_value": iamServerIDHeaderValue,
+	}
+
+	if d.HasChange("access_key") || d.HasChange("secret_key") {
+		log.Printf("[DEBUG] Updating AWS credentials at %q", path)
+		data["access_key"] = d.Get("access_key").(string)
+		data["secret_key"] = d.Get("secret_key").(string)
 	}
 
 	log.Printf("[DEBUG] Writing AWS auth backend client config to %q", path)

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -75,7 +75,6 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	// if backend comes from the config, it won't have the StateFunc
 	// applied yet, so we need to apply it again.
 	backend := d.Get("backend").(string)
-	accessKey := d.Get("access_key").(string)
 	ec2Endpoint := d.Get("ec2_endpoint").(string)
 	iamEndpoint := d.Get("iam_endpoint").(string)
 	stsEndpoint := d.Get("sts_endpoint").(string)
@@ -84,7 +83,6 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	path := awsAuthBackendClientPath(backend)
 
 	data := map[string]interface{}{
-		"access_key":                 accessKey,
 		"endpoint":                   ec2Endpoint,
 		"iam_endpoint":               iamEndpoint,
 		"sts_endpoint":               stsEndpoint,

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -69,6 +69,33 @@ func TestAccAWSAuthBackendClient_nested(t *testing.T) {
 	})
 }
 
+func TestAccAWSAuthBackendClient_withoutSecretKey(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAWSAuthBackendClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAuthBackendClientConfig_basicWithoutSecretKey(backend),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSAuthBackendClientCheck_attrs(backend),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_client.client", "access_key", "AWSACCESSKEY"),
+					resource.TestCheckNoResourceAttr("vault_aws_auth_backend_client.client", "secret_key"),
+				),
+			},
+			{
+				Config: testAccAWSAuthBackendClientConfig_updatedWithoutSecretKey(backend),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSAuthBackendClientCheck_attrs(backend),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_client.client", "access_key", "AWSACCESSKEY"),
+					resource.TestCheckNoResourceAttr("vault_aws_auth_backend_client.client", "secret_key"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAuthBackendClientDestroy(s *terraform.State) error {
 	client := testProvider.Meta().(*api.Client)
 
@@ -85,26 +112,6 @@ func testAccCheckAWSAuthBackendClientDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
-}
-
-func testAccAWSAuthBackendClientConfig_basic(backend string) string {
-	return fmt.Sprintf(`
-resource "vault_auth_backend" "aws" {
-  type = "aws"
-  path = "%s"
-  description = "Test auth backend for AWS backend client config"
-}
-
-resource "vault_aws_auth_backend_client" "client" {
-  backend = "${vault_auth_backend.aws.path}"
-  access_key = "AWSACCESSKEY"
-  secret_key = "AWSSECRETKEY"
-  ec2_endpoint = "http://vault.test/ec2"
-  iam_endpoint = "http://vault.test/iam"
-  sts_endpoint = "http://vault.test/sts"
-  iam_server_id_header_value = "vault.test"
-}
-`, backend)
 }
 
 func testAccAWSAuthBackendClientCheck_attrs(backend string) resource.TestCheckFunc {
@@ -153,6 +160,26 @@ func testAccAWSAuthBackendClientCheck_attrs(backend string) resource.TestCheckFu
 	}
 }
 
+func testAccAWSAuthBackendClientConfig_basic(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+  description = "Test auth backend for AWS backend client config"
+}
+
+resource "vault_aws_auth_backend_client" "client" {
+  backend = "${vault_auth_backend.aws.path}"
+  access_key = "AWSACCESSKEY"
+  secret_key = "AWSSECRETKEY"
+  ec2_endpoint = "http://vault.test/ec2"
+  iam_endpoint = "http://vault.test/iam"
+  sts_endpoint = "http://vault.test/sts"
+  iam_server_id_header_value = "vault.test"
+}
+`, backend)
+}
+
 func testAccAWSAuthBackendClientConfig_updated(backend string) string {
 	return fmt.Sprintf(`
 resource "vault_auth_backend" "aws" {
@@ -165,9 +192,45 @@ resource "vault_aws_auth_backend_client" "client" {
   backend = "${vault_auth_backend.aws.path}"
   access_key = "UPDATEDAWSACCESSKEY"
   secret_key = "UPDATEDAWSSECRETKEY"
-  ec2_endpoint = "http://upadted.vault.test/ec2"
+  ec2_endpoint = "http://updated.vault.test/ec2"
   iam_endpoint = "http://updated.vault.test/iam"
   sts_endpoint = "http://updated.vault.test/sts"
   iam_server_id_header_value = "updated.vault.test"
+}`, backend)
+}
+
+func testAccAWSAuthBackendClientConfig_basicWithoutSecretKey(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  path = "%s"
+  type = "aws"
+  description = "Test auth backend for AWS backend client config"
+}
+
+resource "vault_aws_auth_backend_client" "client" {
+  backend = "${vault_auth_backend.aws.path}"
+  access_key = "AWSACCESSKEY"
+  ec2_endpoint = "http://vault.test/ec2"
+  iam_endpoint = "http://vault.test/iam"
+  sts_endpoint = "http://vault.test/sts"
+  iam_server_id_header_value = "vault.test"
+}`, backend)
+}
+
+func testAccAWSAuthBackendClientConfig_updatedWithoutSecretKey(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  path = "%s"
+  type = "aws"
+  description = "Test auth backend for AWS backend client config"
+}
+
+resource "vault_aws_auth_backend_client" "client" {
+  backend = "${vault_auth_backend.aws.path}"
+  access_key = "AWSACCESSKEY"
+  ec2_endpoint = "http://updated2.vault.test/ec2"
+  iam_endpoint = "http://updated2.vault.test/iam"
+  sts_endpoint = "http://updated2.vault.test/sts"
+  iam_server_id_header_value = "updated2.vault.test"
 }`, backend)
 }


### PR DESCRIPTION
## Description

We use `access_key` argument of `aws_auth_backend_client` resource to configure the AWS access key id, however in order to leave the secret out of Terraform state we configure the secret manually using Vault CLI. So far if we make a change to some argument that is not related to AWS keys (for example `sts_endpoint`) the provider updates the config with empty `secret_key` value.

This change changes the behaviour so that AWS creds are changed only if they have changed in Terraform. Given Vault does not return `secret_key` as part of the read client config response it's quite hard to test this.

## Test output

```sh
$ make testacc TESTARGS='-run=TestAccAWSAuthBackendClient_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSAuthBackendClient_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccAWSAuthBackendClient_import
--- PASS: TestAccAWSAuthBackendClient_import (1.59s)
=== RUN   TestAccAWSAuthBackendClient_basic
--- PASS: TestAccAWSAuthBackendClient_basic (0.29s)
=== RUN   TestAccAWSAuthBackendClient_nested
--- PASS: TestAccAWSAuthBackendClient_nested (0.26s)
=== RUN   TestAccAWSAuthBackendClient_withoutSecretKey
--- PASS: TestAccAWSAuthBackendClient_withoutSecretKey (0.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	2.433s
```