### PR TITLE
Add missing attributes and allow importing on consul_secret_backend_role

### DIFF
--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -3,17 +3,23 @@ package vault
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/vault/api"
 )
 
+var (
+	consulSecretBackendRoleBackendFromPathRegex = regexp.MustCompile("^(.+)/roles/.+$")
+	consulSecretBackendRoleNameFromPathRegex    = regexp.MustCompile("^.+/roles/(.+$)")
+)
+
 func consulSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
-		Create: consulSecretBackendRoleCreate,
+		Create: consulSecretBackendRoleWrite,
 		Read:   consulSecretBackendRoleRead,
-		Update: consulSecretBackendRoleUpdate,
+		Update: consulSecretBackendRoleWrite,
 		Delete: consulSecretBackendRoleDelete,
 		Exists: consulSecretBackendRoleExists,
 		Importer: &schema.ResourceImporter{
@@ -27,11 +33,11 @@ func consulSecretBackendRoleResource() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of an existing role against which to create this Consul credential",
 			},
-			"path": {
+			"backend": {
 				Type:        schema.TypeString,
-				ForceNew:    true,
 				Required:    true,
-				Description: "Unique name of the Vault Consul mount to configure",
+				ForceNew:    true,
+				Description: "The path of the Consul Secret Backend the role belongs to.",
 			},
 			"policies": {
 				Type:        schema.TypeList,
@@ -41,53 +47,92 @@ func consulSecretBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"max_ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Maximum TTL for leases associated with this role, in seconds.",
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the TTL for this role.",
+			},
+			"token_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the type of token to create when using this role. Valid values are \"client\" or \"management\".",
+			},
+			"local": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates that the token should not be replicated globally and instead be local to the current datacenter.",
+			},
 		},
 	}
 }
 
-func consulSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
+func consulSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
+	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
-	path := d.Get("path").(string)
-	policies := d.Get("policies").([]interface{})
 
-	reqPath := consulSecretBackendRolePath(path, name)
+	path := consulSecretBackendRolePath(backend, name)
+
+	policies := d.Get("policies").([]interface{})
 
 	payload := map[string]interface{}{
 		"policies": policies,
 	}
 
-	d.Partial(true)
-	log.Printf("[DEBUG] Configuring Consul secrets backend role at %q", reqPath)
-
-	d.SetId(path + "," + name)
-
-	if _, err := client.Logical().Write(reqPath, payload); err != nil {
-		return fmt.Errorf("error writing role configuration for %q: %s", reqPath, err)
+	if v, ok := d.GetOkExists("max_ttl"); ok {
+		payload["max_ttl"] = v
 	}
-	d.SetPartial("name")
-	d.SetPartial("path")
-	d.SetPartial("policies")
-	d.Partial(false)
+	if v, ok := d.GetOkExists("ttl"); ok {
+		payload["ttl"] = v
+	}
+	if v, ok := d.GetOkExists("token_type"); ok {
+		payload["token_type"] = v
+	}
+	if v, ok := d.GetOkExists("local"); ok {
+		payload["local"] = v
+	}
 
-	return nil
+	d.Partial(true)
+	log.Printf("[DEBUG] Configuring Consul secrets backend role at %q", path)
+
+	if _, err := client.Logical().Write(path, payload); err != nil {
+		return fmt.Errorf("error writing role configuration for %q: %s", path, err)
+	}
+
+	d.SetId(path)
+	return consulSecretBackendRoleRead(d, meta)
 }
 
 func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
-	s := strings.Split(d.Id(), ",")
-	path := s[0]
-	name := s[1]
+	path := d.Id()
 
-	reqPath := consulSecretBackendRolePath(path, name)
-
-	log.Printf("[DEBUG] Reading Consul secrets backend role at %q", reqPath)
-
-	secret, err := client.Logical().Read(reqPath)
+	name, err := consulSecretBackendRoleNameFromPath(path)
 	if err != nil {
-		return fmt.Errorf("error reading role configuration for %q: %s", reqPath, err)
+		log.Printf("[WARN] Removing consul role %q because its ID is invalid", path)
+		d.SetId("")
+		return fmt.Errorf("invalid role ID %q: %s", path, err)
+	}
+
+	backend, err := consulSecretBackendRoleBackendFromPath(path)
+	if err != nil {
+		log.Printf("[WARN] Removing consul role %q because its ID is invalid", path)
+		d.SetId("")
+		return fmt.Errorf("invalid role ID %q: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading Consul secrets backend role at %q", path)
+
+	secret, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading role configuration for %q: %s", path, err)
 	}
 
 	if secret == nil {
@@ -96,78 +141,67 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 
 	data := secret.Data
 	d.Set("name", name)
-	d.Set("path", path)
+	d.Set("backend", backend)
 	d.Set("policies", data["policies"])
+	d.Set("max_ttl", data["max_ttl"])
+	d.Set("ttl", data["ttl"])
+	d.Set("token_type", data["token_type"])
+	d.Set("local", data["local"])
 
 	return nil
-}
-
-func consulSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
-
-	s := strings.Split(d.Id(), ",")
-	path := s[0]
-	name := s[1]
-
-	reqPath := consulSecretBackendRolePath(path, name)
-
-	d.Partial(true)
-
-	if d.HasChange("policies") {
-		log.Printf("[DEBUG] Updating role configuration at %q", reqPath)
-		policies := d.Get("policies").([]interface{})
-
-		payload := map[string]interface{}{
-			"policies": policies,
-		}
-		if _, err := client.Logical().Write(reqPath, payload); err != nil {
-			return fmt.Errorf("error writing role configuration for %q: %s", reqPath, err)
-		}
-		log.Printf("[DEBUG] Updated role configuration at %q", reqPath)
-		d.SetPartial("policies")
-	}
-
-	d.Partial(false)
-	return consulSecretBackendRoleRead(d, meta)
 }
 
 func consulSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
