### PR TITLE
Fix vault_policy example Documentation

### DIFF
--- a/website/docs/r/policy.html.md
+++ b/website/docs/r/policy.html.md
@@ -17,7 +17,7 @@ resource "vault_policy" "example" {
 
   policy = <<EOT
 path "secret/my_app" {
-  policy = "write"
+  capabilities = ["write"]
 }
 EOT
 }


### PR DESCRIPTION
The policy should be about path and capabilities. The documentation provided a wrong example

https://www.vaultproject.io/docs/concepts/policies/#policy-syntax