### PR TITLE
Add allowed_user_key_lengths support to vault_ssh_secret_backend_role

### DIFF
--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -103,6 +103,10 @@ func sshSecretBackendRoleResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"allowed_user_key_lengths": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 			"max_ttl": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -168,6 +172,10 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("key_id_format"); ok {
 		data["key_id_format"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("allowed_user_key_lengths"); ok {
+		data["allowed_user_key_lengths"] = v
 	}
 
 	if v, ok := d.GetOk("max_ttl"); ok {
@@ -236,6 +244,7 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("allowed_users", role.Data["allowed_users"])
 	d.Set("default_user", role.Data["default_user"])
 	d.Set("key_id_format", role.Data["key_id_format"])
+	d.Set("allowed_user_key_lengths", role.Data["allowed_user_key_lengths"])
 	d.Set("max_ttl", role.Data["max_ttl"])
 	d.Set("ttl", role.Data["ttl"])
 

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -37,6 +37,7 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.%", "0"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "0"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "0"),
 				),
@@ -60,6 +61,7 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", "usr"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.rsa", "1"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "86400"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "43200"),
 				),
@@ -117,6 +119,7 @@ func TestAccSSHSecretBackendRole_import(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", "usr"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.rsa", "1"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "86400"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "43200"),
 				),
@@ -189,6 +192,7 @@ resource "vault_ssh_secret_backend_role" "test_role" {
 	default_user             = "usr"
 	key_id_format            = "{{role_name}}-test"
 	key_type                 = "ca"
+	allowed_user_key_lengths = { "rsa" = 1 }
 	max_ttl                  = "86400"
 	ttl                      = "43200"
 }

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `key_id_format` - (Optional) Specifies a custom format for the key id of a signed certificate.
 
+* `allowed_user_key_lengths` - (Optional) Specifies a map of ssh key types and their expected sizes which are allowed to be signed by the CA type.
+
 * `max_ttl` - (Optional) Specifies the Time To Live value.
 
 * `ttl` - (Optional) Specifies the maximum Time To Live value.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #604 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Add `allowed_user_key_lengths` param to `vault_ssh_secret_backend_role`
```

Output from acceptance testing:

```
$ make testacc
...
=== RUN   TestAccSSHSecretBackendCA_basic
--- PASS: TestAccSSHSecretBackendCA_basic (1.64s)
=== RUN   TestAccSSHSecretBackendCA_provided
--- PASS: TestAccSSHSecretBackendCA_provided (0.11s)
=== RUN   TestAccSSHSecretBackend_import
--- PASS: TestAccSSHSecretBackend_import (0.95s)
=== RUN   TestAccSSHSecretBackendRole_basic
--- PASS: TestAccSSHSecretBackendRole_basic (0.21s)
=== RUN   TestAccSSHSecretBackendRoleOTP_basic
--- PASS: TestAccSSHSecretBackendRoleOTP_basic (0.11s)
=== RUN   TestAccSSHSecretBackendRole_import
--- PASS: TestAccSSHSecretBackendRole_import (0.18s)
...
```
