### PR TITLE
Add directory structure

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,6 +8,10 @@ default: build
 build: fmtcheck
 	go install
 
+dev: fmtcheck
+	go build -o terraform-provider-vault
+	mv terraform-provider-vault ~/.terraform.d/plugins
+
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,10 +8,6 @@ default: build
 build: fmtcheck
 	go install
 
-dev: fmtcheck
-	go build -o terraform-provider-vault
-	mv terraform-provider-vault ~/.terraform.d/plugins/
-
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,7 +10,7 @@ build: fmtcheck
 
 dev: fmtcheck
 	go build -o terraform-provider-vault
-	mv terraform-provider-vault ~/.terraform.d/plugins
+	mv terraform-provider-vault ~/.terraform.d/plugins/
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -43,8 +44,8 @@ we eventually cover all >500 of them and add tests.
 			│   └── name.go
 			└── transformation.go
 */
-func codeFilePath(tmplType templateType, path string) string {
-	filename := fmt.Sprintf("%s%s.go", tmplType.String(), path)
+func codeFilePath(tmplType templateType, endpoint string) string {
+	filename := fmt.Sprintf("%s%s.go", tmplType.String(), endpoint)
 	path := filepath.Join(pathToHomeDir, "generated", filename)
 	return stripCurlyBraces(path)
 }
@@ -76,8 +77,8 @@ we eventually cover all >500 of them and add tests.
 			│   └── name.md
 			└── transformation.md
 */
-func docFilePath(tmplType templateType, path string) string {
-	filename := fmt.Sprintf("%s%s.md", tmplType.String(), path)
+func docFilePath(tmplType templateType, endpoint string) string {
+	filename := fmt.Sprintf("%s%s.md", tmplType.String(), endpoint)
 	path := filepath.Join(pathToHomeDir, "website", "docs", "generated", filename)
 	return stripCurlyBraces(path)
 }

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -1,0 +1,89 @@
+package codegen
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// pathToHomeDir yields the path to the terraform-vault-provider
+// home directory on the machine on which it's running.
+// ex. /home/your-name/go/src/github.com/terraform-providers/terraform-provider-vault
+var pathToHomeDir = func() string {
+	repoName := "terraform-provider-vault"
+	wd, _ := os.Getwd()
+	pathParts := strings.Split(wd, repoName)
+	return pathParts[0] + repoName
+}()
+
+/*
+codeFilePath creates a directory structure inside the "generated" folder that's
+intended to make it easy to find the file for each endpoint in Vault, even if
+we eventually cover all >500 of them and add tests.
+	terraform-provider-vault/generated$ tree
+	.
+	├── datasources
+	│   └── transform
+	│       ├── decode
+	│       │   └── role_name.go
+	│       └── encode
+	│           └── role_name.go
+	└── resources
+		└── transform
+			├── alphabet
+			│   └── name.go
+			├── alphabet.go
+			├── role
+			│   └── name.go
+			├── role.go
+			├── template
+			│   └── name.go
+			├── template.go
+			├── transformation
+			│   └── name.go
+			└── transformation.go
+*/
+func codeFilePath(tmplType templateType, path string) string {
+	return stripCurlyBraces(fmt.Sprintf("%s/generated/%s%s.go", pathToHomeDir, tmplType.String(), path))
+}
+
+/*
+docFilePath creates a directory structure inside the "website/docs/generated" folder
+that's intended to make it easy to find the file for each endpoint in Vault, even if
+we eventually cover all >500 of them and add tests.
+	terraform-provider-vault/website/docs/generated$ tree
+	.
+	├── datasources
+	│   └── transform
+	│       ├── decode
+	│       │   └── role_name.md
+	│       └── encode
+	│           └── role_name.md
+	└── resources
+		└── transform
+			├── alphabet
+			│   └── name.md
+			├── alphabet.md
+			├── role
+			│   └── name.md
+			├── role.md
+			├── template
+			│   └── name.md
+			├── template.md
+			├── transformation
+			│   └── name.md
+			└── transformation.md
+*/
+func docFilePath(tmplType templateType, path string) string {
+	result := fmt.Sprintf("%s/website/docs/generated/%s%s.md", pathToHomeDir, tmplType.String(), path)
+	return stripCurlyBraces(result)
+}
+
+// stripCurlyBraces converts a path like
+// "generated/resources/transform-transformation-{name}.go"
+// to "generated/resources/transform-transformation-name.go".
+func stripCurlyBraces(path string) string {
+	path = strings.Replace(path, "{", "", -1)
+	path = strings.Replace(path, "}", "", -1)
+	return path
+}

--- a/codegen/generate_test.go
+++ b/codegen/generate_test.go
@@ -1,0 +1,92 @@
+package codegen
+
+import (
+	"testing"
+)
+
+// testPaths is a sampling of real paths that
+// originate in the OpenAPI doc, pulled via:
+// $ cat testdata/openapi.json | jq '.paths' | jq 'keys[]'
+var testPaths = []string{
+	"/database/roles",
+	"/database/roles/{name}",
+	"/auth/userpass/users/{username}/password",
+	"/auth/userpass/users/{username}/policies",
+	"/transit/export/{type}/{name}/{version}",
+}
+
+func TestCodeFilePath(t *testing.T) {
+	expected := []struct {
+		DataSourceFilePath string
+		ResourceFilePath   string
+	}{
+		{
+			DataSourceFilePath: "/generated/datasources/database/roles.go",
+			ResourceFilePath:   "/generated/resources/database/roles.go",
+		},
+		{
+			DataSourceFilePath: "/generated/datasources/database/roles/name.go",
+			ResourceFilePath:   "/generated/resources/database/roles/name.go",
+		},
+		{
+			DataSourceFilePath: "/generated/datasources/auth/userpass/users/username/password.go",
+			ResourceFilePath:   "/generated/resources/auth/userpass/users/username/password.go",
+		},
+		{
+			DataSourceFilePath: "/generated/datasources/auth/userpass/users/username/policies.go",
+			ResourceFilePath:   "/generated/resources/auth/userpass/users/username/policies.go",
+		},
+		{
+			DataSourceFilePath: "/generated/datasources/transit/export/type/name/version.go",
+			ResourceFilePath:   "/generated/resources/transit/export/type/name/version.go",
+		},
+	}
+	for i, testPath := range testPaths {
+		actualDataSourceFilePath := codeFilePath(templateTypeDataSource, testPath)
+		if actualDataSourceFilePath != pathToHomeDir+expected[i].DataSourceFilePath {
+			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].DataSourceFilePath, actualDataSourceFilePath)
+		}
+		actualResourceFilePath := codeFilePath(templateTypeResource, testPath)
+		if actualResourceFilePath != pathToHomeDir+expected[i].ResourceFilePath {
+			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].ResourceFilePath, actualResourceFilePath)
+		}
+	}
+}
+
+func TestDocFilePath(t *testing.T) {
+	expected := []struct {
+		DataSourceFilePath string
+		ResourceFilePath   string
+	}{
+		{
+			DataSourceFilePath: "/website/docs/generated/datasources/database/roles.md",
+			ResourceFilePath:   "/website/docs/generated/resources/database/roles.md",
+		},
+		{
+			DataSourceFilePath: "/website/docs/generated/datasources/database/roles/name.md",
+			ResourceFilePath:   "/website/docs/generated/resources/database/roles/name.md",
+		},
+		{
+			DataSourceFilePath: "/website/docs/generated/datasources/auth/userpass/users/username/password.md",
+			ResourceFilePath:   "/website/docs/generated/resources/auth/userpass/users/username/password.md",
+		},
+		{
+			DataSourceFilePath: "/website/docs/generated/datasources/auth/userpass/users/username/policies.md",
+			ResourceFilePath:   "/website/docs/generated/resources/auth/userpass/users/username/policies.md",
+		},
+		{
+			DataSourceFilePath: "/website/docs/generated/datasources/transit/export/type/name/version.md",
+			ResourceFilePath:   "/website/docs/generated/resources/transit/export/type/name/version.md",
+		},
+	}
+	for i, testPath := range testPaths {
+		actualDataSourceDocPath := docFilePath(templateTypeDataSource, testPath)
+		if actualDataSourceDocPath != pathToHomeDir+expected[i].DataSourceFilePath {
+			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].DataSourceFilePath, actualDataSourceDocPath)
+		}
+		actualResourceDocPath := docFilePath(templateTypeResource, testPath)
+		if actualResourceDocPath != pathToHomeDir+expected[i].ResourceFilePath {
+			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].ResourceFilePath, actualResourceDocPath)
+		}
+	}
+}

