### PR TITLE
Fix panic when importing from cassandra db

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -541,11 +542,11 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 				result["pem_json"] = v.(string)
 			}
 			if v, ok := data["protocol_version"]; ok {
-				protocol, err := v.(json.Number).Int64()
+				protocol, err := strconv.Atoi(v.(string))
 				if err != nil {
 					return fmt.Errorf("unexpected non-number %q returned as protocol_version from Vault: %s", v, err)
 				}
-				result["protocol_version"] = protocol
+				result["protocol_version"] = int64(protocol)
 			}
 			if v, ok := data["connect_timeout"]; ok {
 				timeout, err := v.(json.Number).Int64()


### PR DESCRIPTION
protocol_version is treated as an int by Terraform, but is returned by
Vault as a string. As such, the code currently panics when importing it.
We should convert the string to an int64.