### PR TITLE
Allow setting HTTP headers

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -161,6 +161,7 @@ func Provider() terraform.ResourceProvider {
 			"headers": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Sensitive:   true,
 				Description: "The headers to send with each Vault request.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -659,7 +659,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 	// Set headers if provided
 	headers := d.Get("headers").([]interface{})
-	parsedHeaders := make(http.Header)
+	parsedHeaders := client.Headers().Clone()
+
+	if parsedHeaders == nil {
+		parsedHeaders = make(http.Header)
+	}
 
 	for _, h := range headers {
 		header := h.(map[string]interface{})

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -164,10 +164,10 @@ func Provider() terraform.ResourceProvider {
 				Description: "The headers to send with each Vault request.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key": {
+						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The header key",
+							Description: "The header name",
 						},
 						"value": {
 							Type:        schema.TypeString,
@@ -661,10 +661,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	headers := d.Get("headers").([]interface{})
 	parsedHeaders := make(http.Header)
 
-	for _, headerKVPair := range headers {
-		header := headerKVPair.(map[string]interface{})
-		if key, ok := header["key"]; ok {
-			parsedHeaders.Add(key.(string), header["value"].(string))
+	for _, h := range headers {
+		header := h.(map[string]interface{})
+		if name, ok := header["name"]; ok {
+			parsedHeaders.Add(name.(string), header["value"].(string))
 		}
 	}
 	client.SetHeaders(parsedHeaders)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -149,6 +149,10 @@ variables in order to keep credential information out of the configuration.
 * `namespace` - (Optional) Set the namespace to use. May be set via the
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
 
+* `headers` - (Optional) A configuration block, described below, that provides headers
+to be sent along with all requests to the Vault server.  This block can be specified 
+multiple times.
+
 The `auth_login` configuration block accepts the following arguments:
 
 * `path` - (Required) The login path of the auth backend. For example, login with
@@ -170,6 +174,12 @@ The `client_auth` configuration block accepts the following arguments:
 
 * `key_file` - (Required) Path to a file on local disk that contains the
   PEM-encoded private key for which the authentication certificate was issued.
+
+The `headers` configuration block accepts the following arguments:
+
+* `name` - (Required) The name of the header.
+
+* `value` - (Required) The value of the header.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

This PR adds the ability to set HTTP headers for Vault API requests made by the Terraform Vault provider.  A sample configuration:

```hcl
provider "vault" {
  address = "https://testvault.123"

  headers {
    name = "header1"
    value = "valueofheader1"
  }

  headers {
    name = "X-Special-Header"
    value = "specialheadervalue"
  }
}
```

I have run the acceptance tests locally and also ran this against a Vault cluster in the cloud that requires specific headers in order for requests to forward to the cluster properly.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added `headers` provider configuration setting to allow setting HTTP headers for all requests to the Vault server.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   94.623s
```
