### PR TITLE
Wait longer for AWS creds to propagate

### DIFF
--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -191,7 +191,7 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 
 	start := time.Now()
 	for sequentialSuccesses < sequentialSuccessesRequired {
-		if time.Now().Sub(start) > sequentialSuccessTimeLimit {
+		if time.Since(start) > sequentialSuccessTimeLimit {
 			return fmt.Errorf("unable to get %d sequential successes within %.f seconds", sequentialSuccessesRequired, sequentialSuccessTimeLimit.Seconds())
 		}
 		if err := resource.Retry(retryTimeOut, validateCreds); err != nil {


### PR DESCRIPTION
This PR adds further delay for AWS creds to propagate. Instead of waiting for 3 total tests of the credentials for them to be considered valid, waits for 5 sequential tries + 5 seconds. 

Since sts credentials are immediately consistent, doesn't wait to test them.