-	s := strings.Split(d.Id(), ",")
-	path := s[0]
-	name := s[1]
+	path := d.Id()
 
-	reqPath := consulSecretBackendRolePath(path, name)
+	log.Printf("[DEBUG] Deleting Consul backend role at %q", path)
 
-	log.Printf("[DEBUG] Deleting Consul backend role at %q", reqPath)
-
-	if _, err := client.Logical().Delete(reqPath); err != nil {
-		return fmt.Errorf("error deleting Consul backend role at %q: %s", reqPath, err)
+	if _, err := client.Logical().Delete(path); err != nil {
+		return fmt.Errorf("error deleting Consul backend role at %q: %s", path, err)
 	}
-	log.Printf("[DEBUG] Deleted Consul backend role at %q", reqPath)
+	log.Printf("[DEBUG] Deleted Consul backend role at %q", path)
 	return nil
 }
 
 func consulSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*api.Client)
 
-	s := strings.Split(d.Id(), ",")
-	path := s[0]
-	name := s[1]
+	path := d.Id()
 
-	reqPath := consulSecretBackendRolePath(path, name)
+	log.Printf("[DEBUG] Checking Consul secrets backend role at %q", path)
 
-	log.Printf("[DEBUG] Checking Consul secrets backend role at %q", reqPath)
-
-	secret, err := client.Logical().Read(reqPath)
+	secret, err := client.Logical().Read(path)
 	if err != nil {
-		return false, fmt.Errorf("error reading role configuration for %q: %s", reqPath, err)
+		return false, fmt.Errorf("error reading role configuration for %q: %s", path, err)
 	}
 
 	return secret != nil, nil
 }
 
-func consulSecretBackendRolePath(path, name string) string {
-	return strings.Trim(path, "/") + "/roles/" + name
+func consulSecretBackendRolePath(backend, name string) string {
+	return strings.Trim(backend, "/") + "/roles/" + name
+}
+
+func consulSecretBackendRoleNameFromPath(path string) (string, error) {
+	if !consulSecretBackendRoleNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no name found")
+	}
+	res := consulSecretBackendRoleNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for name", len(res))
+	}
+	return res[1], nil
+}
+
+func consulSecretBackendRoleBackendFromPath(path string) (string, error) {
+	if !consulSecretBackendRoleBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := consulSecretBackendRoleBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
 }

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -16,6 +16,9 @@ func consulSecretBackendRoleResource() *schema.Resource {
 		Update: consulSecretBackendRoleUpdate,
 		Delete: consulSecretBackendRoleDelete,
 		Exists: consulSecretBackendRoleExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -51,21 +51,25 @@ func consulSecretBackendRoleResource() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum TTL for leases associated with this role, in seconds.",
+				Default:     0,
 			},
 			"ttl": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Specifies the TTL for this role.",
+				Default:     0,
 			},
 			"token_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Specifies the type of token to create when using this role. Valid values are \"client\" or \"management\".",
+				Default:     "client",
 			},
 			"local": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Indicates that the token should not be replicated globally and instead be local to the current datacenter.",
+				Default:     false,
 			},
 		},
 	}
@@ -98,7 +102,6 @@ func consulSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) erro
 		payload["local"] = v
 	}
 
