### PR TITLE
Update auth_backend doc to reflect argument deprecation and tune block

### DIFF
--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -32,13 +32,9 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of the auth method
 
-* `default_lease_ttl_seconds` - (Optional; Deprecated, use the `tune` block's `default_lease_ttl` attribute instead) The default lease duration in seconds.
-
-* `max_lease_ttl_seconds` - (Optional; Deprecated, use the `tune` block's `max_lease_ttl` attribute instead) The maximum lease duration in seconds.
-
-* `listing_visibility` - (Optional; Deprecated, use the `tune` block's `listing_visibility` attribute instead) Specifies whether to show this mount in the UI-specific listing endpoint.
-
 * `local` - (Optional) Specifies if the auth method is local only.
+
+* `tune` - (Optional) Extra configuration block. Structure is documented below.
 
 The `tune` block is used to tune the auth backend:
 
@@ -73,6 +69,17 @@ The `tune` block is used to tune the auth backend:
 In addition to the fields above, the following attributes are exported:
 
 * `accessor` - The accessor for this auth method
+
+### Deprecated Arguments
+
+These arguments are deprecated since version 1.8 of the provider in favour of the `tune` block
+arguments documented above.
+
+* `default_lease_ttl_seconds` - (Optional; Deprecated, use `tune.default_lease_ttl` if you are using Vault provider version >= 1.8) The default lease duration in seconds.
+
+* `max_lease_ttl_seconds` - (Optional; Deprecated, use `tune.max_lease_ttl` if you are using Vault provider version >= 1.8) The maximum lease duration in seconds.
+
+* `listing_visibility` - (Optional; Deprecated, use `tune.listing_visibility` if you are using Vault provider version >= 1.8) Speficies whether to show this mount in the UI-specific listing endpoint.
 
 ## Import
 

--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -35,6 +35,8 @@ The following arguments are supported:
 * `description` - (Optional) Specifies the description of the mount.
   This overrides the current stored value, if any.
 
+* tune - (Optional) Extra configuration block. Structure is documented below.
+
 The `tune` block is used to tune the auth backend:
 
 * `default_lease_ttl` - (Optional) Specifies the default time-to-live.

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 * `default_role` - (Optional) The default role to use if none is provided during login
 
+* tune - (Optional) Extra configuration block. Structure is documented below.
+
 The `tune` block is used to tune the auth backend:
 
 * `default_lease_ttl` - (Optional) Specifies the default time-to-live.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #697
Relates #650 (Introduces the code change without documenting it)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
