### PR TITLE
fix(secret/database): do not send password on updates, unless it changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ jobs:
             echo 'GO111MODULE=on' >> $BASH_ENV
             echo 'export GOBIN=$GOPATH/bin' >> $BASH_ENV
             echo 'export MYSQL_URL="root:mysql@tcp(127.0.0.1:3306)/"' >> $BASH_ENV
+            echo 'export MYSQL_CONNECTION_URL="{{username}}:{{password}}@tcp(127.0.0.1:3306)/"' >> $BASH_ENV
+            echo 'export MYSQL_CONNECTION_USERNAME="root"' >> $BASH_ENV
+            echo 'export MYSQL_CONNECTION_PASSWORD="mysql"' >> $BASH_ENV
             echo 'export MONGODB_URL="mongodb://root:mongodb@localhost:27017/admin?ssl=false"' >> $BASH_ENV
       - run:
           name: "Run Tests"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
   mysql:
     image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password
+    ports:
+    - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: "root"
       MYSQL_DATABASE: "main"

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -693,7 +693,12 @@ func databaseSecretBackendConnectionUpdate(d *schema.ResourceData, meta interfac
 
 	if m, ok := d.GetOkExists("data"); ok {
 		for k, v := range m.(map[string]interface{}) {
-			data[k] = v.(string)
+			// Vault does not return the password in the API. If the root credentials have been rotated, sending
+			// the old password in the update request would break the connection config. Thus we only send it,
+			// if it actually changed, to still support updating it for non-rotated cases.
+			if k == "password" && d.HasChange(k) {
+				data[k] = v.(string)
+			}
 		}
 	}
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -361,7 +361,7 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 	// MYSQL_TEMPLATED_URL is the template URL to be used in vault
 	testConnURL := os.Getenv("MYSQL_TEMPLATED_URL")
 	if testConnURL == "" {
-		t.Skip("MYSQL_TEMPLATED_URL not set")
+		testConnURL = connURL
 	}
 
 	backend := acctest.RandomWithPrefix("tf-test-db")

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1,7 +1,9 @@
 package vault
 
 import (
+	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
@@ -9,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
 )
 
 func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
@@ -339,6 +342,89 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 	})
 }
 
