### PR TITLE
Fix broken link to Vault's GitHub auth backend

### DIFF
--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -9,7 +9,7 @@ description: |-
 # vault\_github\_auth\_backend
 
 Manages a Github Auth mount in a Vault server. See the [Vault
-documentation](https://www.vaultproject.io/docs/auth/github.html) for more
+documentation](https://www.vaultproject.io/docs/auth/github/) for more
 information.
 
 ## Example Usage

--- a/website/docs/r/github_team.html.md
+++ b/website/docs/r/github_team.html.md
@@ -9,7 +9,7 @@ description: |-
 # vault\_github\_team
 
 Manages policy mappings for Github Teams authenticated via Github. See the [Vault
-documentation](https://www.vaultproject.io/docs/auth/github.html) for more
+documentation](https://www.vaultproject.io/docs/auth/github/) for more
 information.
 
 ## Example Usage

--- a/website/docs/r/github_user.html.md
+++ b/website/docs/r/github_user.html.md
@@ -9,7 +9,7 @@ description: |-
 # vault\_github\_user
 
 Manages policy mappings for Github Users authenticated via Github. See the [Vault
-documentation](https://www.vaultproject.io/docs/auth/github.html) for more
+documentation](https://www.vaultproject.io/docs/auth/github/) for more
 information.
 
 ## Example Usage


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
website: Fix vault_github_xxx docs links to Vault's official document
```

Output from acceptance testing:

```
N/A
```
