### PR TITLE
Clarify required vault capabilities and disable_read usage

### DIFF
--- a/website/docs/r/generic_secret.html.md
+++ b/website/docs/r/generic_secret.html.md
@@ -66,15 +66,16 @@ The following arguments are supported:
 
 Use of this resource requires the `create` or `update` capability
 (depending on whether the resource already exists) on the given path,
-along with the `delete` capbility if the resource is removed from
-configuration.
+the `delete` capbility if the resource is removed from configuration,
+and the `read` capability for drift detection (by default).
 
-This resource does not *read* the secret data back from Terraform
-on refresh by default. This avoids the need for `read` access on the given
-path, but it means that Terraform is not able to detect and repair
-"drift" on this resource should the data be updated or deleted outside
-of Terraform. This limitation can be negated by setting `allow_read` to
-true
+### Drift Detection
+
+This resource does not necessarily need to *read* the secret data back from
+Terraform on refresh. To avoid the need for `read` access on the given path
+set the `disable_read` argument to `true`. This means that Terraform *will not*
+be able to detect and repair "drift" on this resource,
+should the data be updated or deleted outside of Terraform.
 
 ## Attributes Reference
 

--- a/website/docs/r/generic_secret.html.md
+++ b/website/docs/r/generic_secret.html.md
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 Use of this resource requires the `create` or `update` capability
 (depending on whether the resource already exists) on the given path,
-the `delete` capbility if the resource is removed from configuration,
+the `delete` capability if the resource is removed from configuration,
 and the `read` capability for drift detection (by default).
 
 ### Drift Detection


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
```release-note
Docs: Clarify required vault capabilities and disable_read usage for generic_secret
```

Output from acceptance testing:
```
This does PR does not modify any working code.
```