+func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(t *testing.T) {
+	connURL := os.Getenv("MYSQL_CONNECTION_URL")
+	if connURL == "" {
+		t.Skip("MYSQL_CONNECTION_URL not set")
+	}
+	username := os.Getenv("MYSQL_CONNECTION_USERNAME")
+	if username == "" {
+		t.Skip("MYSQL_CONNECTION_USERNAME not set")
+	}
+	password := os.Getenv("MYSQL_CONNECTION_PASSWORD")
+	if password == "" {
+		t.Skip("MYSQL_CONNECTION_PASSWORD not set")
+	}
+
+	// The MYQSL_CONNECTION_* vars are from within the test suite (might be different host due to docker)
+	// They are used to create test DB users
+	// MYSQL_TEMPLATED_URL is the template URL to be used in vault
+	testConnURL := os.Getenv("MYSQL_TEMPLATED_URL")
+	if testConnURL == "" {
+		t.Skip("MYSQL_TEMPLATED_URL not set")
+	}
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+	testUsername := acctest.RandomWithPrefix("username")
+	testPassword := acctest.RandomWithPrefix("password")
+
+	db := newMySQLConnection(t, connURL, username, password)
+	createMySQSUser(t, db, testUsername, testPassword)
+	defer deleteMySQLUser(t, db, testUsername)
+
+	client := testProvider.Meta().(*api.Client)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, backend, testConnURL, testUsername, testPassword, 0),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", testConnURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", testUsername),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", testPassword),
+				),
+			},
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, backend, testConnURL, testUsername, testPassword, 10),
+				PreConfig: func() {
+					path := fmt.Sprintf("%s/rotate-root/%s", backend, name)
+					resp, err := client.Logical().Write(path, map[string]interface{}{})
+					if err != nil {
+						t.Error(err)
+					}
+
+					log.Printf("rotate-root: %v", resp)
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", testConnURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "10"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", testUsername),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", testPassword),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 	connURL := os.Getenv("POSTGRES_URL")
 	if connURL == "" {
@@ -580,6 +666,31 @@ resource "vault_database_secret_backend_connection" "test" {
 `, path, name, connURL, connLifetime, password)
 }
 
+func testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, path, connURL, username, password string, connLifetime int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend = "${vault_mount.db.path}"
+  name = "%s"
+  allowed_roles = ["dev", "prod"]
+
+  mysql {
+	  connection_url          = "%s"
+	  max_connection_lifetime = "%d"
+  }
+
+  data = {
+	  username = "%s"
+	  password = "%s"
+  }
+}
+`, path, name, connURL, connLifetime, username, password)
+}
+
 func testAccDatabaseSecretBackendConnectionConfig_mysql_rds(name, path, connURL string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "db" {
@@ -658,4 +769,40 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }
 `, path, name, connURL)
+}
+
+func newMySQLConnection(t *testing.T, connURL string, username string, password string) *sql.DB {
+	dbURL := dbutil.QueryHelper(connURL, map[string]string{
+		"username": username,
+		"password": password,
+	})
+
+	db, err := sql.Open("mysql", dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return db
+}
+
+func createMySQSUser(t *testing.T, db *sql.DB, username string, password string) {
+	createUser := fmt.Sprintf("CREATE USER '%s'@'%%' IDENTIFIED BY '%s';", username, password)
+	grantPrivileges := fmt.Sprintf("GRANT ALL PRIVILEGES ON *.* TO '%s'@'%%' WITH GRANT OPTION;", username)
+
+	_, err := db.Exec(createUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(grantPrivileges)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func deleteMySQLUser(t *testing.T, db *sql.DB, username string) {
+	query := fmt.Sprintf("DROP USER '%s'@'%%';", username)
+	_, err := db.Exec(query)
+	if err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Updates on database connection, which had their root credentials rotated fails through the terraform resources. This PR addresses this by only sending the password on changes.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
secret/database: do not send `.data.password` on connection config updates, unless it changed
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection.*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDatabaseSecretBackendConnection.* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccDatabaseSecretBackendConnection_import
    TestAccDatabaseSecretBackendConnection_import: resource_database_secret_backend_connection_test.go:20: POSTGRES_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_import (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandra
    TestAccDatabaseSecretBackendConnection_cassandra: resource_database_secret_backend_connection_test.go:59: CASSANDRA_HOST not set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandra (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandraProtocol
    TestAccDatabaseSecretBackendConnection_cassandraProtocol: resource_database_secret_backend_connection_test.go:102: CASSANDRA_HOST not set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandraProtocol (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mongodb
    TestAccDatabaseSecretBackendConnection_mongodb: resource_database_secret_backend_connection_test.go:145: MONGODB_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodb (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mssql
    TestAccDatabaseSecretBackendConnection_mssql: resource_database_secret_backend_connection_test.go:175: MSSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_mssql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql
--- PASS: TestAccDatabaseSecretBackendConnection_mysql (0.48s)
=== RUN   TestAccDatabaseSecretBackendConnectionUpdate_mysql
--- PASS: TestAccDatabaseSecretBackendConnectionUpdate_mysql (0.28s)
=== RUN   TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql
--- PASS: TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql (0.25s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
    TestAccDatabaseSecretBackendConnection_postgresql: resource_database_secret_backend_connection_test.go:431: POSTGRES_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_postgresql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_elasticsearch
    TestAccDatabaseSecretBackendConnection_elasticsearch: resource_database_secret_backend_connection_test.go:464: ELASTIC_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_elasticsearch (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.024s

...
```
