### PR TITLE
Add missing documentation link to `vault_consul_secret_backend_role`

### DIFF
--- a/website/vault.erb
+++ b/website/vault.erb
@@ -142,6 +142,10 @@
                             <a href="/docs/providers/vault/r/consul_secret_backend.html">vault_consul_secret_backend</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-consul-secret-backend-role") %>>
+                            <a href="/docs/providers/vault/r/consul_secret_backend_role.html">vault_consul_secret_backend_role</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-database-secret-backend-connection") %>>
                             <a href="/docs/providers/vault/r/database_secret_backend_connection.html">vault_database_secret_backend_connection</a>
                         </li>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Fix link to `vault_consul_secret_backend_role` resource documentation
```

Output from acceptance testing:

```
No Code changes
```
