### PR TITLE
Prevent panic when Cassandra protocol_version is set

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -125,7 +124,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 						"protocol_version": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Default:     2,
+							Default:     4,
 							Description: "The CQL protocol version to use.",
 						},
 						"connect_timeout": {
@@ -542,7 +541,7 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 				result["pem_json"] = v.(string)
 			}
 			if v, ok := data["protocol_version"]; ok {
-				protocol, err := strconv.Atoi(v.(string))
+				protocol, err := v.(json.Number).Int64()
 				if err != nil {
 					return fmt.Errorf("unexpected non-number %q returned as protocol_version from Vault: %s", v, err)
 				}

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -124,7 +124,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 						"protocol_version": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Default:     4,
+							Default:     2,
 							Description: "The CQL protocol version to use.",
 						},
 						"connect_timeout": {


### PR DESCRIPTION
I circled back to #559 to see if it was really working for me by running Cassandra in Docker locally. I found that if I added `protocol_version = 4` line to our tests, I received a panic on line 544 stating that `v` was a `json.Number`, not a `string`.

This PR fixes that and adds test coverage for when the field is _actively_ set. Test coverage already exists for when it defaults.