### PR TITLE
Move new token fields from Github teams/users into config

### DIFF
--- a/vault/resource_github_team.go
+++ b/vault/resource_github_team.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
+const tokenParamDeprecationMsg = "This parameter should be moved to the Github Auth backend config " +
+	"block. It does nothing in a user/team block."
+
 func githubTeamResource() *schema.Resource {
 	return &schema.Resource{
 		Create: githubTeamCreate,
@@ -43,6 +46,78 @@ func githubTeamResource() *schema.Resource {
 				ForceNew:     true,
 				Description:  "GitHub team name in \"slugified\" format.",
 				ValidateFunc: validateStringSlug,
+			},
+
+			// These token fields were added and released in error. They do nothing and should be
+			// removed at the next major version bump.
+			"token_bound_cidrs": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Specifies the blocks of IP addresses which are allowed to use the generated token",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_explicit_max_ttl": {
+				Type:        schema.TypeInt,
+				Description: "Generated Token's Explicit Maximum TTL in seconds",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_max_ttl": {
+				Type:        schema.TypeInt,
+				Description: "The maximum lifetime of the generated token",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_no_default_policy": {
+				Type:        schema.TypeBool,
+				Description: "If true, the 'default' policy will not automatically be added to generated tokens",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_period": {
+				Type:        schema.TypeInt,
+				Description: "Generated Token's Period",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_policies": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description:   "Generated Token's Policies",
+				ConflictsWith: []string{"policies"},
+				Deprecated:    tokenParamDeprecationMsg,
+			},
+
+			"token_type": {
+				Type:        schema.TypeString,
+				Description: "The type of token to generate, service or batch",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_ttl": {
+				Type:        schema.TypeInt,
+				Description: "The initial ttl of the token to generate in seconds",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_num_uses": {
+				Type:        schema.TypeInt,
+				Description: "The maximum number of times a token may be used, a value of zero means unlimited",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
 			},
 		},
 	}

--- a/vault/resource_github_team.go
+++ b/vault/resource_github_team.go
@@ -9,44 +9,7 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
-func githubTeamTokenConfig() *addTokenFieldsConfig {
-	return &addTokenFieldsConfig{
-		TokenPoliciesConflict: []string{"policies"},
-	}
-}
-
 func githubTeamResource() *schema.Resource {
-	fields := map[string]*schema.Schema{
-		"backend": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Auth backend to which team mapping will be congigured.",
-			ForceNew:    true,
-			Default:     "github",
-			// standardise on no beginning or trailing slashes
-			StateFunc: func(v interface{}) string {
-				return strings.Trim(v.(string), "/")
-			},
-		},
-		"team": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			Description:  "GitHub team name in \"slugified\" format.",
-			ValidateFunc: validateStringSlug,
-		},
-		"policies": {
-			Type:          schema.TypeList,
-			Optional:      true,
-			Elem:          &schema.Schema{Type: schema.TypeString},
-			Description:   "Policies to be assigned to this team.",
-			Deprecated:    "use `token_policies` instead",
-			ConflictsWith: []string{"token_policies"},
-		},
-	}
-
-	addTokenFields(fields, githubTeamTokenConfig())
-
 	return &schema.Resource{
 		Create: githubTeamCreate,
 		Read:   githubTeamRead,
@@ -55,42 +18,43 @@ func githubTeamResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: fields,
+
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Auth backend to which team mapping will be congigured.",
+				ForceNew:    true,
+				Default:     "github",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Policies to be assigned to this team.",
+			},
+			"team": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "GitHub team name in \"slugified\" format.",
+				ValidateFunc: validateStringSlug,
+			},
+		},
 	}
-}
-
-func githubTeamUpdateFields(d *schema.ResourceData, data map[string]interface{}) error {
-	setTokenFields(d, data, githubTeamTokenConfig())
-
-	data["key"] = d.Get("team").(string)
-	if v, ok := d.GetOk("policies"); ok {
-		vs := expandStringSlice(v.([]interface{}))
-		data["value"] = strings.Join(vs, ",")
-	}
-
-	return nil
 }
 
 func githubTeamCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
 	id := githubMapId(d.Get("backend").(string), d.Get("team").(string), "teams")
 	d.SetId(id)
 	d.MarkNewResource()
 
-	data := map[string]interface{}{}
-	githubTeamUpdateFields(d, data)
-
 	log.Printf("[INFO] Creating new github team map at '%v'", id)