-	d.Partial(true)
 	log.Printf("[DEBUG] Configuring Consul secrets backend role at %q", path)
 
 	if _, err := client.Logical().Write(path, payload); err != nil {

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -34,7 +34,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "backend", backend),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "name", name),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "ttl", "120"),
-					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "max_ttl", "140"),
+					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "max_ttl", "240"),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "local", "true"),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "token_type", "client"),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "policies.0", "foo"),

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -132,3 +132,47 @@ resource "vault_consul_secret_backend_role" "test_path" {
 }
 `, backend, token, name)
 }
+
+func TestConsulSecretBackendRoleNameFromPath(t *testing.T) {
+	{
+		name, err := consulSecretBackendRoleNameFromPath("foo/roles/bar")
+		if err != nil {
+			t.Fatalf("error getting name: %v", err)
+		}
+		if name != "bar" {
+			t.Fatalf("expected name 'bar', but got %s", name)
+		}
+	}
+
+	{
+		name, err := consulSecretBackendRoleNameFromPath("no match")
+		if err == nil {
+			t.Fatal("Expected error getting name but got nil")
+		}
+		if name != "" {
+			t.Fatalf("expected empty name, but got %s", name)
+		}
+	}
+}
+
+func TestConsulSecretBackendRoleBackendFromPath(t *testing.T) {
+	{
+		backend, err := consulSecretBackendRoleBackendFromPath("foo/roles/bar")
+		if err != nil {
+			t.Fatalf("error getting backend: %v", err)
+		}
+		if backend != "foo" {
+			t.Fatalf("expected backend 'foo', but got %s", backend)
+		}
+	}
+
+	{
+		backend, err := consulSecretBackendRoleBackendFromPath("no match")
+		if err == nil {
+			t.Fatal("Expected error getting backend but got nil")
+		}
+		if backend != "" {
+			t.Fatalf("expected empty backend, but got %s", backend)
+		}
+	}
+}

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -26,6 +26,8 @@ func TestConsulSecretBackendRole(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "name", name),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "ttl", "0"),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "policies.0", "foo"),
+					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test_path", "path", backend),
+					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test_path", "policies.0", "foo"),
 				),
 			},
 			{
@@ -39,6 +41,8 @@ func TestConsulSecretBackendRole(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "token_type", "client"),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "policies.0", "foo"),
 					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test", "policies.1", "bar"),
+					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test_path", "path", backend),
+					resource.TestCheckResourceAttr("vault_consul_secret_backend_role.test_path", "ttl", "120"),
 				),
 			},
 		},
@@ -81,7 +85,16 @@ resource "vault_consul_secret_backend_role" "test" {
   policies = [
     "foo"
   ]
-}`, backend, token, name)
+}
+resource "vault_consul_secret_backend_role" "test_path" {
+  path = vault_consul_secret_backend.test.path
+  name = "%[2]s_path"
+
+  policies = [
+    "foo"
+  ]
+}
+`, backend, token, name)
 }
 
 func testConsulSecretBackendRole_updateConfig(backend, name, token string) string {
@@ -107,6 +120,15 @@ resource "vault_consul_secret_backend_role" "test" {
   max_ttl = 240
   local = true
   token_type = "client"
+}
+resource "vault_consul_secret_backend_role" "test_path" {
+  path = vault_consul_secret_backend.test.path
+  name = "%[2]s_path"
 
-}`, backend, token, name)
+  policies = [
+    "foo"
+  ]
+  ttl = 120
+}
+`, backend, token, name)
 }

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -21,9 +21,9 @@ resource "vault_consul_secret_backend" "test" {
   token   = "4240861b-ce3d-8530-115a-521ff070dd29"
 }
 
-resource vault_consul_secret_backend_role" "example" {
+resource "vault_consul_secret_backend_role" "example" {
   name = "test-role"
-  path = "${vault_consul_secret_backend.test.path}"
+  backend = vault_consul_secret_backend.test.path
 
   policies = [
     "example-policy",
@@ -41,6 +41,22 @@ The following arguments are supported:
 
 * `policies` - (Required) The list of Consul ACL policies to associate with these roles.
 
+* `max_ttl` - (Optional) Maximum TTL for leases associated with this role, in seconds.
+
+* `ttl` - (Optional) Specifies the TTL for this role.
+
+* `token_type` - (Optional) Specifies the type of token to create when using this role. Valid values are "client" or "management".
+
+* `local` - (Optional) Indicates that the token should not be replicated globally and instead be local to the current datacenter.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+Consul secret backend roles can be imported using the `backend`, `/roles/`, and the `name` e.g.
+
+```
+$ terraform import vault_consul_secret_backend_role.example consul/roles/my-role
+```

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -35,7 +35,9 @@ resource "vault_consul_secret_backend_role" "example" {
 
 The following arguments are supported:
 
-* `path` - (Required) The unique name of an existing Consul secrets backend mount. Must not begin or end with a `/`.
+* `path` - (Optional) The unique name of an existing Consul secrets backend mount. Must not begin or end with a `/`. **Deprecated**
+
+* `backend` - (Optional) The unique name of an existing Consul secrets backend mount. Must not begin or end with a `/`. One of `path` or `backend` is required.
 
 * `name` - (Required) The name of the Consul secrets engine role to create.
 


### PR DESCRIPTION
Also changes the ID to follow the pattern of other vault resources where the Vault API path is the ID, rather than a comma separated backend,role format.

This breaks backward compatibility, not sure if some kind of migration is required?