### PR TITLE
Elasticsearch support in vault_database_secret_backend_connection

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,3 +1,6 @@
 export VAULT_ADDR="http://localhost:8200"
 export VAULT_TOKEN="TEST"
 export MYSQL_URL="vault:vault@tcp(mysql:3306)/"
+export ELASTIC_URL="http://elastic:9200"
+export ELASTIC_USERNAME="elastic"
+export ELASTIC_PASSWORD="elastic"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,3 +21,12 @@ services:
       MYSQL_DATABASE: "main"
       MYSQL_USER: "vault"
       MYSQL_PASSWORD: "vault"
+
+  elastic:
+    image: elasticsearch:7.6.0
+    ports:
+    - "9200:9200"
+    environment:
+      "discovery.type": "single-node"
+      "xpack.security.enabled": "true"
+      "ELASTIC_PASSWORD": "elastic"

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -74,17 +74,17 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"url": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 							Description: "The URL for Elasticsearch's API",
 						},
 						"username": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 							Description: "The username to be used in the connection URL",
 						},
 						"password": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 							Description: "The password to be used in the connection URL",
 							Sensitive:   true,
 						},

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -16,7 +16,7 @@ import (
 var (
 	databaseSecretBackendConnectionBackendFromPathRegex = regexp.MustCompile("^(.+)/config/.+$")
 	databaseSecretBackendConnectionNameFromPathRegex    = regexp.MustCompile("^.+/config/(.+$)")
-	dbBackendTypes                                      = []string{"cassandra", "hana", "mongodb", "mssql", "mysql", "mysql_rds", "mysql_aurora", "mysql_legacy", "postgresql", "oracle"}
+	dbBackendTypes                                      = []string{"cassandra", "hana", "mongodb", "mssql", "mysql", "mysql_rds", "mysql_aurora", "mysql_legacy", "postgresql", "oracle", "elasticsearch"}
 )
 
 func databaseSecretBackendConnectionResource() *schema.Resource {
@@ -64,6 +64,34 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Optional:    true,
 				Description: "A map of sensitive data to pass to the endpoint. Useful for templated connection strings.",
 				Sensitive:   true,
+			},
+
+			"elasticsearch": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Connection parameters for the elasticsearch-database-plugin.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The URL for Elasticsearch's API",
+						},
+						"username": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The username to be used in the connection URL",
+						},
+						"password": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The password to be used in the connection URL",
+							Sensitive:   true,
+						},
+					},
+				},
+				MaxItems:      1,
+				ConflictsWith: util.CalculateConflictsWith("elasticsearch", dbBackendTypes),
 			},
 
 			"cassandra": {
@@ -281,6 +309,8 @@ func getDatabasePluginName(d *schema.ResourceData) (string, error) {
 		return "oracle-database-plugin", nil
 	case len(d.Get("postgresql").([]interface{})) > 0:
 		return "postgresql-database-plugin", nil
+	case len(d.Get("elasticsearch").([]interface{})) > 0:
+		return "elasticsearch-database-plugin", nil
 	default:
 		return "", fmt.Errorf("at least one database plugin must be configured")
 	}
@@ -353,6 +383,8 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 		setDatabaseConnectionData(d, "oracle.0.", data)
 	case "postgresql-database-plugin":
 		setDatabaseConnectionData(d, "postgresql.0.", data)
+	case "elasticsearch-database-plugin":
+		setElasticsearchDatabaseConnectionData(d, "elasticsearch.0.", data)
 	}
 
 	return data, nil
@@ -399,6 +431,34 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 	return []map[string]interface{}{result}
 }
 
+func getElasticsearchConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) []map[string]interface{} {
+	details := resp.Data["connection_details"]
+	data, ok := details.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result := map[string]interface{}{}
+	if v, ok := d.GetOk(prefix + "url"); ok {
+		result["url"] = v.(string)
+	} else {
+		if v, ok := data["url"]; ok {
+			result["url"] = v.(string)
+		}
+	}
+
+	if v, ok := data["username"]; ok {
+		result["username"] = v.(string)
+	}
+	if v, ok := data["password"]; ok {
+		result["password"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "password"); ok {
+		// keep the password we have in state/config if the API doesn't return one
+		result["password"] = v.(string)
+	}
+
+	return []map[string]interface{}{result}
+}
+
 func setDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
 	if v, ok := d.GetOk(prefix + "connection_url"); ok {
 		data["connection_url"] = v.(string)
@@ -411,6 +471,20 @@ func setDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[s
 	}
 	if v, ok := d.GetOkExists(prefix + "max_connection_lifetime"); ok {
 		data["max_connection_lifetime"] = fmt.Sprintf("%ds", v)
+	}
+}
+
+func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
+	if v, ok := d.GetOk(prefix + "url"); ok {
+		data["url"] = v.(string)
+	}
+
+	if v, ok := d.GetOk(prefix + "username"); ok {
+		data["username"] = v.(string)
+	}
+
+	if v, ok := d.GetOk(prefix + "password"); ok {
+		data["password"] = v.(string)
 	}
 }
 
@@ -564,6 +638,8 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 		d.Set("oracle", getConnectionDetailsFromResponse(d, "oracle.0.", resp))
 	case "postgresql-database-plugin":
 		d.Set("postgresql", getConnectionDetailsFromResponse(d, "postgresql.0.", resp))
+	case "elasticsearch-database-plugin":
+		d.Set("elasticsearch", getElasticsearchConnectionDetailsFromResponse(d, "elasticsearch.0.", resp))
 	}
 
 	if err != nil {

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -75,6 +75,8 @@ The following arguments are supported:
 
 * `oracle` - (Optional) A nested block containing configuration options for Oracle connections.
 
+* `elasticsearch` - (Optional) A nested block containing configuration options for Elasticsearch connections.
+
 Exactly one of the nested blocks of configuration options must be supplied.
 
 ### Cassandra Configuration Options
@@ -189,6 +191,15 @@ Exactly one of the nested blocks of configuration options must be supplied.
 
 * `max_connection_lifetime` - (Optional) The maximum number of seconds to keep
   a connection alive for.
+
+### Elasticsearch Configuration Options
+
+* `url` - (Required) The URL for Elasticsearch's API. https requires certificate
+  by trusted CA if used.
+
+* `username` - (Required) The username to be used in the connection.
+
+* `password` - (Required) The password to be used in the connection.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add basic support for elasticsearch database. By basic, I mean that we only have properties for url, username and password. No ca certificates, or client_certs because they would need to reside inside vaults filesystem.

Current vault's elasticsearch support is not great:
1) it's using legacy API
2) CA certs needs to be in filesystem (can't define them in requests)
3) Role definitions can't modify kibana ACLs

Example of vault-cli walkthrough: https://github.com/hashicorp/vault-plugin-database-elasticsearch#example-walkthrough

This would allow us to setup user provision through vault with terraform same way as with vault-cli. Good enough for now, but when ES support gets better in vault, this could be extended to be better as well.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds support for elasticsearch in vault_database_secret_backend_connection
```

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_elasticsearch'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDatabaseSecretBackendConnection_elasticsearch -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestAccDatabaseSecretBackendConnection_elasticsearch
--- PASS: TestAccDatabaseSecretBackendConnection_elasticsearch (0.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   (cached)
```