-
-	_, err := client.Logical().Write(id, data)
-	if err != nil {
-		d.SetId("")
-		return err
-	}
-
-	log.Printf("[INFO] Saved github team map at '%v'", id)
-
-	return githubTeamRead(d, meta)
+	return githubTeamUpdate(d, meta)
 }
 
 func githubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -98,7 +62,11 @@ func githubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 	path := d.Id()
 
 	data := map[string]interface{}{}
-	githubTeamUpdateFields(d, data)
+	data["key"] = d.Get("team").(string)
+	if v, ok := d.GetOk("policies"); ok {
+		vs := expandStringSlice(v.([]interface{}))
+		data["value"] = strings.Join(vs, ",")
+	}
 
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
@@ -119,17 +87,6 @@ func githubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		log.Printf("[ERROR] error when reading github team mapping from '%s'", path)
 		return err
-	}
-
-	readTokenFields(d, dt)
-
-	// Check if the user is using the deprecated `policies`
-	if _, deprecated := d.GetOk("policies"); deprecated {
-		// Then we see if `token_policies` was set and unset it
-		// Vault will still return `policies`
-		if _, ok := d.GetOk("token_policies"); ok {
-			d.Set("token_policies", nil)
-		}
 	}
 
 	if v, ok := dt.Data["key"]; ok {

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -17,7 +17,6 @@ func TestAccGithubTeam_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("github")
 	resName := "vault_github_team.team"
 	team := "my-team-slugified"
-
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -29,9 +28,9 @@ func TestAccGithubTeam_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/teams/"+team),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
 					resource.TestCheckResourceAttr(resName, "team", "my-team-slugified"),
-					resource.TestCheckResourceAttr(resName, "token_policies.#", "2"),
-					resource.TestCheckResourceAttr(resName, "token_ttl", "300"),
-					resource.TestCheckResourceAttr(resName, "token_max_ttl", "1800"),
+					resource.TestCheckResourceAttr(resName, "policies.#", "2"),
+					resource.TestCheckResourceAttr(resName, "policies.0", "admin"),
+					resource.TestCheckResourceAttr(resName, "policies.1", "security"),
 				),
 			},
 			{
@@ -40,9 +39,7 @@ func TestAccGithubTeam_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/teams/"+team),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
 					resource.TestCheckResourceAttr(resName, "team", "my-team-slugified"),
-					resource.TestCheckResourceAttr(resName, "token_policies.#", "0"),
-					resource.TestCheckResourceAttr(resName, "token_ttl", "300"),
-					resource.TestCheckResourceAttr(resName, "token_max_ttl", "1800"),
+					resource.TestCheckResourceAttr(resName, "policies.#", "0"),
 				),
 			},
 		},
