### PR TITLE
Set VAULT_ADDR in process env when using token helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 2.10.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* Add `add_address_to_env` argument to set the value of the provider's address argument as the VAULT_ADDR environment variable in the Terraform process, enabling VAULT_ADDR external token helpers to work with this provider ([#651](https://github.com/terraform-providers/terraform-provider-vault/pull/651)).
+
 ## 2.9.0 (March 13, 2020)
 
 FEATURES:
@@ -305,7 +310,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-* Fixes issue with `vault_database_secret_backend_connection` always updating the connection URL ([#217](https://github.com/terraform-providers/terraform-provider-vault/pull/217)) 
+* Fixes issue with `vault_database_secret_backend_connection` always updating the connection URL ([#217](https://github.com/terraform-providers/terraform-provider-vault/pull/217))
 
 ## 1.3.1 (November 06, 2018)
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -560,6 +561,20 @@ func providerToken(d *schema.ResourceData) (string, error) {
 	if token := d.Get("token").(string); token != "" {
 		return token, nil
 	}
+
+	if addr := d.Get("address").(string); addr != "" {
+		if current, exists := os.LookupEnv("VAULT_ADDR"); exists {
+			defer func() {
+				os.Setenv("VAULT_ADDR", current)
+			}()
+		} else {
+			defer func() {
+				os.Unsetenv("VAULT_ADDR")
+			}()
+		}
+		os.Setenv("VAULT_ADDR", addr)
+	}
+
 	// Use ~/.vault-token, or the configured token helper.
 	tokenHelper, err := config.DefaultTokenHelper()
 	if err != nil {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -116,8 +116,7 @@ func getTestRMQCreds(t *testing.T) (string, string, string) {
 }
 
 // A basic token helper script.
-const tokenHelperScript = `
-#!/usr/bin/env bash
+const tokenHelperScript = `#!/usr/bin/env bash
 echo "helper-token"
 `
 
@@ -387,17 +386,8 @@ func TestAccProviderToken(t *testing.T) {
 	}
 
 	// Clear the config file env var and restore it after the test.
-	origConfigPath, ok := os.LookupEnv(config.ConfigPathEnv)
-	if ok {
-		// A config path env var was set; ensure we restore it.
-		defer func() {
-			err := os.Setenv(config.ConfigPathEnv, origConfigPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
-	}
-	err = os.Unsetenv(config.ConfigPathEnv)
+	reset, err := tempUnsetenv(config.ConfigPathEnv)
+	defer failIfErr(t, reset)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,38 +452,8 @@ func TestAccProviderToken(t *testing.T) {
 
 			// Set up the custom helper token.
 			if tc.helperToken {
-				// Use a temp dir for test files.
-				dir, err := ioutil.TempDir("", "terraform-provider-vault")
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer func() {
-					if err := os.RemoveAll(dir); err != nil {
-						t.Fatal(err)
-					}
-				}()
-				// Write out the config file and helper script file.
-				configPath := path.Join(dir, "vault-config")
-				helperPath := path.Join(dir, "helper-script")
-				configStr := fmt.Sprintf(`token_helper = "%s"`, helperPath)
-				err = ioutil.WriteFile(configPath, []byte(configStr), 0666)
-				if err != nil {
-					t.Fatal(err)
-				}
-				err = ioutil.WriteFile(helperPath, []byte(tokenHelperScript), 0777)
-				if err != nil {
-					t.Fatal(err)
-				}
-				// Point Vault at the config file.
-				os.Setenv(config.ConfigPathEnv, configPath)
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer func() {
-					if err := os.Unsetenv(config.ConfigPathEnv); err != nil {
-						t.Fatal(err)
-					}
-				}()
+				cleanup := setupTestTokenHelper(t, tokenHelperScript)
+				defer cleanup()
 			}
 
 			d := providerResource.TestResourceData()
@@ -638,5 +598,194 @@ func testTokenName_check(expectedTokenName string) resource.TestCheckFunc {
 		}
 
 		return nil
+	}
+}
+
+// A token helper script that echos back the VAULT_ADDR value
+const echoBackTokenHelperScript = `#!/usr/bin/env bash
+printenv VAULT_ADDR
+`
+
+func TestAccProviderVaultAddrEnv(t *testing.T) {
+	// This is an acceptance test because it requires filesystem and env var
+	// changes that could interfere with other Vault operations.
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf(
+			"Acceptance tests skipped unless env '%s' set",
+			resource.TestEnvVar))
+	}
+
+	// Clear the config file env var and restore it after the test.
+	reset, err := tempUnsetenv(config.ConfigPathEnv)
+	defer failIfErr(t, reset)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		// vaultAddrEnv is set prior to the provider being instantiated or called
+		// simulating any value the user or program may have in its existing environment
+		vaultAddrEnv            string
+		providerAddress         string
+		providerAddAddressToEnv string
+		expectedToken           string
+	}{
+		{
+			// If add_address_to_env is not configured at all, do not add the address to the env
+			name:                    "AddAddressToEnvNotConfigured",
+			providerAddAddressToEnv: "",
+			providerAddress:         "https://provider.example.com",
+			vaultAddrEnv:            "https://pretest-env-var.example.com",
+			expectedToken:           "https://pretest-env-var.example.com",
+		},
+		{
+			name:                    "AddAddressToEnvIsFalse",
+			providerAddAddressToEnv: "false",
+			providerAddress:         "https://provider.example.com",
+			vaultAddrEnv:            "https://pretest-env-var.example.com",
+			expectedToken:           "https://pretest-env-var.example.com",
+		},
+		{
+			name:                    "AddAddressToEnvIsTrue",
+			providerAddAddressToEnv: "true",
+			providerAddress:         "https://provider.example.com",
+			vaultAddrEnv:            "https://pretest-env-var.example.com",
+			expectedToken:           "https://provider.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			if tc.vaultAddrEnv != "" {
+				unset, err := tempSetenv("VAULT_ADDR", tc.vaultAddrEnv)
+				defer failIfErr(t, unset)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cleanup := setupTestTokenHelper(t, echoBackTokenHelperScript)
+			defer cleanup()
+
+			d, err := newTestResourceData(tc.providerAddress, tc.providerAddAddressToEnv)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Get and check the provider token.
+			token, err := providerToken(d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if token != tc.expectedToken {
+				t.Errorf("bad token value: want %#v, got %#v", tc.expectedToken, token)
+			}
+		})
+	}
+}
+
+func newTestResourceData(address string, addAddressToEnv string) (*schema.ResourceData, error) {
+	// Create a "resource" we can use for constructing ResourceData.
+	provider := Provider().(*schema.Provider)
+	providerResource := &schema.Resource{
+		Schema: provider.Schema,
+		// this needs to be configured with and without add_Address_to_env
+	}
+
+	d := providerResource.TestResourceData()
+	err := d.Set("address", address)
+	if err != nil {
+		return nil, err
+	}
+
+	if addAddressToEnv != "" {
+		err = d.Set("add_address_to_env", addAddressToEnv)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return d, nil
+}
+
+func failIfErr(t *testing.T, f func() error) {
+	if err := f(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// tempUnsetenv is the equivalent of calling `os.Unsetenv` but returns
+// a function that be called to restore the modified environment variable
+// to its state prior to this function being called.
+// The reset function will never be nil.
+func tempUnsetenv(key string) (reset func() error, err error) {
+	reset = resetEnvFunc(key)
+	err = os.Unsetenv(key)
+	return reset, err
+}
+
+// tempSetenv is the equivalent of calling `os.Setenv` but returns
+// a function that be called to restore the modified environment variable
+// to its state prior to this function being called.
+// The reset function will never be nil.
+func tempSetenv(key string, value string) (reset func() error, err error) {
+	reset = resetEnvFunc(key)
+	err = os.Setenv(key, value)
+	return reset, err
+}
+
+// resetEnvFunc returns a func that will reset the state of
+// the environment variable named `key` when it is called to the
+// state captured at the time the function was created
+func resetEnvFunc(key string) (reset func() error) {
+	if current, exists := os.LookupEnv(key); exists {
+		return func() error {
+			return os.Setenv(key, current)
+		}
+	} else {
+		return func() error {
+			return os.Unsetenv(key)
+		}
+	}
+}
+
+// setupTestTokenHelper creates a temporary vault config that uses the provided
+// script as a token helper and returns a cleanup function that should be deferred and
+// called to set back the environment to how it was were pre test.
+func setupTestTokenHelper(t *testing.T, script string) (cleanup func()) {
+	// Use a temp dir for test files.
+	dir, err := ioutil.TempDir("", "terraform-provider-vault")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write out the config file and helper script file.
+	configPath := path.Join(dir, "vault-config")
+	helperPath := path.Join(dir, "helper-script")
+	configStr := fmt.Sprintf(`token_helper = "%s"`, helperPath)
+	err = ioutil.WriteFile(configPath, []byte(configStr), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(helperPath, []byte(script), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Point Vault at the config file.
+	os.Setenv(config.ConfigPathEnv, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+		if err := os.Unsetenv(config.ConfigPathEnv); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -90,6 +90,10 @@ variables in order to keep credential information out of the configuration.
   with a scheme, a hostname and a port but with no path. May be set
   via the `VAULT_ADDR` environment variable.
 
+* `add_address_to_env` - (Optional) If `true` the environment variable
+  `VAULT_ADDR` in the Terraform process environment will be set to the
+  value of the `address` argument from this provider. By default, this is false.
+
 * `token` - (Required) Vault token that will be used by Terraform to
   authenticate. May be set via the `VAULT_TOKEN` environment variable.
   If none is otherwise supplied, Terraform will attempt to read it from
@@ -101,7 +105,7 @@ variables in order to keep credential information out of the configuration.
 
 * `token_name` - (Optional) Token name, that will be used by Terraform when
   creating the child token (`display_name`). This is useful to provide a reference of the
-  Terraform run traceable in vault audit log, e.g. commit hash or id of the CI/CD 
+  Terraform run traceable in vault audit log, e.g. commit hash or id of the CI/CD
   execution job. May be set via the `VAULT_TOKEN_NAME` environment variable.
   Default value will be `terraform` if not set or empty.
 
@@ -113,9 +117,9 @@ variables in order to keep credential information out of the configuration.
   contains one or more certificate files that will be used to validate
   the certificate presented by the Vault server. May be set via the
   `VAULT_CAPATH` environment variable.
-  
-* `auth_login` - (Optional) A configuration block, described below, that 
-  attempts to authenticate using the `auth/<method>/login` path to 
+
+* `auth_login` - (Optional) A configuration block, described below, that
+  attempts to authenticate using the `auth/<method>/login` path to
   aquire a token which Terraform will use. Terraform still issues itself
   a limited child token using auth/token/create in order to enforce a short
   TTL and limit exposure.
@@ -144,12 +148,12 @@ variables in order to keep credential information out of the configuration.
 
 * `namespace` - (Optional) Set the namespace to use. May be set via the
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
-  
+
 The `auth_login` configuration block accepts the following arguments:
 
 * `path` - (Required) The login path of the auth backend. For example, login with
   approle by setting this path to `auth/approle/login`. Additionally, some mounts use parameters
-  in the URL, like with `userpass`: `auth/userpass/login/:username`. 
+  in the URL, like with `userpass`: `auth/userpass/login/:username`.
 
 * `namespace` - (Optional) The path to the namespace that has the mounted auth method.
   This defaults to the root namespace. Cannot contain any leading or trailing slashes.
@@ -202,7 +206,7 @@ variable login_password {}
 provider "vault" {
   auth_login {
     path = "auth/userpass/login/${var.login_username}"
-    
+
     parameters = {
       password = var.login_password
     }
@@ -219,7 +223,7 @@ variable login_approle_secret_id {}
 provider "vault" {
   auth_login {
     path = "auth/approle/login"
-    
+
     parameters = {
       role_id   = var.login_approle_role_id
       secret_id = var.login_approle_secret_id


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
### Description

Closes #526 

I'm opening this as a draft pull request because I'd like to get the maintainers thoughts on the approach being taken.

I've been using a token helper that stores tokens based on the configured value of VAULT_ADDR in the environment while using terraform across many Vault clusters, and having support for this would make it much easier to run changes en masse and avoid needing to manage setting and unsetting the VAULT_ADDR for different applies based on what was configured in the Vault terraform provider.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
VAULT_ADDR is always set to the provider's address attribute when a Vault token helper is used to resolve a Vault token.
```

Output from acceptance testing:

- None at this time -- if the general approach is ok with the maintainers, I can write up some specific tests for this.
