### PR TITLE
Sort vault_policy_document allowed/denied parameters by key name

### DIFF
--- a/vault/data_source_policy_document.go
+++ b/vault/data_source_policy_document.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -234,8 +235,14 @@ func policyRenderListOfStrings(items []string) string {
 func policyRenderListOfMapsOfListToString(input map[string][]string) string {
 	output := fmt.Sprintf("{\n")
 
-	for k, v := range input {
-		output = fmt.Sprintf("%s    \"%s\" = %s\n", output, k, policyRenderListOfStrings(v))
+	keys := make([]string, 0, len(input))
+	for k := range input {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		output = fmt.Sprintf("%s    \"%s\" = %s\n", output, k, policyRenderListOfStrings(input[k]))
 	}
 
 	return fmt.Sprintf("%s  }", output)

--- a/vault/data_source_policy_document_test.go
+++ b/vault/data_source_policy_document_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestDataSourcePolicyDocument(t *testing.T) {
-	t.Skip("this test fails intermittently and needs to be fixed")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -32,17 +31,22 @@ data "vault_policy_document" "test" {
     required_parameters = ["test_param1"]
 
     allowed_parameter {
-      key   = "eggs"
-      value = ["foo", "bar"]
-    }
-
-    allowed_parameter {
       key   = "spam"
       value = ["eggs"]
     }
 
+    allowed_parameter {
+      key   = "eggs"
+      value = ["foo", "bar"]
+    }
+
     denied_parameter {
-      key   = "*"
+      key   = "b"
+      value = ["eggs"]
+    }
+
+    denied_parameter {
+      key   = "a"
       value = ["spam"]
     }
 
@@ -65,6 +69,11 @@ data "vault_policy_document" "test" {
       value = []
     }
 
+    denied_parameter {
+      key   = "foo"
+      value = []
+    }
+
     min_wrapping_ttl = "1s"
   }
 
@@ -84,7 +93,8 @@ path "secret/test1/*" {
     "spam" = ["eggs"]
   }
   denied_parameters = {
-    "*" = ["spam"]
+    "a" = ["spam"]
+    "b" = ["eggs"]
   }
   max_wrapping_ttl = "1h"
 }
@@ -98,6 +108,7 @@ path "secret/test2/*" {
   }
   denied_parameters = {
     "*" = []
+    "foo" = []
   }
   min_wrapping_ttl = "1s"
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Description

When running `terraform plan`, terraform produces false positive changes because Go iterates maps in randomized order. This change adds sorting by keys name values to overcome randomness.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
```release-note
Sort `vault_policy_document` data source allowed/denied parameters by key name.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestDataSourcePolicyDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestDataSourcePolicyDocument -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestDataSourcePolicyDocument
--- PASS: TestDataSourcePolicyDocument (0.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	(cached)
...
```