@@ -120,16 +117,14 @@ func testAccGithubTeamConfig_basic(backend string, team string, policies []strin
 	p, _ := json.Marshal(policies)
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
-  path = "%s"
-  organization = "vault"
+	path = "%s"
+  	organization = "vault"
 }
 
 resource "vault_github_team" "team" {
 	backend = "${vault_github_auth_backend.gh.id}"
 	team = "%s"
-	token_policies = %s
-	token_ttl = 300
-	token_max_ttl = 1800
+	policies = %s
 }
 `, backend, team, p)
 }

--- a/vault/resource_github_user.go
+++ b/vault/resource_github_user.go
@@ -43,6 +43,78 @@ func githubUserResource() *schema.Resource {
 				ForceNew:    true,
 				Description: "GitHub user name.",
 			},
+
+			// These token fields were added and released in error. They do nothing and should be
+			// removed at the next major version bump.
+			"token_bound_cidrs": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Specifies the blocks of IP addresses which are allowed to use the generated token",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_explicit_max_ttl": {
+				Type:        schema.TypeInt,
+				Description: "Generated Token's Explicit Maximum TTL in seconds",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_max_ttl": {
+				Type:        schema.TypeInt,
+				Description: "The maximum lifetime of the generated token",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_no_default_policy": {
+				Type:        schema.TypeBool,
+				Description: "If true, the 'default' policy will not automatically be added to generated tokens",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_period": {
+				Type:        schema.TypeInt,
+				Description: "Generated Token's Period",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_policies": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description:   "Generated Token's Policies",
+				ConflictsWith: []string{"policies"},
+				Deprecated:    tokenParamDeprecationMsg,
+			},
+
+			"token_type": {
+				Type:        schema.TypeString,
+				Description: "The type of token to generate, service or batch",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_ttl": {
+				Type:        schema.TypeInt,
+				Description: "The initial ttl of the token to generate in seconds",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
+
+			"token_num_uses": {
+				Type:        schema.TypeInt,
+				Description: "The maximum number of times a token may be used, a value of zero means unlimited",
+				Optional:    true,
+				Deprecated:  tokenParamDeprecationMsg,
+			},
 		},
 	}
 }

--- a/vault/resource_github_user.go
+++ b/vault/resource_github_user.go
@@ -9,43 +9,7 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
-func githubUserTokenConfig() *addTokenFieldsConfig {
-	return &addTokenFieldsConfig{
-		TokenPoliciesConflict: []string{"policies"},
-	}
-}
-
 func githubUserResource() *schema.Resource {
-	fields := map[string]*schema.Schema{
-		"backend": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Auth backend to which user mapping will be congigured.",
-			ForceNew:    true,
-			Default:     "github",
-			// standardise on no beginning or trailing slashes
-			StateFunc: func(v interface{}) string {
-				return strings.Trim(v.(string), "/")
-			},
-		},
-		"user": {
-			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
-			Description: "GitHub user name.",
-		},
-		"policies": {
-			Type:          schema.TypeList,
-			Optional:      true,
-			Elem:          &schema.Schema{Type: schema.TypeString},
-			Description:   "Policies to be assigned to this team.",
-			Deprecated:    "use `token_policies` instead",
-			ConflictsWith: []string{"token_policies"},
-		},
-	}
-
-	addTokenFields(fields, githubUserTokenConfig())
-
 	return &schema.Resource{
 		Create: githubUserCreate,
 		Read:   githubUserRead,
@@ -54,42 +18,42 @@ func githubUserResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: fields,
+
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Auth backend to which user mapping will be congigured.",
+				ForceNew:    true,
+				Default:     "github",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Policies to be assigned to this user.",
+			},
+			"user": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "GitHub user name.",
+			},
+		},
 	}
-}
-
-func githubUserUpdateFields(d *schema.ResourceData, data map[string]interface{}) error {
-	setTokenFields(d, data, githubUserTokenConfig())
-
-	data["key"] = d.Get("user").(string)
-	if v, ok := d.GetOk("policies"); ok {
-		vs := expandStringSlice(v.([]interface{}))
-		data["value"] = strings.Join(vs, ",")
-	}
-
-	return nil
 }
 
 func githubUserCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
-
 	id := githubMapId(d.Get("backend").(string), d.Get("user").(string), "users")
 	d.SetId(id)
 	d.MarkNewResource()
 
-	data := map[string]interface{}{}
-	githubUserUpdateFields(d, data)
-
 	log.Printf("[INFO] Creating new github user map at '%v'", id)
-	_, err := client.Logical().Write(id, data)
-	if err != nil {
-		d.SetId("")
-		return err
-	}
-
-	log.Printf("[INFO] Saved github user map at '%v'", id)
-
-	return githubUserRead(d, meta)
+	return githubUserUpdate(d, meta)
 }
 
 func githubUserUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -97,7 +61,11 @@ func githubUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	path := d.Id()
 
 	data := map[string]interface{}{}
-	githubUserUpdateFields(d, data)
+	data["key"] = d.Get("user").(string)
+	if v, ok := d.GetOk("policies"); ok {
+		vs := expandStringSlice(v.([]interface{}))
+		data["value"] = strings.Join(vs, ",")
+	}
 
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
@@ -118,17 +86,6 @@ func githubUserRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		log.Printf("[ERROR] error when reading github user mapping from '%s'", path)
 		return err
-	}
-
-	readTokenFields(d, dt)
-
-	// Check if the user is using the deprecated `policies`
-	if _, deprecated := d.GetOk("policies"); deprecated {
-		// Then we see if `token_policies` was set and unset it
-		// Vault will still return `policies`
-		if _, ok := d.GetOk("token_policies"); ok {
-			d.Set("token_policies", nil)
-		}
 	}
 
 	if v, ok := dt.Data["key"]; ok {

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -27,9 +27,9 @@ func TestAccGithubUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/users/"+user),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
 					resource.TestCheckResourceAttr(resName, "user", "john_doe"),
-					resource.TestCheckResourceAttr(resName, "token_policies.#", "2"),
-					resource.TestCheckResourceAttr(resName, "token_ttl", "300"),
-					resource.TestCheckResourceAttr(resName, "token_max_ttl", "1800"),
+					resource.TestCheckResourceAttr(resName, "policies.#", "2"),
+					resource.TestCheckResourceAttr(resName, "policies.0", "admin"),
+					resource.TestCheckResourceAttr(resName, "policies.1", "security"),
 				),
 			},
 			{
@@ -38,9 +38,7 @@ func TestAccGithubUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/users/"+user),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
 					resource.TestCheckResourceAttr(resName, "user", "john_doe"),
-					resource.TestCheckResourceAttr(resName, "token_policies.#", "0"),
-					resource.TestCheckResourceAttr(resName, "token_ttl", "300"),
-					resource.TestCheckResourceAttr(resName, "token_max_ttl", "1800"),
+					resource.TestCheckResourceAttr(resName, "policies.#", "0"),
 				),
 			},
 		},
@@ -109,9 +107,7 @@ resource "vault_github_auth_backend" "gh" {
 resource "vault_github_user" "user" {
 	backend = "${vault_github_auth_backend.gh.id}"
 	user = "%s"
-	token_policies = %s
-	token_ttl = 300
-	token_max_ttl = 1800
+	policies = %s
 }
 `, backend, user, p)
 }

