### PR TITLE
token: avoid panic when expire_time is nil

### DIFF
--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -335,7 +335,7 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 
 	issueTime, err := time.Parse(time.RFC3339Nano, issueTimeStr)
 	if err != nil {
-		return fmt.Errorf("error parsing issue_time is not a string, got %s", err)
+		return fmt.Errorf("error parsing issue_time: %s, please format string like '2006-01-02T15:04:05.999999999Z07:00'", err)
 	}
 	d.Set("lease_started", issueTime.Format(time.RFC3339))
 

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -330,7 +330,7 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 
 	issueTimeStr, ok := resp.Data["issue_time"].(string)
 	if !ok {
-		return fmt.Errorf("error issue_time is not a string, got %v", resp.Data["issue_time"])
+		return fmt.Errorf("error issue_time is not a string, got %T", resp.Data["issue_time"])
 	}
 
 	issueTime, err := time.Parse(time.RFC3339Nano, issueTimeStr)

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -341,7 +341,7 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 
 	expireTimeStr, ok := resp.Data["expire_time"].(string)
 	if !ok {
-		return fmt.Errorf("error expire_time is %v", resp.Data["expire_time"])
+		return fmt.Errorf("error expire_time is %T", resp.Data["expire_time"])
 	}
 
 	expireTime, err := time.Parse(time.RFC3339Nano, expireTimeStr)

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -328,13 +328,23 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("encrypted_client_token", "")
 	}
 
-	issueTime, err := time.Parse(time.RFC3339Nano, resp.Data["issue_time"].(string))
+	issueTimeStr, ok := resp.Data["issue_time"].(string)
+	if !ok {
+		return fmt.Errorf("error issue_time is not a string, got %v", resp.Data["issue_time"])
+	}
+
+	issueTime, err := time.Parse(time.RFC3339Nano, issueTimeStr)
 	if err != nil {
-		return fmt.Errorf("error parsing issue_time: %s", err)
+		return fmt.Errorf("error parsing issue_time is not a string, got %s", err)
 	}
 	d.Set("lease_started", issueTime.Format(time.RFC3339))
 
-	expireTime, err := time.Parse(time.RFC3339Nano, resp.Data["expire_time"].(string))
+	expireTimeStr, ok := resp.Data["expire_time"].(string)
+	if !ok {
+		return fmt.Errorf("error expire_time is %v", resp.Data["expire_time"])
+	}
+
+	expireTime, err := time.Parse(time.RFC3339Nano, expireTimeStr)
 	if err != nil {
 		return fmt.Errorf("error parsing expire_time: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

----

I'm generating vault tokens which are expiring when not used, and it triggered a `panic` on the `expire_time` because the type assertion wasn't ok.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
avoid panicing when `vault_token` is gone from the server.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```