### PR TITLE
Fix approle_auth_backend docs links

### DIFF
--- a/website/docs/r/approle_auth_backend_login.html.md
+++ b/website/docs/r/approle_auth_backend_login.html.md
@@ -9,7 +9,7 @@ description: |-
 # vault\_approle\_auth\_backend\_login
 
 Logs into Vault using the AppRole auth backend. See the [Vault
-documentation](https://www.vaultproject.io/docs/auth/approle.html) for more
+documentation](https://www.vaultproject.io/docs/auth/approle) for more
 information.
 
 ## Example Usage

--- a/website/docs/r/approle_auth_backend_role.html.md
+++ b/website/docs/r/approle_auth_backend_role.html.md
@@ -9,7 +9,7 @@ description: |-
 # vault\_approle\_auth\_backend\_role
 
 Manages an AppRole auth backend role in a Vault server. See the [Vault
-documentation](https://www.vaultproject.io/docs/auth/approle.html) for more
+documentation](https://www.vaultproject.io/docs/auth/approle) for more
 information.
 
 ## Example Usage

--- a/website/docs/r/approle_auth_backend_role_secret_id.html.md
+++ b/website/docs/r/approle_auth_backend_role_secret_id.html.md
@@ -9,7 +9,7 @@ description: |-
 # vault\_approle\_auth\_backend\_role\_secret\_id
 
 Manages an AppRole auth backend SecretID in a Vault server. See the [Vault
-documentation](https://www.vaultproject.io/docs/auth/approle.html) for more
+documentation](https://www.vaultproject.io/docs/auth/approle) for more
 information.
 
 ## Example Usage
@@ -51,9 +51,9 @@ The following arguments are supported:
 
 * `secret_id` - (Optional) The SecretID to be created. If set, uses "Push"
   mode.  Defaults to Vault auto-generating SecretIDs.
-  
+
 * `wrapping_ttl` - (Optional) If set, the SecretID response will be
-  [response-wrapped](https://www.vaultproject.io/docs/concepts/response-wrapping.html)
+  [response-wrapped](https://www.vaultproject.io/docs/concepts/response-wrapping)
   and available for the duration specified. Only a single unwrapping of the
   token is allowed.
 
@@ -65,5 +65,5 @@ In addition to the fields above, the following attributes are exported:
 
 * `wrapping_accessor` - The unique ID for the response-wrapped SecretID that can
    be safely logged.
-   
+
 * `wrapping_token` - The token used to retrieve a response-wrapped SecretID.


### PR DESCRIPTION
The links in the various `approle_auth_backend_` documentations to Vault's documentations were 404-ing. This PR fixes them by removing the `.html` extension in the links.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
website: Fix approle_auth_backend docs links
```

Output from acceptance testing:

```
N/A
```
