### PR TITLE
correctly update name attribute of vault_identity_entity_alias resources

### DIFF
--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -99,6 +99,9 @@ func identityEntityAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 		"canonical_id":   resp.Data["canonical_id"],
 	}
 
+	if name, ok := d.GetOk("name"); ok {
+		data["name"] = name
+	}
 	if mountAccessor, ok := d.GetOk("mount_accessor"); ok {
 		data["mount_accessor"] = mountAccessor
 	}

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccIdentityEntityAlias(t *testing.T) {
 	entity := acctest.RandomWithPrefix("my-entity")
 
-	nameEntity := "vault_identity_entity.entity"
+	nameEntity := "vault_identity_entity.entityA"
 	nameEntityAlias := "vault_identity_entity_alias.entity-alias"
 	nameGithubA := "vault_auth_backend.githubA"
 
@@ -24,16 +24,50 @@ func TestAccIdentityEntityAlias(t *testing.T) {
 		CheckDestroy: testAccCheckIdentityEntityAliasDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityEntityAliasConfig(entity, false),
+				Config: testAccIdentityEntityAliasConfig(entity, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(nameEntityAlias, "name", entity),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntity, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntity, "id"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubA, "accessor"),
 				),
 			},
 			{
-				Config:      testAccIdentityEntityAliasConfig(entity, true),
+				Config:      testAccIdentityEntityAliasConfig(entity, true, false),
 				ExpectError: regexp.MustCompile(`IdentityEntityAlias.*already exists.*may be imported`),
+			},
+		},
+	})
+}
+
+func TestAccIdentityEntityAlias_Update(t *testing.T) {
+	entity := acctest.RandomWithPrefix("my-entity")
+
+	nameEntityA := "vault_identity_entity.entityA"
+	nameEntityB := "vault_identity_entity.entityB"
+	nameEntityAlias := "vault_identity_entity_alias.entity-alias"
+	nameGithubA := "vault_auth_backend.githubA"
+	nameGithubB := "vault_auth_backend.githubB"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckIdentityEntityAliasDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityEntityAliasConfig(entity, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityA, "name"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityA, "id"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubA, "accessor"),
+				),
+			},
+			{
+				Config: testAccIdentityEntityAliasConfig(entity, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityB, "name"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityB, "id"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubB, "accessor"),
+				),
 			},
 		},
 	})
@@ -57,10 +91,20 @@ func testAccCheckIdentityEntityAliasDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityEntityAliasConfig(entityName string, dupeAlias bool) string {
+func testAccIdentityEntityAliasConfig(entityName string, dupeAlias bool, altTarget bool) string {
+	entityId := "A"
+	if altTarget {
+		entityId = "B"
+	}
+
 	ret := fmt.Sprintf(`
-resource "vault_identity_entity" "entity" {
-  name = "%s"
+resource "vault_identity_entity" "entityA" {
+  name = "%s-A"
+  policies = ["test"]
+}
+
+resource "vault_identity_entity" "entityB" {
+  name = "%s-B"
   policies = ["test"]
 }
 
@@ -75,22 +119,22 @@ resource "vault_auth_backend" "githubB" {
 }
 
 resource "vault_identity_entity_alias" "entity-alias" {
-  name = "%s"
-  mount_accessor = "${vault_auth_backend.githubA.accessor}"
-  canonical_id = "${vault_identity_entity.entity.id}"
+  name = "${vault_identity_entity.entity%s.name}"
+  mount_accessor = "${vault_auth_backend.github%s.accessor}"
+  canonical_id = "${vault_identity_entity.entity%s.id}"
 }
-`, entityName, entityName, entityName, entityName)
+`, entityName, entityName, entityName, entityName, entityId, entityId, entityId)
 
 	// This duplicate alias tests the provider's handling of aliases that already exist but aren't
 	// known to the provider.
 	if dupeAlias {
 		ret += fmt.Sprintf(`
 resource "vault_identity_entity_alias" "entity-alias-dupe" {
-  name = "%s"
+  name = "${vault_identity_entity.entity%s.name}"
   mount_accessor = "${vault_auth_backend.githubA.accessor}"
-  canonical_id = "${vault_identity_entity.entity.id}"
+  canonical_id = "${vault_identity_entity.entity%s.id}"
 }
-`, entityName)
+`, entityId, entityId)
 	}
 
 	return ret


### PR DESCRIPTION
- fixed updates to the name of an entity-alias
- added an update test to ensure all attributes of an entity-alias are updated

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
correctly update name attribute of vault_identity_entity_alias resources
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIdentityEntityAlias -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    0.019s [no tests to run]
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (0.34s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (0.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   (cached)
```
