### PR TITLE
token_policy argument

### DIFF
--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -24,7 +24,7 @@ resource "vault_jwt_auth_backend" "jwt" {
 resource "vault_jwt_auth_backend_role" "example" {
   backend         = vault_jwt_auth_backend.jwt.path
   role_name       = "test-role"
-  token+policies  = ["default", "dev", "prod"]
+  token_policies  = ["default", "dev", "prod"]
 
   bound_audiences = ["https://myco.test"]
   user_claim      = "https://vault/user"


### PR DESCRIPTION
vault_jwt_auth_backend_role argument was stated to be token+policies when it really was token_policies.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
