### PR TITLE
fix(resource_transit_secret_backend_key): add more officially supported key types

### DIFF
--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -3,13 +3,14 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/vault/api"
-	"log"
-	"regexp"
-	"strings"
 )
 
 var (
@@ -75,10 +76,10 @@ func transitSecretBackendKeyResource() *schema.Resource {
 			"type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Specifies the type of key to create. The currently-supported types are: aes256-gcm96, chacha20-poly1305, ed25519, ecdsa-p256, rsa-2048, rsa-4096",
+				Description:  "Specifies the type of key to create. The currently-supported types are: aes128-gcm96, aes256-gcm96, chacha20-poly1305, ed25519, ecdsa-p256, ecdsa-p384, ecdsa-p521, rsa-2048, rsa-4096",
 				ForceNew:     true,
 				Default:      "aes256-gcm96",
-				ValidateFunc: validation.StringInSlice([]string{"aes256-gcm96", "chacha20-poly1305", "ed25519", "ecdsa-p256", "rsa-2048", "rsa-4096"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"aes128-gcm96", "aes256-gcm96", "chacha20-poly1305", "ed25519", "ecdsa-p256", "ecdsa-p384", "ecdsa-p521", "rsa-2048", "rsa-4096"}, false),
 			},
 			"keys": {
 				Type:        schema.TypeList,


### PR DESCRIPTION
fix(resource_transit_secret_backend_key): add more officially supported key types

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #645

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add more officially supported key types: aes128-gcm96, ecdsa-p384, ecdsa-p521
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
