### PR TITLE
ldap_auth_backend_user: fix diff when groups is empty

### DIFF
--- a/vault/resource_ldap_auth_backend_user.go
+++ b/vault/resource_ldap_auth_backend_user.go
@@ -130,8 +130,13 @@ func ldapAuthBackendUserResourceRead(d *schema.ResourceData, meta interface{}) e
 			schema.HashString, resp.Data["policies"].([]interface{})))
 
 	groupSet := schema.NewSet(schema.HashString, []interface{}{})
-	for _, group := range strings.Split(resp.Data["groups"].(string), ",") {
-		groupSet.Add(group)
+	// Vault stores `groups` for an LDAP user as a string, not a list. We explicitly check
+	// for an empty string here because without it, there exists a logical mismatch between
+	// an empty set/list and the result of creating a list by splitting on an empty string.
+	if resp.Data["groups"].(string) != "" {
+		for _, group := range strings.Split(resp.Data["groups"].(string), ",") {
+			groupSet.Add(group)
+		}
 	}
 	d.Set("groups", groupSet)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #537

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* Fixes an issue where the "vault_ldap_auth_backend_user" resource did not respect an empty `groups` value
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestLDAPAuthBackend.*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestLDAPAuthBackend.* -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestLDAPAuthBackendGroup_import
--- PASS: TestLDAPAuthBackendGroup_import (1.40s)
=== RUN   TestLDAPAuthBackendGroup_basic
--- PASS: TestLDAPAuthBackendGroup_basic (0.14s)
=== RUN   TestLDAPAuthBackend_import
--- PASS: TestLDAPAuthBackend_import (0.15s)
=== RUN   TestLDAPAuthBackend_basic
--- PASS: TestLDAPAuthBackend_basic (0.13s)
=== RUN   TestLDAPAuthBackendUser_import
--- PASS: TestLDAPAuthBackendUser_import (0.15s)
=== RUN   TestLDAPAuthBackendUser_basic
--- PASS: TestLDAPAuthBackendUser_basic (0.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   2.131s
```
