### PR TITLE
Use set connection_url when available instead of value read for API response for MongoDB plugin

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -563,8 +563,12 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 		data, ok := details.(map[string]interface{})
 		if ok {
 			result := map[string]interface{}{}
-			if v, ok := data["connection_url"]; ok {
+			if v, ok := d.GetOk("mongodb.0." + "connection_url"); ok {
 				result["connection_url"] = v.(string)
+			} else {
+				if v, ok := data["connection_url"]; ok {
+					result["connection_url"] = v.(string)
+				}
 			}
 			d.Set("mongodb", []map[string]interface{}{result})
 		}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates And Closes #215 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Use set connection_url when available instead of the value read for the API response for MongoDB
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_mongodb'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDatabaseSecretBackendConnection_mongodb -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccDatabaseSecretBackendConnection_mongodb
--- PASS: TestAccDatabaseSecretBackendConnection_mongodb (5.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault
```
