### PR TITLE
Add support for standard auth mount tune configuration to vault_auth_backend resource

### DIFF
--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -203,4 +204,220 @@ func testResourceAuth_updateCheck(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestResourceAuthTune(t *testing.T) {
+	backend := acctest.RandomWithPrefix("github")
+	resName := "vault_auth_backend.test"
+	var resAuthFirst api.AuthMount
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceAuthTune_initialConfig(backend),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAuthMountExists(resName, &resAuthFirst),
+					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "id", backend),
+					resource.TestCheckResourceAttr(resName, "type", "github"),
+					resource.TestCheckResourceAttr(resName, "tune.2820787064.default_lease_ttl", "60s"),
+					resource.TestCheckResourceAttr(resName, "tune.2820787064.max_lease_ttl", "3600s"),
+					resource.TestCheckResourceAttr(resName, "tune.2820787064.listing_visibility", "unauth"),
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
+					checkAuthMount(backend, listingVisibility("unauth")),
+					checkAuthMount(backend, defaultLeaseTtl(60)),
+					checkAuthMount(backend, maxLeaseTtl(3600)),
+				),
+			},
+			{
+				Config: testResourceAuthTune_updateConfig(backend),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
+					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "id", backend),
+					resource.TestCheckResourceAttr(resName, "type", "github"),
+					resource.TestCheckResourceAttr(resName, "tune.1501804413.default_lease_ttl", "60s"),
+					resource.TestCheckResourceAttr(resName, "tune.1501804413.max_lease_ttl", "7200s"),
+					resource.TestCheckResourceAttr(resName, "tune.1501804413.listing_visibility", ""),
+					checkAuthMount(backend, listingVisibility("unauth")),
+					checkAuthMount(backend, defaultLeaseTtl(60)),
+					checkAuthMount(backend, maxLeaseTtl(7200)),
+				),
+			},
+		},
+	})
+}
+
+func testResourceAuthTune_initialConfig(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "test" {
+	type = "github"
+	path = "%s"
+	tune {
+		listing_visibility = "unauth"
+		max_lease_ttl      = "3600s"
+		default_lease_ttl  = "60s"
+	}
+}`, backend)
+}
+
+func testResourceAuthTune_updateConfig(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "test" {
+	type = "github"
+	path = "%s"
+	tune {
+		max_lease_ttl      = "7200s"
+		default_lease_ttl  = "60s"
+	}
+}`, backend)
+}
+
+func TestResourceAuthTuneTtlConflict(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ExpectError: regexp.MustCompile(`config is invalid: "max_lease_ttl_seconds": conflicts with tune.0.max_lease_ttl`),
+				Config:      testResourceAuthTune_conflictWithTuneConfig(),
+			},
+		},
+	})
+}
+
+func testResourceAuthTune_conflictWithTuneConfig() string {
+	return `
+resource "vault_auth_backend" "test" {
+	type = "github"
+	max_lease_ttl_seconds = "4800"
+	tune {
+		max_lease_ttl      = "7200s"
+		default_lease_ttl  = "60s"
+	}
+}`
+}
+
+func TestResourceAuthMigrateToTune(t *testing.T) {
+	backend := acctest.RandomWithPrefix("github")
+	resName := "vault_auth_backend.test"
+	var resAuthFirst api.AuthMount
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceAuthMigrateToTune_initialConfig(backend),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAuthMountExists(resName, &resAuthFirst),
+					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "id", backend),
+					resource.TestCheckResourceAttr(resName, "type", "github"),
+					resource.TestCheckResourceAttr(resName, "max_lease_ttl_seconds", "4800"),
+					resource.TestCheckResourceAttr(resName, "default_lease_ttl_seconds", "75"),
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
+					checkAuthMount(backend, defaultLeaseTtl(75)),
+					checkAuthMount(backend, maxLeaseTtl(4800)),
+				),
+			},
+			{
+				Config: testResourceAuthMigrateToTune_updateConfig(backend),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
+					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "id", backend),
+					resource.TestCheckResourceAttr(resName, "type", "github"),
+					resource.TestCheckResourceAttr(resName, "tune.4062844355.max_lease_ttl", "5600s"),
+					resource.TestCheckResourceAttr(resName, "tune.4062844355.default_lease_ttl", "90s"),
+					checkAuthMount(backend, defaultLeaseTtl(90)),
+					checkAuthMount(backend, maxLeaseTtl(5600)),
+				),
+			},
+		},
+	})
+}
+
+func testResourceAuthMigrateToTune_initialConfig(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "test" {
+	type = "github"
+	path = "%s"
+	max_lease_ttl_seconds = "4800"
+    default_lease_ttl_seconds = "75"
+}`, backend)
+}
+
+func testResourceAuthMigrateToTune_updateConfig(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "test" {
+	type = "github"
+	path = "%s"
+	tune {
+		max_lease_ttl      = "5600s"
+		default_lease_ttl  = "90s"
+	}
+}`, backend)
+}
+
+func checkAuthMount(backend string, checker func(*api.AuthMount) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testProvider.Meta().(*api.Client)
+		auths, err := client.Sys().ListAuth()
+
+		if err != nil {
+			return fmt.Errorf("error reading back auth: %s", err)
+		}
+
+		found := false
+		for serverPath, serverAuth := range auths {
+			if serverPath == backend+"/" {
+				found = true
+				if serverAuth.Type != "github" {
+					return fmt.Errorf("unexpected auth type")
+				}
+
+				if err := checker(serverAuth); err != nil {
+					return err
+				}
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("could not find auth backend %q in %+v", "github", auths)
+		}
+
+		return nil
+	}
+}
+
+func listingVisibility(expected string) func(*api.AuthMount) error {
+	return func(auth *api.AuthMount) error {
+		actual := auth.Config.ListingVisibility
+		if actual != expected {
+			return fmt.Errorf("unexpected auth listing_visibility: expected %q but got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+func defaultLeaseTtl(expected int) func(*api.AuthMount) error {
+	return func(auth *api.AuthMount) error {
+		actual := auth.Config.DefaultLeaseTTL
+		if actual != expected {
+			return fmt.Errorf("unexpected auth default_lease_ttl: expected %d but got %d", expected, actual)
+		}
+		return nil
+	}
+}
+
+func maxLeaseTtl(expected int) func(*api.AuthMount) error {
+	return func(auth *api.AuthMount) error {
+		actual := auth.Config.MaxLeaseTTL
+		if actual != expected {
+			return fmt.Errorf("unexpected auth max_lease_ttl: expected %d but got %d", expected, actual)
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

Currently, updates to `default_lease_ttl_seconds`, `max_lease_ttl_seconds` or `listing_visibility` attributes of the `vault_auth_backend` resource force creation of a new resource, which invalidates existing tokens previously issued by the backend, and can result in roles under that backend no longer exiting/not being recreated, leading to outages for users depending on that backend to login.

This PR follows up on the PR @leominov opened in #557, but implemented using the suggestion by @shwuandwing in this comment: https://github.com/terraform-providers/terraform-provider-vault/pull/557#issuecomment-539193352

It does not strictly speaking resolve #315, in that the existing parameters will still force a new resource, but it addresses the root issue but deprecating those existing parameters and introducing a `tune` configuration block consistent with what has been done in the `vault_github_auth_backend` and `vault_jwt_auth_backend`. 

The common tune schema and implementation does allow for updating those values without forcing a new resource.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #269 
Relates #315
Relates #557 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Adds support to `vault_auth_backend` for common backend tune parameters. Also allows updating Max TTL, Default TTL and Visibility Listing tuning settings on `vault_auth_backend` without forcing a new resource.
```

Output from acceptance testing:

```
> env TESTARGS="-run TestAccAuthBackend.*" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccAuthBackend.* -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestAccAuthBackend_importBasic
--- PASS: TestAccAuthBackend_importBasic (0.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   0.168s

> env TESTARGS="-run TestResourceAuth.*" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestResourceAuth.* -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestResourceAuth
--- PASS: TestResourceAuth (0.23s)
=== RUN   TestResourceAuthTune
--- PASS: TestResourceAuthTune (0.21s)
=== RUN   TestResourceAuthTuneTtlConflict
--- PASS: TestResourceAuthTuneTtlConflict (0.02s)
=== RUN   TestResourceAuthMigrateToTune
--- PASS: TestResourceAuthMigrateToTune (0.23s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   0.734s
...
```
