### PR TITLE
Support sts_region in AWS auth's client resource

### DIFF
--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -60,6 +60,12 @@ func awsAuthBackendClientResource() *schema.Resource {
 				Optional:    true,
 				Description: "URL to override the default generated endpoint for making AWS STS API calls.",
 			},
+			"sts_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: `Region to override the default region for making AWS STS API calls. Should only be set 
+if sts_endpoint is set. If so, should be set to the region in which the custom sts_endpoint resides.`,
+			},
 			"iam_server_id_header_value": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -78,6 +84,7 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	ec2Endpoint := d.Get("ec2_endpoint").(string)
 	iamEndpoint := d.Get("iam_endpoint").(string)
 	stsEndpoint := d.Get("sts_endpoint").(string)
+	stsRegion := d.Get("sts_region").(string)
 	iamServerIDHeaderValue := d.Get("iam_server_id_header_value").(string)
 
 	path := awsAuthBackendClientPath(backend)
@@ -86,6 +93,7 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 		"endpoint":                   ec2Endpoint,
 		"iam_endpoint":               iamEndpoint,
 		"sts_endpoint":               stsEndpoint,
+		"sts_region":                 stsRegion,
 		"iam_server_id_header_value": iamServerIDHeaderValue,
 	}
 
@@ -134,6 +142,7 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ec2_endpoint", secret.Data["endpoint"])
 	d.Set("iam_endpoint", secret.Data["iam_endpoint"])
 	d.Set("sts_endpoint", secret.Data["sts_endpoint"])
+	d.Set("sts_region", secret.Data["sts_region"])
 	d.Set("iam_server_id_header_value", secret.Data["iam_server_id_header_value"])
 	return nil
 }

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -82,6 +82,7 @@ func TestAccAWSAuthBackendClient_withoutSecretKey(t *testing.T) {
 					testAccAWSAuthBackendClientCheck_attrs(backend),
 					resource.TestCheckResourceAttr("vault_aws_auth_backend_client.client", "access_key", "AWSACCESSKEY"),
 					resource.TestCheckNoResourceAttr("vault_aws_auth_backend_client.client", "secret_key"),
+					resource.TestCheckResourceAttr("vault_aws_auth_backend_client.client", "sts_region", "us-west-2"),
 				),
 			},
 			{
@@ -146,6 +147,7 @@ func testAccAWSAuthBackendClientCheck_attrs(backend string) resource.TestCheckFu
 			"ec2_endpoint":               "endpoint",
 			"iam_endpoint":               "iam_endpoint",
 			"sts_endpoint":               "sts_endpoint",
+			"sts_region":                 "sts_region",
 			"iam_server_id_header_value": "iam_server_id_header_value",
 		}
 		for stateAttr, apiAttr := range attrs {
@@ -175,6 +177,7 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://vault.test/ec2"
   iam_endpoint = "http://vault.test/iam"
   sts_endpoint = "http://vault.test/sts"
+  sts_region = "us-west-2"
   iam_server_id_header_value = "vault.test"
 }
 `, backend)
@@ -195,6 +198,7 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://updated.vault.test/ec2"
   iam_endpoint = "http://updated.vault.test/iam"
   sts_endpoint = "http://updated.vault.test/sts"
+  sts_region = "us-west-2"
   iam_server_id_header_value = "updated.vault.test"
 }`, backend)
 }
@@ -213,6 +217,7 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://vault.test/ec2"
   iam_endpoint = "http://vault.test/iam"
   sts_endpoint = "http://vault.test/sts"
+  sts_region = "us-west-2"
   iam_server_id_header_value = "vault.test"
 }`, backend)
 }
@@ -231,6 +236,7 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://updated2.vault.test/ec2"
   iam_endpoint = "http://updated2.vault.test/iam"
   sts_endpoint = "http://updated2.vault.test/sts"
+  sts_region = "us-west-2"
   iam_server_id_header_value = "updated2.vault.test"
 }`, backend)
 }

--- a/website/docs/r/aws_auth_backend_client.html.md
+++ b/website/docs/r/aws_auth_backend_client.html.md
@@ -59,6 +59,10 @@ The following arguments are supported:
 
 * `sts_endpoint` - (Optional) Override the URL Vault uses when making STS API
 	calls.
+	
+* `sts_region` - (Optional) Region to override the default region for making AWS 
+    STS API calls. Should only be set if sts_endpoint is set. If so, should be 
+    set to the region in which the custom sts_endpoint resides.
 
 * `iam_server_id_header_value` - (Optional) The value to require in the
 	`X-Vault-AWS-IAM-Server-ID` header as part of `GetCallerIdentity` requests


### PR DESCRIPTION
Closes #689 

This PR adds support for `sts_region` for those using Terraform to configure the client used in AWS auth.