### PR TITLE
Add auth_backend data source

### DIFF
--- a/vault/data_source_auth_backend.go
+++ b/vault/data_source_auth_backend.go
@@ -1,0 +1,87 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func authBackendDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: authBackendDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The auth backend mount point.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the auth backend.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the auth backend.",
+			},
+			"default_lease_ttl_seconds": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Default lease duration in seconds",
+			},
+			"max_lease_ttl_seconds": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Maximum possible lease duration in seconds",
+			},
+			"listing_visibility": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Specifies whether to show this mount in the UI-specific listing endpoint.",
+			},
+			"local": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Specifies if the auth method is local only",
+			},
+			"accessor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The accessor of the auth backend.",
+			},
+		},
+	}
+}
+
+func authBackendDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	targetPath := d.Get("path").(string)
+
+	auths, err := client.Sys().ListAuth()
+	if err != nil {
+		return fmt.Errorf("error reading from Vault: %s", err)
+	}
+
+	for path, auth := range auths {
+		path = strings.TrimSuffix(path, "/")
+		if path == targetPath {
+			// Compatibility with resource_auth_backend id
+			d.SetId(path)
+			d.Set("type", auth.Type)
+			d.Set("description", auth.Description)
+			d.Set("accessor", auth.Accessor)
+			d.Set("default_lease_ttl_seconds", auth.Config.DefaultLeaseTTL)
+			d.Set("max_lease_ttl_seconds", auth.Config.MaxLeaseTTL)
+			d.Set("listing_visibility", auth.Config.ListingVisibility)
+			d.Set("local", auth.Local)
+			return nil
+		}
+	}
+
+	// If we fell out here then we didn't find our Auth in the list.
+	return nil
+}

--- a/vault/data_source_auth_backend_test.go
+++ b/vault/data_source_auth_backend_test.go
@@ -1,0 +1,89 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	r "github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestDataSourceAuthBackend(t *testing.T) {
+	path := acctest.RandomWithPrefix("foo")
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []r.TestStep{
+			{
+				Config: testDataSourceAuthBackendBasic_config,
+				Check:  testDataSourceAuthBackend_check,
+			},
+			{
+				Config: testDataSourceAuthBackend_config(path),
+				Check:  testDataSourceAuthBackend_check,
+			},
+		},
+	})
+}
+
+var testDataSourceAuthBackendBasic_config = `
+
+resource "vault_auth_backend" "test" {
+	type = "userpass"
+}
+
+data "vault_auth_backend" "test" {
+	path = "${vault_auth_backend.test.path}"
+}
+
+`
+
+func testDataSourceAuthBackend_config(path string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "test" {
+	path = "%s"
+	type = "userpass"
+}
+
+data "vault_auth_backend" "test" {
+	path = "${vault_auth_backend.test.path}"
+}
+`, path)
+}
+
+func testDataSourceAuthBackend_check(s *terraform.State) error {
+	baseResourceState := s.Modules[0].Resources["vault_auth_backend.test"]
+	if baseResourceState == nil {
+		return fmt.Errorf("base resource not found in state %v", s.Modules[0].Resources)
+	}
+
+	baseInstanceState := baseResourceState.Primary
+	if baseInstanceState == nil {
+		return fmt.Errorf("base resource has no primary instance")
+	}
+
+	resourceState := s.Modules[0].Resources["data.vault_auth_backend.test"]
+	if resourceState == nil {
+		return fmt.Errorf("resource not found in state %v", s.Modules[0].Resources)
+	}
+
+	iState := resourceState.Primary
+	if iState == nil {
+		return fmt.Errorf("resource has no primary instance")
+	}
+
+	if got, want := iState.Attributes["id"], baseInstanceState.Attributes["id"]; got != want {
+		return fmt.Errorf("id contains %s; want %s", got, want)
+	}
+
+	if got, want := iState.Attributes["type"], "userpass"; got != want {
+		return fmt.Errorf("type contains %s; want %s", got, want)
+	}
+
+	if got, want := iState.Attributes["accessor"], baseInstanceState.Attributes["accessor"]; got != want {
+		return fmt.Errorf("accessor contains %s; want %s", got, want)
+	}
+
+	return nil
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -206,6 +206,10 @@ var (
 			Resource:      policyDocumentDataSource(),
 			PathInventory: []string{"/sys/policy/{name}"},
 		},
+		"vault_auth_backend": {
+			Resource:      authBackendDataSource(),
+			PathInventory: []string{"/sys/auth"},
+		},
 	}
 
 	ResourceRegistry = map[string]*Description{

--- a/website/docs/d/auth_backend.html.md
+++ b/website/docs/d/auth_backend.html.md
@@ -1,0 +1,41 @@
+---
+layout: "vault"
+page_title: "Vault: vault_auth_backend data source"
+sidebar_current: "docs-vault-datasource-auth-backend"
+description: |-
+  Lookup an Auth Backend from Vault
+---
+
+# vault\_auth\_backend
+
+## Example Usage
+
+```hcl
+data "vault_auth_backend" "example" {
+  path = "userpass"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `path` - (Required) The auth backend mount point.
+
+## Attributes Reference
+
+In addition to the fields above, the following attributes are exported:
+
+* `type` - The name of the auth method type.
+
+* `description` - A description of the auth method.
+
+* `default_lease_ttl_seconds` - The default lease duration in seconds.
+
+* `max_lease_ttl_seconds` - The maximum lease duration in seconds.
+
+* `listing_visibility` - Speficies whether to show this mount in the UI-specific listing endpoint.
+
+* `local` - Specifies if the auth method is local only.
+
+* `accessor` - The accessor for this auth method

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -21,6 +21,9 @@
                         <li<%= sidebar_current("docs-vault-datasource-approle-auth-backend-role-id") %>>
                             <a href="/docs/providers/vault/d/approle_auth_backend_role_id.html">vault_approle_auth_backend_role_id</a>
                         </li>
+                        <li<%= sidebar_current("docs-vault-datasource-auth-backend") %>>
+                            <a href="/docs/providers/vault/d/auth_backend.html">vault_auth_backend</a>
+                        </li>
 
                         <li<%= sidebar_current("docs-vault-datasource-aws-access-credentials") %>>
                             <a href="/docs/providers/vault/d/aws_access_credentials.html">vault_aws_access_credentials</a>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Add support for querying `vault_auth_backend` data with a datasource.
Some resources need the auth backend accessor (e.g. for identity groups). If it's managed outside Terraform, we can query the accessor through this datasource.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `vault_auth_backend` datasource
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestDataSourceAuthBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestDataSourceAuthBackend -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	0.008s [no tests to run]
=== RUN   TestDataSourceAuthBackend
--- PASS: TestDataSourceAuthBackend (0.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	0.217s
```
