### PR TITLE
Add support to select AWS ARN from role with multiple configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ $ make test
 
 In order to run the full suite of Acceptance tests, you will need the following:
 
+*Note:* Acceptance tests create real resources, and often cost money to run.
+
 1. An instance of Vault running to run the tests against
 2. The following environment variables are set:
     - `VAULT_ADDR` - location of Vault

--- a/README.md
+++ b/README.md
@@ -67,10 +67,25 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
+In order to run the full suite of Acceptance tests, you will need the following:
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+1. An instance of Vault running to run the tests against
+2. The following environment variables are set:
+    - `VAULT_ADDR` - location of Vault
+    - `VAULT_TOKEN` - token to use to query Vault. These tests do not attempt to read `~/.vault-token`.
+3. The following environment variables may need to be set depending on which acceptance tests you wish to run.
+There may be additional variables for specific tests. Consult the specific test(s) for more information.
+    - `AWS_ACCESS_KEY_ID`
+    - `AWS_SECRET_ACCESS_KEY`
+    - `GOOGLE_CREDENTIALS`
+    - `GOOGLE_PROJECT`
+    - `RMQ_CONNECTION_URI`
+    - `RMQ_USERNAME`
+    - `RMQ_PASSWORD`
+4. Run `make testacc`
+
+If you wish to run specific tests, use the `TESTARGS` environment variable:
 
 ```sh
-$ make testacc
+TESTARGS="--run DataSourceAWSAccessCredentials" make testacc
 ```

--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -31,7 +31,7 @@ func TestAccDataSourceAWSAccessCredentials_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "security_token", ""),
 					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "creds"),
 					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
-					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(mountPath),
+					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(),
 				),
 			},
 		},
@@ -41,23 +41,80 @@ func TestAccDataSourceAWSAccessCredentials_basic(t *testing.T) {
 func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 	mountPath := acctest.RandomWithPrefix("aws")
 	accessKey, secretKey := getTestAWSCreds(t)
-	resource.Test(t, resource.TestCase{
-		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t) },
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataSourceAWSAccessCredentialsConfig_sts(mountPath, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
-					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
-					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "security_token"),
-					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
-					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
-					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(mountPath),
-				),
-			},
+
+	type testCase struct {
+		config string
+	}
+
+	tests := map[string]testCase{
+		"sts without role_arn": {
+			config: fmt.Sprintf(`
+				resource "vault_aws_secret_backend" "aws" {
+					path = "%s"
+					description = "Obtain AWS credentials."
+					access_key = "%s"
+					secret_key = "%s"
+				}
+				
+				resource "vault_aws_secret_backend_role" "role" {
+					backend = "${vault_aws_secret_backend.aws.path}"
+					name = "test"
+					credential_type = "federation_token"
+					policy_document = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
+				}
+				
+				data "vault_aws_access_credentials" "test" {
+					backend = "${vault_aws_secret_backend.aws.path}"
+					role = "${vault_aws_secret_backend_role.role.name}"
+					type = "sts"
+				}`, mountPath, accessKey, secretKey),
 		},
-	})
+		"sts with role_arn": {
+			config: fmt.Sprintf(`
+				resource "vault_aws_secret_backend" "aws" {
+					path = "%s"
+					description = "Obtain AWS credentials."
+					access_key = "%s"
+					secret_key = "%s"
+				}
+				
+				resource "vault_aws_secret_backend_role" "role" {
+					backend = "${vault_aws_secret_backend.aws.path}"
+					name = "test"
+					credential_type = "federation_token"
+					policy_document = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
+				}
+				
+				data "vault_aws_access_credentials" "test" {
+					backend  = "${vault_aws_secret_backend.aws.path}"
+					role     = "${vault_aws_secret_backend_role.role.name}"
+					type     = "sts"
+					role_arn = "arn:aws:iam::012345678901:role/foobar"
+				}`, mountPath, accessKey, secretKey),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				Providers: testProviders,
+				PreCheck:  func() { testAccPreCheck(t) },
+				Steps: []resource.TestStep{
+					{
+						Config: test.config,
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
+							resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
+							resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "security_token"),
+							resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
+							resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
+							testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(),
+						),
+					},
+				},
+			})
+		})
+	}
 }
 
 func testAccDataSourceAWSAccessCredentialsConfig_basic(mountPath, accessKey, secretKey string) string {
@@ -83,30 +140,7 @@ data "vault_aws_access_credentials" "test" {
 }`, mountPath, accessKey, secretKey)
 }
 
-func testAccDataSourceAWSAccessCredentialsConfig_sts(mountPath, accessKey, secretKey string) string {
-	return fmt.Sprintf(`
-resource "vault_aws_secret_backend" "aws" {
-    path = "%s"
-    description = "Obtain AWS credentials."
-    access_key = "%s"
-    secret_key = "%s"
-}
-
-resource "vault_aws_secret_backend_role" "role" {
-    backend = "${vault_aws_secret_backend.aws.path}"
-    name = "test"
-    credential_type = "federation_token"
-    policy_document = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
-}
-
-data "vault_aws_access_credentials" "test" {
-    backend = "${vault_aws_secret_backend.aws.path}"
-    role = "${vault_aws_secret_backend_role.role.name}"
-    type = "sts"
-}`, mountPath, accessKey, secretKey)
-}
-
-func testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(mountPath string) resource.TestCheckFunc {
+func testAccDataSourceAWSAccessCredentialsCheck_tokenWorks() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState := s.Modules[0].Resources["data.vault_aws_access_credentials.test"]
 		if resourceState == nil {

--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -71,6 +71,10 @@ to `"creds"`, which just returns an AWS Access Key ID and Secret
 Key. Can also be set to `"sts"`, which will return a security token
 in addition to the keys.
 
+* `role_arn` - (Required if role has multiple ARNs) The specific AWS ARN to use
+from the configured role. If the role does not have multiple ARNs, this does
+not need to be specified.
+
 ## Attributes Reference
 
 In addition to the arguments above, the following attributes are exported:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Adds ability to choose a specific AWS ARN in vault_aws_access_credentials when a Vault role has multiple ARNs configured.
```

Output from acceptance testing:

```
$ TESTARGS="--run DataSourceAWSAccessCredentials --count=1" gnumake testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run DataSourceAWSAccessCredentials --count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	0.633s [no tests to run]
=== RUN   TestAccDataSourceAWSAccessCredentials_basic
--- PASS: TestAccDataSourceAWSAccessCredentials_basic (79.31s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn
--- PASS: TestAccDataSourceAWSAccessCredentials_sts (3.40s)
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn (1.72s)
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn (1.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	83.594s
...
```