--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -35,12 +35,6 @@ The following arguments are supported:
 * `description` - (Optional) Specifies the description of the mount. 
   This overrides the current stored value, if any.
 
-* `ttl` - (Optional) Duration after which authentication will be expired. 
-  This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration).
-
-* `max_ttl` - (Optional) Maximum duration after which authentication will be expired.
-  This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration).
-
 The `tune` block is used to tune the auth backend:
 
 * `default_lease_ttl` - (Optional) Specifies the default time-to-live. 
@@ -68,6 +62,55 @@ The `tune` block is used to tune the auth backend:
 In addition to all arguments above, the following attributes are exported:
 
 * `accessor` - The mount accessor related to the auth mount. It is useful for integration with [Identity Secrets Engine](https://www.vaultproject.io/docs/secrets/identity/index.html).
+
+### Common Token Arguments
+
+These arguments are common across several Authentication Token resources since Vault 1.2.
+
+* `token_ttl` - (Optional) The incremental lifetime for generated tokens in number of seconds.
+  Its current value will be referenced at renewal time.
+
+* `token_max_ttl` - (Optional) The maximum lifetime for generated tokens in number of seconds.
+  Its current value will be referenced at renewal time.
+
+* `token_policies` - (Optional) List of policies to encode onto generated tokens. Depending
+  on the auth method, this list may be supplemented by user/group/other values.
+
+* `token_bound_cidrs` - (Optional) List of CIDR blocks; if set, specifies blocks of IP
+  addresses which can authenticate successfully, and ties the resulting token to these blocks
+  as well.
+
+* `token_explicit_max_ttl` - (Optional) If set, will encode an
+  [explicit max TTL](https://www.vaultproject.io/docs/concepts/tokens.html#token-time-to-live-periodic-tokens-and-explicit-max-ttls)
+  onto the token in number of seconds. This is a hard cap even if `token_ttl` and
+  `token_max_ttl` would otherwise allow a renewal.
+
+* `token_no_default_policy` - (Optional) If set, the default policy will not be set on
+  generated tokens; otherwise it will be added to the policies set in token_policies.
+
+* `token_num_uses` - (Optional) The number of times issued tokens can be used.
+  A value of 0 means unlimited uses.
+
+* `token_num_uses` - (Optional) The
+  [period](https://www.vaultproject.io/docs/concepts/tokens.html#token-time-to-live-periodic-tokens-and-explicit-max-ttls),
+  if any, in number of seconds to set on the token.
+
+* `token_type` - (Optional) The type of token that should be generated. Can be `service`,
+  `batch`, or `default` to use the mount's tuned default (which unless changed will be
+  `service` tokens). For token store roles, there are two additional possibilities:
+  `default-service` and `default-batch` which specify the type to return unless the client
+  requests a different type at generation time.
+
+### Deprecated Arguments
+
+These arguments are deprecated since Vault 1.2 in favour of the common token arguments
+documented above.
+
+* `ttl` - (Optional; Deprecated, use `token_ttl` isntead) The TTL period of tokens issued
+  using this role. This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration).
+
+* `max_ttl` - (Optional; Deprecated, use `token_max_ttl` instead) The maximum allowed lifetime of tokens
+  issued using this role. This must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration).
 
 ## Import
 

--- a/website/docs/r/github_team.html.md
+++ b/website/docs/r/github_team.html.md
@@ -35,49 +35,9 @@ The following arguments are supported:
 
 * `team` - (Required) GitHub team name in "slugified" format, for example: Terraform
   Developers -> `terraform-developers`.
