### PR TITLE
fix(okta_auth_backend_group): allow '/' in group_name

### DIFF
--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -104,8 +104,8 @@ func oktaAuthBackendResource() *schema.Resource {
 							ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
 								value := v.(string)
 								// No comma as it'll become part of a comma separate list
-								if strings.Contains(value, ",") || strings.Contains(value, "/") {
-									errs = append(errs, errors.New("group cannot contain ',' or '/'"))
+								if strings.Contains(value, ",") {
+									errs = append(errs, errors.New("group cannot contain ','"))
 								}
 								return
 							},
@@ -150,8 +150,8 @@ func oktaAuthBackendResource() *schema.Resource {
 								ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
 									value := v.(string)
 									// No comma as it'll become part of a comma separate list
-									if strings.Contains(value, ",") || strings.Contains(value, "/") {
-										errs = append(errs, errors.New("group cannot contain ',' or '/'"))
+									if strings.Contains(value, ",") {
+										errs = append(errs, errors.New("group cannot contain ','"))
 									}
 									return
 								},

--- a/vault/resource_okta_auth_backend_group.go
+++ b/vault/resource_okta_auth_backend_group.go
@@ -38,8 +38,8 @@ func oktaAuthBackendGroupResource() *schema.Resource {
 				ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
 					value := v.(string)
 					// No comma as it'll become part of a comma separate list
-					if strings.Contains(value, ",") || strings.Contains(value, "/") {
-						errs = append(errs, errors.New("group name cannot contain ',' or '/'"))
+					if strings.Contains(value, ",") {
+						errs = append(errs, errors.New("group name cannot contain ','"))
 					}
 					return
 				},
@@ -179,7 +179,7 @@ func oktaAuthBackendGroupID(path, groupName string) string {
 }
 
 func oktaAuthBackendGroupPathFromID(id string) (string, error) {
-	var parts = strings.Split(id, "/")
+	var parts = strings.SplitN(id, "/", 2)
 	if len(parts) != 2 {
 		return "", fmt.Errorf("Expected 2 parts in ID '%s'", id)
 	}
@@ -187,7 +187,7 @@ func oktaAuthBackendGroupPathFromID(id string) (string, error) {
 }
 
 func oktaAuthBackendGroupNameFromID(id string) (string, error) {
-	var parts = strings.Split(id, "/")
+	var parts = strings.SplitN(id, "/", 2)
 	if len(parts) != 2 {
 		return "", fmt.Errorf("Expected 2 parts in ID '%s'", id)
 	}

--- a/vault/resource_okta_auth_backend_group_test.go
+++ b/vault/resource_okta_auth_backend_group_test.go
@@ -12,19 +12,19 @@ import (
 )
 
 // This is light on testing as most of the code is covered by `resource_okta_auth_backend_test.go`
-func TestOktaAuthBackendGroup(t *testing.T) {
+func TestAccOktaAuthBackendGroup(t *testing.T) {
 	path := "okta-" + strconv.Itoa(acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testOktaAuthBackendGroup_Destroyed(path, "foo"),
+		CheckDestroy: testAccOktaAuthBackendGroup_Destroyed(path, "foo"),
 		Steps: []resource.TestStep{
 			{
-				Config: initialOktaAuthGroupConfig(path),
+				Config: testAccOktaAuthGroupConfig(path),
 				Check: resource.ComposeTestCheckFunc(
-					testOktaAuthBackendGroup_InitialCheck,
-					testOktaAuthBackend_GroupsCheck(path, "foo", []string{"one", "two", "default"}),
+					testAccOktaAuthBackendGroup_InitialCheck,
+					testAccOktaAuthBackend_GroupsCheck(path, "foo", []string{"one", "two", "default"}),
 				),
 			},
 			{
@@ -36,7 +36,7 @@ func TestOktaAuthBackendGroup(t *testing.T) {
 	})
 }
 
-func initialOktaAuthGroupConfig(path string) string {
+func testAccOktaAuthGroupConfig(path string) string {
 	return fmt.Sprintf(`
 resource "vault_okta_auth_backend" "test" {
     path = "%s"
@@ -51,7 +51,7 @@ resource "vault_okta_auth_backend_group" "test" {
 `, path)
 }
 
-func testOktaAuthBackendGroup_InitialCheck(s *terraform.State) error {
+func testAccOktaAuthBackendGroup_InitialCheck(s *terraform.State) error {
 	resourceState := s.Modules[0].Resources["vault_okta_auth_backend_group.test"]
 	if resourceState == nil {
 		return fmt.Errorf("resource not found in state")
@@ -65,7 +65,7 @@ func testOktaAuthBackendGroup_InitialCheck(s *terraform.State) error {
 	return nil
 }
 
-func testOktaAuthBackendGroup_Destroyed(path, groupName string) resource.TestCheckFunc {
+func testAccOktaAuthBackendGroup_Destroyed(path, groupName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testProvider.Meta().(*api.Client)
 

--- a/vault/resource_okta_auth_backend_group_test.go
+++ b/vault/resource_okta_auth_backend_group_test.go
@@ -14,6 +14,7 @@ import (
 // This is light on testing as most of the code is covered by `resource_okta_auth_backend_test.go`
 func TestAccOktaAuthBackendGroup(t *testing.T) {
 	path := "okta-" + strconv.Itoa(acctest.RandInt())
+	organization := "dummy"
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -21,7 +22,7 @@ func TestAccOktaAuthBackendGroup(t *testing.T) {
 		CheckDestroy: testAccOktaAuthBackendGroup_Destroyed(path, "foo"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOktaAuthGroupConfig(path),
+				Config: testAccOktaAuthGroupConfig(path, organization),
 				Check: resource.ComposeTestCheckFunc(
 					testAccOktaAuthBackendGroup_InitialCheck,
 					testAccOktaAuthBackend_GroupsCheck(path, "foo", []string{"one", "two", "default"}),
@@ -36,11 +37,11 @@ func TestAccOktaAuthBackendGroup(t *testing.T) {
 	})
 }
 
-func testAccOktaAuthGroupConfig(path string) string {
+func testAccOktaAuthGroupConfig(path string, organization string) string {
 	return fmt.Sprintf(`
 resource "vault_okta_auth_backend" "test" {
     path = "%s"
-    organization = "dummy"
+    organization = "%s"
 }
 
 resource "vault_okta_auth_backend_group" "test" {
@@ -48,7 +49,7 @@ resource "vault_okta_auth_backend_group" "test" {
     group_name = "foo"
     policies = ["one", "two", "default"]
 }
-`, path)
+`, path, organization)
 }
 
 func testAccOktaAuthBackendGroup_InitialCheck(s *terraform.State) error {

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -14,34 +14,34 @@ import (
 	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
-func TestOktaAuthBackend(t *testing.T) {
+func TestAccOktaAuthBackend(t *testing.T) {
 	path := "okta-" + strconv.Itoa(acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testOktaAuthBackend_Destroyed(path),
+		CheckDestroy: testAccOktaAuthBackend_Destroyed(path),
 		Steps: []resource.TestStep{
 			{
-				Config: initialOktaAuthConfig(path),
+				Config: testAccOktaAuthConfig_basic(path),
 				Check: resource.ComposeTestCheckFunc(
-					testOktaAuthBackend_InitialCheck,
-					testOktaAuthBackend_GroupsCheck(path, "dummy", []string{"one", "two", "default"}),
-					testOktaAuthBackend_UsersCheck(path, "foo", []string{"dummy"}, []string{}),
+					testAccOktaAuthBackend_InitialCheck,
+					testAccOktaAuthBackend_GroupsCheck(path, "dummy", []string{"one", "two", "default"}),
+					testAccOktaAuthBackend_UsersCheck(path, "foo", []string{"dummy"}, []string{}),
 				),
 			},
 			{
-				Config: updatedOktaAuthConfig(path),
+				Config: testAccOktaAuthConfig_updated(path),
 				Check: resource.ComposeTestCheckFunc(
-					testOktaAuthBackend_GroupsCheck(path, "example", []string{"three", "four", "default"}),
-					testOktaAuthBackend_UsersCheck(path, "bar", []string{"example"}, []string{}),
+					testAccOktaAuthBackend_GroupsCheck(path, "example", []string{"three", "four", "default"}),
+					testAccOktaAuthBackend_UsersCheck(path, "bar", []string{"example"}, []string{}),
 				),
 			},
 		},
 	})
 }
 
-func initialOktaAuthConfig(path string) string {
+func testAccOktaAuthConfig_basic(path string) string {
 	return fmt.Sprintf(`
 resource "vault_okta_auth_backend" "test" {
     description = "Testing the Terraform okta auth backend"
@@ -61,7 +61,7 @@ resource "vault_okta_auth_backend" "test" {
 `, path)
 }
 
-func testOktaAuthBackend_InitialCheck(s *terraform.State) error {
+func testAccOktaAuthBackend_InitialCheck(s *terraform.State) error {
 	resourceState := s.Modules[0].Resources["vault_okta_auth_backend.test"]
 	if resourceState == nil {
 		return fmt.Errorf("resource not found in state")
@@ -124,7 +124,7 @@ func testOktaAuthBackend_InitialCheck(s *terraform.State) error {
 	return nil
 }
 
-func testOktaAuthBackend_GroupsCheck(path, groupName string, expectedPolicies []string) resource.TestCheckFunc {
+func testAccOktaAuthBackend_GroupsCheck(path, groupName string, expectedPolicies []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testProvider.Meta().(*api.Client)
 
@@ -165,7 +165,7 @@ func testOktaAuthBackend_GroupsCheck(path, groupName string, expectedPolicies []
 
 }
 
-func testOktaAuthBackend_UsersCheck(path, userName string, expectedGroups, expectedPolicies []string) resource.TestCheckFunc {
+func testAccOktaAuthBackend_UsersCheck(path, userName string, expectedGroups, expectedPolicies []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testProvider.Meta().(*api.Client)
 
@@ -229,7 +229,7 @@ func testOktaAuthBackend_UsersCheck(path, userName string, expectedGroups, expec
 
 }
 
-func updatedOktaAuthConfig(path string) string {
+func testAccOktaAuthConfig_updated(path string) string {
 	return fmt.Sprintf(`
 resource "vault_okta_auth_backend" "test" {
     description = "Testing the Terraform okta auth backend"
@@ -248,7 +248,7 @@ resource "vault_okta_auth_backend" "test" {
 `, path)
 }
 
-func testOktaAuthBackend_Destroyed(path string) resource.TestCheckFunc {
+func testAccOktaAuthBackend_Destroyed(path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		client := testProvider.Meta().(*api.Client)

--- a/vault/resource_okta_auth_backend_user.go
+++ b/vault/resource_okta_auth_backend_user.go
@@ -43,8 +43,8 @@ func oktaAuthBackendUserResource() *schema.Resource {
 					ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
 						value := v.(string)
 						// No comma as it'll become part of a comma separate list
-						if strings.Contains(value, ",") || strings.Contains(value, "/") {
-							errs = append(errs, errors.New("group cannot contain ',' or '/'"))
+						if strings.Contains(value, ",") {
+							errs = append(errs, errors.New("group cannot contain ','"))
 						}
 						return
 					},

--- a/vault/resource_okta_auth_backend_user_test.go
+++ b/vault/resource_okta_auth_backend_user_test.go
@@ -13,6 +13,7 @@ import (
 // This is light on testing as most of the code is covered by `resource_okta_auth_backend_test.go`
 func TestAccOktaAuthBackendUser(t *testing.T) {
 	path := "okta-" + strconv.Itoa(acctest.RandInt())
+	organization := "dummy"
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -20,7 +21,7 @@ func TestAccOktaAuthBackendUser(t *testing.T) {
 		CheckDestroy: testAccOktaAuthBackendUser_Destroyed(path, "user_test"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOktaAuthUserConfig(path),
+				Config: testAccOktaAuthUserConfig(path, organization),
 				Check: resource.ComposeTestCheckFunc(
 					testAccOktaAuthBackendUser_InitialCheck,
 					testAccOktaAuthBackend_UsersCheck(path, "user_test", []string{"one", "two"}, []string{"three"}),
@@ -30,11 +31,11 @@ func TestAccOktaAuthBackendUser(t *testing.T) {
 	})
 }
 
-func testAccOktaAuthUserConfig(path string) string {
+func testAccOktaAuthUserConfig(path string, organization string) string {
 	return fmt.Sprintf(`
 resource "vault_okta_auth_backend" "test" {
     path = "%s"
-    organization = "dummy"
+    organization = "%s"
 }
 
 resource "vault_okta_auth_backend_user" "test" {
@@ -43,7 +44,7 @@ resource "vault_okta_auth_backend_user" "test" {
     groups = ["one", "two"]
     policies = ["three"]
 }
-`, path)
+`, path, organization)
 }
 
 func testAccOktaAuthBackendUser_InitialCheck(s *terraform.State) error {

--- a/vault/resource_okta_auth_backend_user_test.go
+++ b/vault/resource_okta_auth_backend_user_test.go
@@ -11,26 +11,26 @@ import (
 )
 
 // This is light on testing as most of the code is covered by `resource_okta_auth_backend_test.go`
-func TestOktaAuthBackendUser(t *testing.T) {
+func TestAccOktaAuthBackendUser(t *testing.T) {
 	path := "okta-" + strconv.Itoa(acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testOktaAuthBackendUser_Destroyed(path, "user_test"),
+		CheckDestroy: testAccOktaAuthBackendUser_Destroyed(path, "user_test"),
 		Steps: []resource.TestStep{
 			{
-				Config: initialOktaAuthUserConfig(path),
+				Config: testAccOktaAuthUserConfig(path),
 				Check: resource.ComposeTestCheckFunc(
-					testOktaAuthBackendUser_InitialCheck,
-					testOktaAuthBackend_UsersCheck(path, "user_test", []string{"one", "two"}, []string{"three"}),
+					testAccOktaAuthBackendUser_InitialCheck,
+					testAccOktaAuthBackend_UsersCheck(path, "user_test", []string{"one", "two"}, []string{"three"}),
 				),
 			},
 		},
 	})
 }
 
-func initialOktaAuthUserConfig(path string) string {
+func testAccOktaAuthUserConfig(path string) string {
 	return fmt.Sprintf(`
 resource "vault_okta_auth_backend" "test" {
     path = "%s"
@@ -46,7 +46,7 @@ resource "vault_okta_auth_backend_user" "test" {
 `, path)
 }
 
-func testOktaAuthBackendUser_InitialCheck(s *terraform.State) error {
+func testAccOktaAuthBackendUser_InitialCheck(s *terraform.State) error {
 	resourceState := s.Modules[0].Resources["vault_okta_auth_backend_user.test"]
 	if resourceState == nil {
 		return fmt.Errorf("resource not found in state")
@@ -60,7 +60,7 @@ func testOktaAuthBackendUser_InitialCheck(s *terraform.State) error {
 	return nil
 }
 
-func testOktaAuthBackendUser_Destroyed(path, userName string) resource.TestCheckFunc {
+func testAccOktaAuthBackendUser_Destroyed(path, userName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testProvider.Meta().(*api.Client)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Maybe I missed some context but why do we not allowed '/' initially in the group name ?

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allow '/' character in the group_name field of the okta_auth_backend_group resource
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestOkta'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestOkta -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestOktaAuthBackendGroup
--- PASS: TestOktaAuthBackendGroup (4.49s)
=== RUN   TestOktaAuthBackend
--- PASS: TestOktaAuthBackend (3.99s)
=== RUN   TestOktaAuthBackendUser
--- PASS: TestOktaAuthBackendUser (8.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   17.053s

...
```