--- a/codegen/generate_test.go
+++ b/codegen/generate_test.go
@@ -4,89 +4,90 @@ import (
 	"testing"
 )
 
-// testPaths is a sampling of real paths that
-// originate in the OpenAPI doc, pulled via:
-// $ cat testdata/openapi.json | jq '.paths' | jq 'keys[]'
-var testPaths = []string{
-	"/database/roles",
-	"/database/roles/{name}",
-	"/auth/userpass/users/{username}/password",
-	"/auth/userpass/users/{username}/policies",
-	"/transit/export/{type}/{name}/{version}",
-}
-
 func TestCodeFilePath(t *testing.T) {
-	expected := []struct {
-		DataSourceFilePath string
-		ResourceFilePath   string
+	testCases := []struct {
+		input                      string
+		expectedDataSourceFilePath string
+		expectedResourceFilePath   string
 	}{
 		{
-			DataSourceFilePath: "/generated/datasources/database/roles.go",
-			ResourceFilePath:   "/generated/resources/database/roles.go",
+			input:                      "/database/roles",
+			expectedDataSourceFilePath: "/generated/datasources/database/roles.go",
+			expectedResourceFilePath:   "/generated/resources/database/roles.go",
 		},
 		{
-			DataSourceFilePath: "/generated/datasources/database/roles/name.go",
-			ResourceFilePath:   "/generated/resources/database/roles/name.go",
+			input:                      "/database/roles/{name}",
+			expectedDataSourceFilePath: "/generated/datasources/database/roles/name.go",
+			expectedResourceFilePath:   "/generated/resources/database/roles/name.go",
 		},
 		{
-			DataSourceFilePath: "/generated/datasources/auth/userpass/users/username/password.go",
-			ResourceFilePath:   "/generated/resources/auth/userpass/users/username/password.go",
+			input:                      "/auth/userpass/users/{username}/password",
+			expectedDataSourceFilePath: "/generated/datasources/auth/userpass/users/username/password.go",
+			expectedResourceFilePath:   "/generated/resources/auth/userpass/users/username/password.go",
 		},
 		{
-			DataSourceFilePath: "/generated/datasources/auth/userpass/users/username/policies.go",
-			ResourceFilePath:   "/generated/resources/auth/userpass/users/username/policies.go",
+			input:                      "/auth/userpass/users/{username}/policies",
+			expectedDataSourceFilePath: "/generated/datasources/auth/userpass/users/username/policies.go",
+			expectedResourceFilePath:   "/generated/resources/auth/userpass/users/username/policies.go",
 		},
 		{
-			DataSourceFilePath: "/generated/datasources/transit/export/type/name/version.go",
-			ResourceFilePath:   "/generated/resources/transit/export/type/name/version.go",
+			input:                      "/transit/export/{type}/{name}/{version}",
+			expectedDataSourceFilePath: "/generated/datasources/transit/export/type/name/version.go",
+			expectedResourceFilePath:   "/generated/resources/transit/export/type/name/version.go",
 		},
 	}
-	for i, testPath := range testPaths {
-		actualDataSourceFilePath := codeFilePath(templateTypeDataSource, testPath)
-		if actualDataSourceFilePath != pathToHomeDir+expected[i].DataSourceFilePath {
-			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].DataSourceFilePath, actualDataSourceFilePath)
+	for _, testCase := range testCases {
+		actualDataSourceFilePath := codeFilePath(templateTypeDataSource, testCase.input)
+		if actualDataSourceFilePath != pathToHomeDir+testCase.expectedDataSourceFilePath {
+			t.Fatalf("testCases %q but received %q", pathToHomeDir+testCase.expectedDataSourceFilePath, actualDataSourceFilePath)
 		}
-		actualResourceFilePath := codeFilePath(templateTypeResource, testPath)
-		if actualResourceFilePath != pathToHomeDir+expected[i].ResourceFilePath {
-			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].ResourceFilePath, actualResourceFilePath)
+		actualResourceFilePath := codeFilePath(templateTypeResource, testCase.input)
+		if actualResourceFilePath != pathToHomeDir+testCase.expectedResourceFilePath {
+			t.Fatalf("testCases %q but received %q", pathToHomeDir+testCase.expectedResourceFilePath, actualResourceFilePath)
 		}
 	}
 }
 
 func TestDocFilePath(t *testing.T) {
-	expected := []struct {
-		DataSourceFilePath string
-		ResourceFilePath   string
+	testCases := []struct {
+		input                      string
+		expectedDataSourceFilePath string
+		expectedResourceFilePath   string
 	}{
 		{
-			DataSourceFilePath: "/website/docs/generated/datasources/database/roles.md",
-			ResourceFilePath:   "/website/docs/generated/resources/database/roles.md",
+			input:                      "/database/roles",
+			expectedDataSourceFilePath: "/website/docs/generated/datasources/database/roles.md",
+			expectedResourceFilePath:   "/website/docs/generated/resources/database/roles.md",
 		},
 		{
-			DataSourceFilePath: "/website/docs/generated/datasources/database/roles/name.md",
-			ResourceFilePath:   "/website/docs/generated/resources/database/roles/name.md",
+			input:                      "/database/roles/{name}",
+			expectedDataSourceFilePath: "/website/docs/generated/datasources/database/roles/name.md",
+			expectedResourceFilePath:   "/website/docs/generated/resources/database/roles/name.md",
 		},
 		{
-			DataSourceFilePath: "/website/docs/generated/datasources/auth/userpass/users/username/password.md",
-			ResourceFilePath:   "/website/docs/generated/resources/auth/userpass/users/username/password.md",
+			input:                      "/auth/userpass/users/{username}/password",
+			expectedDataSourceFilePath: "/website/docs/generated/datasources/auth/userpass/users/username/password.md",
+			expectedResourceFilePath:   "/website/docs/generated/resources/auth/userpass/users/username/password.md",
 		},
 		{
-			DataSourceFilePath: "/website/docs/generated/datasources/auth/userpass/users/username/policies.md",
-			ResourceFilePath:   "/website/docs/generated/resources/auth/userpass/users/username/policies.md",
+			input:                      "/auth/userpass/users/{username}/policies",
+			expectedDataSourceFilePath: "/website/docs/generated/datasources/auth/userpass/users/username/policies.md",
+			expectedResourceFilePath:   "/website/docs/generated/resources/auth/userpass/users/username/policies.md",
 		},
 		{
-			DataSourceFilePath: "/website/docs/generated/datasources/transit/export/type/name/version.md",
-			ResourceFilePath:   "/website/docs/generated/resources/transit/export/type/name/version.md",
+			input:                      "/transit/export/{type}/{name}/{version}",
+			expectedDataSourceFilePath: "/website/docs/generated/datasources/transit/export/type/name/version.md",
+			expectedResourceFilePath:   "/website/docs/generated/resources/transit/export/type/name/version.md",
 		},
 	}
-	for i, testPath := range testPaths {
-		actualDataSourceDocPath := docFilePath(templateTypeDataSource, testPath)
-		if actualDataSourceDocPath != pathToHomeDir+expected[i].DataSourceFilePath {
-			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].DataSourceFilePath, actualDataSourceDocPath)
+	for _, testCase := range testCases {
+		actualDataSourceDocPath := docFilePath(templateTypeDataSource, testCase.input)
+		if actualDataSourceDocPath != pathToHomeDir+testCase.expectedDataSourceFilePath {
+			t.Fatalf("testCases %q but received %q", pathToHomeDir+testCase.expectedDataSourceFilePath, actualDataSourceDocPath)
 		}
-		actualResourceDocPath := docFilePath(templateTypeResource, testPath)
-		if actualResourceDocPath != pathToHomeDir+expected[i].ResourceFilePath {
-			t.Fatalf("expected %q but received %q", pathToHomeDir+expected[i].ResourceFilePath, actualResourceDocPath)
+		actualResourceDocPath := docFilePath(templateTypeResource, testCase.input)
+		if actualResourceDocPath != pathToHomeDir+testCase.expectedResourceFilePath {
+			t.Fatalf("testCases %q but received %q", pathToHomeDir+testCase.expectedResourceFilePath, actualResourceDocPath)
 		}
 	}
 }

--- a/codegen/templates.go
+++ b/codegen/templates.go
@@ -3,7 +3,8 @@ package codegen
 type templateType int
 
 const (
-	templateTypeDataSource templateType = iota
+	templateTypeUnset templateType = iota
+	templateTypeDataSource
 	templateTypeResource
 	templateTypeDoc
 )
@@ -14,6 +15,8 @@ func (t templateType) String() string {
 		return "datasources"
 	case templateTypeResource:
 		return "resources"
+	case templateTypeDoc:
+		return "docs"
 	}
-	return "docs"
+	return "unset"
 }

--- a/codegen/templates.go
+++ b/codegen/templates.go
@@ -1,0 +1,19 @@
+package codegen
+
+type templateType int
+
+const (
+	templateTypeDataSource templateType = iota
+	templateTypeResource
+	templateTypeDoc
+)
+
+func (t templateType) String() string {
+	switch t {
+	case templateTypeDataSource:
+		return "datasources"
+	case templateTypeResource:
+		return "resources"
+	}
+	return "docs"
+}


### PR DESCRIPTION
This PR adds the code that will be used to create a directory structure for the generated code in the Terraform Vault Provider.

There's a 1:3 ratio of Vault endpoints to files in the Terraform Vault Provider. Each endpoint (like `"/database/roles/{name}"` requires:
- A `.go` file with its actual code
- A `_test.go` file with its associated tests
- A `.md` file with its docs

Creating a less flat directory structure makes it easier to look for the files related to one of Vault's >500 endpoints. The list of the endpoints for the `transit` engine alone is:
```
"/transit/backup/{name}"
"/transit/cache-config"
"/transit/datakey/{plaintext}/{name}"
"/transit/decrypt/{name}"
"/transit/encrypt/{name}"
"/transit/export/{type}/{name}"
"/transit/export/{type}/{name}/{version}"
"/transit/hash"
"/transit/hash/{urlalgorithm}"
"/transit/hmac/{name}"
"/transit/hmac/{name}/{urlalgorithm}"
"/transit/keys"
"/transit/keys/{name}"
"/transit/keys/{name}/config"
"/transit/keys/{name}/rotate"
"/transit/keys/{name}/trim"
"/transit/random"
"/transit/random/{urlbytes}"
"/transit/restore"
"/transit/restore/{name}"
"/transit/rewrap/{name}"
"/transit/sign/{name}"
"/transit/sign/{name}/{urlalgorithm}"
"/transit/verify/{name}"
"/transit/verify/{name}/{urlalgorithm}"
```
Having a less flat directory structure that directly mirrors the endpoint you're seeking makes it very straight-forward and intuitive to find the file you're looking for.

On alternative approaches, I considered other ideas like making all the endpoints be under "transit" with no further directories, but this makes code generation more complicated. It makes it more likely for collisions to occur with regards to how functions and variables are named in each file. It would be possible to prefix all functions with the "thing" they refer to, like for all methods in `"/transit/sign/{name}/{urlalgorithm}"` to be prefixed with `signNameUrlalgorithmRead`, but I thought that made the generated code read awkwardly.