### PR TITLE
Fix typo in path validation

### DIFF
--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -400,7 +400,7 @@ func gcpAuthResourceExists(d *schema.ResourceData, meta interface{}) (bool, erro
 func gcpAuthResourceBackendFromPath(path string) (string, error) {
 	var parts = strings.Split(path, "/")
 	if len(parts) != 4 {
-		return "", fmt.Errorf("Expecdted 4 parts in path '%s'", path)
+		return "", fmt.Errorf("Expected 4 parts in path '%s'", path)
 	}
 	return parts[1], nil
 }
@@ -408,7 +408,7 @@ func gcpAuthResourceBackendFromPath(path string) (string, error) {
 func gcpAuthResourceRoleFromPath(path string) (string, error) {
 	var parts = strings.Split(path, "/")
 	if len(parts) != 4 {
-		return "", fmt.Errorf("Expecdted 4 parts in path '%s'", path)
+		return "", fmt.Errorf("Expected 4 parts in path '%s'", path)
 	}
 	return parts[3], nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixed typo "Expecdted"  in the error message of path validation in resource_gcp_auth_backend_role 
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
None
...
```
