### PR TITLE
Support not_before_duration property in pki_secret_backend_role

### DIFF
--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -301,9 +301,9 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     false,
 				Optional:     true,
+				Computed:     true,
 				Description:  "Specifies the duration by which to backdate the NotBefore property.",
 				ValidateFunc: validateDuration,
-				Default:      "30s",
 			},
 		},
 	}

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -297,6 +297,13 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Description: "Flag to mark basic constraints valid when issuing non-CA certificates.",
 				Default:     false,
 			},
+			"not_before_duration": {
+				Type:         schema.TypeString,
+				Required:     false,
+				Optional:     true,
+				Description:  "Specifies the duration by which to backdate the NotBefore property.",
+				ValidateFunc: validateDuration,
+			},
 		},
 	}
 }
@@ -366,6 +373,7 @@ func pkiSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error 
 		"no_store":                           d.Get("no_store"),
 		"require_cn":                         d.Get("require_cn"),
 		"basic_constraints_valid_for_non_ca": d.Get("basic_constraints_valid_for_non_ca"),
+		"not_before_duration":                d.Get("not_before_duration"),
 	}
 
 	if len(allowedDomains) > 0 {
@@ -491,6 +499,9 @@ func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("policy_identifiers", policyIdentifiers)
 	d.Set("basic_constraints_valid_for_non_ca", secret.Data["basic_constraints_valid_for_non_ca"])
 
+	notBeforeDuration := flattenVaultDuration(secret.Data["not_before_duration"])
+	d.Set("not_before_duration", notBeforeDuration)
+
 	return nil
 }
 
@@ -555,6 +566,7 @@ func pkiSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error 
 		"no_store":                           d.Get("no_store"),
 		"require_cn":                         d.Get("require_cn"),
 		"basic_constraints_valid_for_non_ca": d.Get("basic_constraints_valid_for_non_ca"),
+		"not_before_duration":                d.Get("not_before_duration"),
 	}
 
 	if len(allowedDomains) > 0 {

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -303,6 +303,7 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Optional:     true,
 				Description:  "Specifies the duration by which to backdate the NotBefore property.",
 				ValidateFunc: validateDuration,
+				Default:      "30s",
 			},
 		},
 	}
@@ -462,6 +463,8 @@ func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		policyIdentifiers = append(policyIdentifiers, iIdentifier.(string))
 	}
 
+	notBeforeDuration := flattenVaultDuration(secret.Data["not_before_duration"])
+
 	d.Set("backend", backend)
 	d.Set("name", name)
 	d.Set("ttl", secret.Data["ttl"])
@@ -498,8 +501,6 @@ func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("require_cn", secret.Data["require_cn"])
 	d.Set("policy_identifiers", policyIdentifiers)
 	d.Set("basic_constraints_valid_for_non_ca", secret.Data["basic_constraints_valid_for_non_ca"])
-
-	notBeforeDuration := flattenVaultDuration(secret.Data["not_before_duration"])
 	d.Set("not_before_duration", notBeforeDuration)
 
 	return nil

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -64,6 +64,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "policy_identifiers.#", "1"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "policy_identifiers.0", "1.2.3.4"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "basic_constraints_valid_for_non_ca", "false"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "not_before_duration", "45m"),
 				),
 			},
 			{
@@ -110,6 +111,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "policy_identifiers.#", "1"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "policy_identifiers.0", "1.2.3.4"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "basic_constraints_valid_for_non_ca", "false"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "not_before_duration", "45m"),
 				),
 			},
 		},
@@ -160,6 +162,7 @@ resource "vault_pki_secret_backend_role" "test" {
   require_cn = true
   policy_identifiers = ["1.2.3.4"]
   basic_constraints_valid_for_non_ca = false
+  not_before_duration = "45m"
 }`, path, name)
 }
 
@@ -207,6 +210,7 @@ resource "vault_pki_secret_backend_role" "test" {
   require_cn = true
   policy_identifiers = ["1.2.3.4"]
   basic_constraints_valid_for_non_ca = false
+  not_before_duration = "45m"
 }`, path, name)
 }
 

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `basic_constraints_valid_for_non_ca` - (Optional) Flag to mark basic constraints valid when issuing non-CA certificates
 
+* `not_before_duration` - (Optional) Specifies the duration by which to backdate the NotBefore property.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Output from acceptance testing:

```
TESTARGS="--run TestPkiSecretBackendRole_basic" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run TestPkiSecretBackendRole_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (0.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   0.282s
```
