### PR TITLE
Move provider to separate package

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-vault/provider"
+	"github.com/terraform-providers/terraform-provider-vault/schema"
 	"github.com/terraform-providers/terraform-provider-vault/vault"
 )
 
 func main() {
-	p := provider.New(vault.Provider())
+	p := schema.NewProvider(vault.Provider())
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: p.ResourceProvider})
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
+	"github.com/terraform-providers/terraform-provider-vault/provider"
 	"github.com/terraform-providers/terraform-provider-vault/vault"
 )
 
 func main() {
+	p := provider.New(vault.Provider())
 	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: vault.Provider})
+		ProviderFunc: p.ResourceProvider})
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func New(seed *schema.Provider) *Provider {
+	return &Provider{
+		provider: seed,
+	}
+}
+
+type Provider struct {
+	provider *schema.Provider
+}
+
+func (p *Provider) RegisterDataSource(name string, dataSource *schema.Resource) {
+	p.provider.DataSourcesMap[name] = dataSource
+}
+
+func (p *Provider) RegisterResource(name string, resource *schema.Resource) {
+	p.provider.ResourcesMap[name] = resource
+}
+
+func (p *Provider) SchemaProvider() *schema.Provider {
+	return p.provider
+}
+
+func (p *Provider) ResourceProvider() terraform.ResourceProvider {
+	return p.provider
+}

--- a/schema/provider.go
+++ b/schema/provider.go
@@ -1,11 +1,11 @@
-package provider
+package schema
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func New(seed *schema.Provider) *Provider {
+func NewProvider(seed *schema.Provider) *Provider {
 	return &Provider{
 		provider: seed,
 	}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/config"
 )
@@ -34,7 +33,7 @@ const (
 // The key of the mutex should be the path in Vault.
 var vaultMutexKV = mutexkv.NewMutexKV()
 
-func Provider() terraform.ResourceProvider {
+func Provider() *schema.Provider {
 	dataSourcesMap, err := parse(DataSourceRegistry)
 	if err != nil {
 		panic(err)

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -43,7 +43,7 @@ import (
 // start over with a fresh Vault. (Remember to reset VAULT_TOKEN.)
 
 func TestProvider(t *testing.T) {
-	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
@@ -52,7 +52,7 @@ var testProvider *schema.Provider
 var testProviders map[string]terraform.ResourceProvider
 
 func init() {
-	testProvider = Provider().(*schema.Provider)
+	testProvider = Provider()
 	testProviders = map[string]terraform.ResourceProvider{
 		"vault": testProvider,
 	}
@@ -151,7 +151,7 @@ echo "helper-token"
 `
 
 func TestAccAuthLoginProviderConfigure(t *testing.T) {
-	rootProvider := Provider().(*schema.Provider)
+	rootProvider := Provider()
 	rootProviderResource := &schema.Resource{
 		Schema: rootProvider.Schema,
 	}
@@ -180,7 +180,7 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")
 	}
 
-	rootProvider := Provider().(*schema.Provider)
+	rootProvider := Provider()
 	rootProviderResource := &schema.Resource{
 		Schema: rootProvider.Schema,
 	}
@@ -205,7 +205,7 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 		},
 	})
 
-	nsProvider := Provider().(*schema.Provider)
+	nsProvider := Provider()
 	nsProviderResource := &schema.Resource{
 		Schema: nsProvider.Schema,
 	}
@@ -293,7 +293,7 @@ func testResourceApproleLoginCheckAttrs(t *testing.T) resource.TestCheckFunc {
 				},
 			},
 		}
-		approleProvider := Provider().(*schema.Provider)
+		approleProvider := Provider()
 		approleProviderResource := &schema.Resource{
 			Schema: approleProvider.Schema,
 		}
@@ -349,7 +349,7 @@ func testResourceAdminPeriodicOrphanTokenCheckAttrs(namespacePath string, t *tes
 
 		vaultToken := tokenResourceState.Primary.Attributes["client_token"]
 
-		ns2Provider := Provider().(*schema.Provider)
+		ns2Provider := Provider()
 		ns2ProviderResource := &schema.Resource{
 			Schema: ns2Provider.Schema,
 		}
@@ -423,7 +423,7 @@ func TestAccProviderToken(t *testing.T) {
 	}
 
 	// Create a "resource" we can use for constructing ResourceData.
-	provider := Provider().(*schema.Provider)
+	provider := Provider()
 	providerResource := &schema.Resource{
 		Schema: provider.Schema,
 	}
@@ -732,7 +732,7 @@ func TestAccProviderVaultAddrEnv(t *testing.T) {
 
 func newTestResourceData(address string, addAddressToEnv string) (*schema.ResourceData, error) {
 	// Create a "resource" we can use for constructing ResourceData.
-	provider := Provider().(*schema.Provider)
+	provider := Provider()
 	providerResource := &schema.Resource{
 		Schema: provider.Schema,
 		// this needs to be configured with and without add_Address_to_env


### PR DESCRIPTION
In most Terraform providers, all resources and data sources live in the same package as `provider.go`. That's because the provider needs to import all the resources and data sources so it can return them, _and_ all the tests require the full provider to test. So, if they were moved into separate packages, this would create a cyclic dependency:

- `provider` package needs `resources` package to return them
- `resources` package need `provider` package to test

We would like to move towards generating more resources and data sources to cover the Vault API. Vault has a total of 544 endpoints, which translates to at least 544 resources and data sources if we were to fully cover all of Vault's endpoints. Each file should have an accompanying test, so full coverage would add up to 1,088 files + `provider.go` and `provider_test.go` (1,090) files all in one single package. It would be difficult to find a particular file or endpoint you're looking for, and quite awkward and unusual.

This PR moves the provider into its own package and allows resources and data sources to register with it. This breaks the import cycle because now, the provider _won't know_ about the specific resources and data sources registering with it. This creates a one-way path of knowledge. Resources and data sources know about the provider, can register with it, and can test with it. 

Because of breaking the import cycle, this frees us from being required to keep all potential 1,090 files in the same directory, and allows us to organize them in a way that may make more sense to someone looking for the code for a particular endpoint.