### PR TITLE
aws_secret_backend: allow role_arns with policy_arns

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -38,7 +38,7 @@ func awsSecretBackendRoleResource() *schema.Resource {
 			"policy_arns": {
 				Type:          schema.TypeSet,
 				Optional:      true,
-				ConflictsWith: []string{"policy", "policy_arn", "role_arns"},
+				ConflictsWith: []string{"policy", "policy_arn"},
 				Description:   "ARN for an existing IAM policy the role should use.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -78,7 +78,7 @@ func awsSecretBackendRoleResource() *schema.Resource {
 				},
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"policy", "policy_arn", "policy_arns"},
+				ConflictsWith: []string{"policy", "policy_arn"},
 				Description:   "ARNs of AWS roles allowed to be assumed. Only valid when credential_type is 'assumed_role'",
 			},
 			"default_sts_ttl": {

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -29,7 +29,7 @@ resource "vault_aws_secret_backend" "aws" {
 resource "vault_aws_secret_backend_role" "role" {
   backend = "${vault_aws_secret_backend.aws.path}"
   name    = "deploy"
-  credential_type = "assumed_role"
+  credential_type = "iam_user"
 
   policy_document = <<EOT
 {
@@ -56,19 +56,27 @@ with no leading or trailing `/`s.
 * `name` - (Required) The name to identify this role within the backend.
 Must be unique within the backend.
 
-* `policy_document` - (Optional) The JSON-formatted policy to associate with this
-role. Either `policy_document` or `policy_arns` must be specified.
-
-* `policy_arns` - (Optional) The ARN for a pre-existing policy to associate
-with this role. Either `policy_document` or `policy_arns` must be specified.
+* `credential_type` - (Required) Specifies the type of credential to be used when
+retrieving credentials from the role. Must be one of `iam_user`, `assumed_role`, or
+`federation_token`.
 
 * `role_arns` - (Optional) Specifies the ARNs of the AWS roles this Vault role
 is allowed to assume. Required when `credential_type` is `assumed_role` and
 prohibited otherwise.
 
-* `credential_type` - (Required) Specifies the type of credential to be used when
-retrieving credentials from the role. Must be one of `iam_user`, `assumed_role`, or
-`federation_token`.
+* `policy_arns` - (Optional) Specifies a list of AWS managed policy ARNs. The
+behavior depends on the credential type. With `iam_user`, the policies will be
+attached to IAM users when they are requested. With `assumed_role` and
+`federation_token`, the policy ARNs will act as a filter on what the credentials
+can do, similar to `policy_document`. When `credential_type` is `iam_user` or
+`federation_token`, at least one of `policy_document` or `policy_arns` must
+be specified.
+
+* `policy_document` - (Optional) The IAM policy document for the role. The
+behavior depends on the credential type. With `iam_user`, the policy document
+will be attached to the IAM user generated and augment the permissions the IAM
+user has. With `assumed_role` and `federation_token`, the policy document will
+act as a filter on what the credentials can do, similar to `policy_arns`.
 
 * `default_sts_ttl` - (Optional) The default TTL in seconds for STS credentials.
   When a TTL is not specified when STS credentials are requested,


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Closes #709 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
aws_secret_backend: when `credential_type = assumed_role`, allow `policy_arns`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSecretBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackend -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccAWSSecretBackendRole_basic
--- PASS: TestAccAWSSecretBackendRole_basic (0.23s)
=== RUN   TestAccAWSSecretBackendRole_import
--- PASS: TestAccAWSSecretBackendRole_import (0.19s)
=== RUN   TestAccAWSSecretBackendRole_nested
--- PASS: TestAccAWSSecretBackendRole_nested (0.27s)
=== RUN   TestAccAWSSecretBackend_basic
--- PASS: TestAccAWSSecretBackend_basic (0.25s)
=== RUN   TestAccAWSSecretBackend_import
--- PASS: TestAccAWSSecretBackend_import (0.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.070s
```

Tests did not update. I let the Vault binary provide validation as done here: https://github.com/hashicorp/vault/blob/master/builtin/logical/aws/path_roles.go

I did not change the code for the deprecated attributes (as they have `Removed`). Website documentation has been copied from the Vault website and reordered.

The sample Terraform has been updated, as only specifying a `policy_document` with `credential_type = assumed_role` is illegal.

Thanks!