### PR TITLE
Change JWT bound_audiences to be optional

### DIFF
--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -33,7 +33,7 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 		},
 		"bound_audiences": {
 			Type:        schema.TypeSet,
-			Required:    true,
+			Optional:    true,
 			Description: "List of aud claims to match against. Any match is sufficient.",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,


### PR DESCRIPTION
It isn't required by the JWT backend.

Fixes #648