-
-### Common Token Arguments
-
-These arguments are common across several Authentication Token resources since Vault 1.2.
-
-* `token_ttl` - (Optional) The incremental lifetime for generated tokens in number of seconds.
-  Its current value will be referenced at renewal time.
-
-* `token_max_ttl` - (Optional) The maximum lifetime for generated tokens in number of seconds.
-  Its current value will be referenced at renewal time.
-
-* `token_policies` - (Optional) List of policies to encode onto generated tokens. Depending
-  on the auth method, this list may be supplemented by user/group/other values.
-
-* `token_bound_cidrs` - (Optional) List of CIDR blocks; if set, specifies blocks of IP
-  addresses which can authenticate successfully, and ties the resulting token to these blocks
-  as well.
-
-* `token_explicit_max_ttl` - (Optional) If set, will encode an
-  [explicit max TTL](https://www.vaultproject.io/docs/concepts/tokens.html#token-time-to-live-periodic-tokens-and-explicit-max-ttls)
-  onto the token in number of seconds. This is a hard cap even if `token_ttl` and
-  `token_max_ttl` would otherwise allow a renewal.
-
-* `token_no_default_policy` - (Optional) If set, the default policy will not be set on
-  generated tokens; otherwise it will be added to the policies set in token_policies.
-
-* `token_num_uses` - (Optional) The
-  [period](https://www.vaultproject.io/docs/concepts/tokens.html#token-time-to-live-periodic-tokens-and-explicit-max-ttls),
-  if any, in number of seconds to set on the token.
-
-* `token_type` - (Optional) The type of token that should be generated. Can be `service`,
-  `batch`, or `default` to use the mount's tuned default (which unless changed will be
-  `service` tokens). For token store roles, there are two additional possibilities:
-  `default-service` and `default-batch` which specify the type to return unless the client
-  requests a different type at generation time.
-
-### Deprecated Arguments
-
-These arguments are deprecated since Vault 1.2 in favour of the common token arguments
-documented above.
-
-* `policies` - (Optional; Deprecated, use `token_policies` instead) An array of strings
-  specifying the policies to be set on tokens issued using this role.
+  
+* `policies` - (Optional) An array of strings specifying the policies to be set on tokens
+  issued using this role.
 
 ## Attributes Reference
 

--- a/website/docs/r/github_user.html.md
+++ b/website/docs/r/github_user.html.md
@@ -35,48 +35,8 @@ The following arguments are supported:
 
 * `user` - (Required) GitHub user name.
 
-### Common Token Arguments
-
-These arguments are common across several Authentication Token resources since Vault 1.2.
-
-* `token_ttl` - (Optional) The incremental lifetime for generated tokens in number of seconds.
-  Its current value will be referenced at renewal time.
-
-* `token_max_ttl` - (Optional) The maximum lifetime for generated tokens in number of seconds.
-  Its current value will be referenced at renewal time.
-
-* `token_policies` - (Optional) List of policies to encode onto generated tokens. Depending
-  on the auth method, this list may be supplemented by user/group/other values.
-
-* `token_bound_cidrs` - (Optional) List of CIDR blocks; if set, specifies blocks of IP
-  addresses which can authenticate successfully, and ties the resulting token to these blocks
-  as well.
-
-* `token_explicit_max_ttl` - (Optional) If set, will encode an
-  [explicit max TTL](https://www.vaultproject.io/docs/concepts/tokens.html#token-time-to-live-periodic-tokens-and-explicit-max-ttls)
-  onto the token in number of seconds. This is a hard cap even if `token_ttl` and
-  `token_max_ttl` would otherwise allow a renewal.
-
-* `token_no_default_policy` - (Optional) If set, the default policy will not be set on
-  generated tokens; otherwise it will be added to the policies set in token_policies.
-
-* `token_num_uses` - (Optional) The
-  [period](https://www.vaultproject.io/docs/concepts/tokens.html#token-time-to-live-periodic-tokens-and-explicit-max-ttls),
-  if any, in number of seconds to set on the token.
-
-* `token_type` - (Optional) The type of token that should be generated. Can be `service`,
-  `batch`, or `default` to use the mount's tuned default (which unless changed will be
-  `service` tokens). For token store roles, there are two additional possibilities:
-  `default-service` and `default-batch` which specify the type to return unless the client
-  requests a different type at generation time.
-
-### Deprecated Arguments
-
-These arguments are deprecated since Vault 1.2 in favour of the common token arguments
-documented above.
-
-* `policies` - (Optional; Deprecated, use `token_policies` instead) An array of strings
-  specifying the policies to be set on tokens issued using this role.
+* `policies` - (Optional) An array of strings specifying the policies to be set on tokens issued
+   using this role.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This reverts 958733aa3e and moves those changes under the config endpoint.

Fixes #502