### PR TITLE
Add missing quote to vault consul docs

### DIFF
--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -21,7 +21,7 @@ resource "vault_consul_secret_backend" "test" {
   token   = "4240861b-ce3d-8530-115a-521ff070dd29"
 }
 
-resource vault_consul_secret_backend_role" "example" {
+resource "vault_consul_secret_backend_role" "example" {
   name = "test-role"
   path = "${vault_consul_secret_backend.test.path}"
 


### PR DESCRIPTION
Add missing quote to the `vault_consul_secret_backend_role` docs

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
