### PR TITLE
identity_*_policies: fix policies updates not removing old policies

### DIFF
--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -68,6 +68,13 @@ func identityEntityPoliciesUpdate(d *schema.ResourceData, meta interface{}) erro
 		if err != nil {
 			return err
 		}
+		if d.HasChange("policies") {
+			oldPoliciesI, _ := d.GetChange("policies")
+			oldPolicies := oldPoliciesI.(*schema.Set).List()
+			for _, policy := range oldPolicies {
+				apiPolicies = util.SliceRemoveIfPresent(apiPolicies, policy)
+			}
+		}
 		for _, policy := range policies {
 			apiPolicies = util.SliceAppendIfMissing(apiPolicies, policy)
 		}

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -68,6 +68,13 @@ func identityGroupPoliciesUpdate(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return err
 		}
+		if d.HasChange("policies") {
+			oldPoliciesI, _ := d.GetChange("policies")
+			oldPolicies := oldPoliciesI.(*schema.Set).List()
+			for _, policy := range oldPolicies {
+				apiPolicies = util.SliceRemoveIfPresent(apiPolicies, policy)
+			}
+		}
 		for _, policy := range policies {
 			apiPolicies = util.SliceAppendIfMissing(apiPolicies, policy)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #636 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
identity policies: fix updates not removing old policies
```

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccIdentity'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIdentity -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (0.18s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (0.26s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (0.24s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (0.17s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (0.09s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (0.16s)
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (0.12s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (0.39s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (0.18s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (0.18s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (0.09s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (0.24s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (0.09s)
=== RUN   TestAccIdentityOidcKeyAllowedClientId
--- PASS: TestAccIdentityOidcKeyAllowedClientId (0.61s)
=== RUN   TestAccIdentityOidcKey
--- PASS: TestAccIdentityOidcKey (0.44s)
=== RUN   TestAccIdentityOidcKeyUpdate
--- PASS: TestAccIdentityOidcKeyUpdate (0.57s)
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (0.22s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (0.36s)
=== RUN   TestAccIdentityOidc
--- PASS: TestAccIdentityOidc (0.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	(cached)
```
