### PR TITLE
Undo Deprecation of `vault_identity_oidc_key_allowed_client_id`

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -468,8 +468,6 @@ var (
 			Resource:      identityOidcKey(),
 			PathInventory: []string{"/identity/oidc/key/{name}"},
 		},
-		// TODO: Strip in the next major release. This is a dupe of the above.
-		// Deprecation message has already been added.
 		"vault_identity_oidc_key_allowed_client_id": {
 			Resource:      identityOidcKeyAllowedClientId(),
 			PathInventory: []string{"/identity/oidc/key/{name}"},

--- a/vault/resource_identity_oidc_key_allowed_client_id.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id.go
@@ -11,7 +11,6 @@ import (
 
 func identityOidcKeyAllowedClientId() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "This resource is a less-featured dupe and is being deprecated in favor of the `vault_identity_oidc_key` resource. Please update your configuration.",
 		Create: identityOidcKeyAllowedClientIdWrite,
 		Read:   identityOidcKeyAllowedClientIdRead,
 		Delete: identityOidcKeyAllowedClientIdDelete,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The `vault_identity_oidc_key_allowed_client_id` resource is not a duplicate. Its use case is meant for a decoupled manner of updating an OIDC key with an allowed Client ID generated from an OIDC role.

For example

```hcl
resource "vault_identity_oidc_key" "key" {
  name      = "key"
  algorithm = "RS256"
}

##############################################
# Another module
resource "vault_identity_oidc_role" "role" {
  name = "role"
  key  = "key"
}

resource "vault_identity_oidc_key_allowed_client_id" "role" {
  key_name          = "key"
  allowed_client_id = vault_identity_oidc_role.role.client_id
}
```

The discussion for the use case of this was done in the PR that introduced it: https://github.com/terraform-providers/terraform-provider-vault/pull/488