### PR TITLE
Correct bad markdown

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -188,7 +188,7 @@ EOT
 
 ### Example `auth_login` Usage
 With the `userpass` backend:
-```hcl-terraform
+```hcl
 variable login_username {}
 variable login_password {}
 
@@ -203,7 +203,7 @@ provider "vault" {
 }
 ```
 Or, using approle:
-```hcl-terraform
+```hcl
 variable login_approle_role_id {}
 variable login_approle_secret_id {}
 


### PR DESCRIPTION
Examples didn't render because hcl-terraform is apparently not defined, but hcl worked fine.