### PR TITLE
vault_approle_auth_backend_role: Fix perpetual diff when upgrading from `policies` to `token_policies`

### DIFF
--- a/vault/resource_approle_auth_backend_role.go
+++ b/vault/resource_approle_auth_backend_role.go
@@ -264,6 +264,9 @@ func approleAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error 
 		if _, ok := d.GetOk("token_policies"); ok {
 			d.Set("token_policies", nil)
 		}
+		if v, ok := resp.Data["policies"]; ok {
+			d.Set("policies", v)
+		}
 	}
 
 	// Check if the user is using the deprecated `period`
@@ -273,9 +276,12 @@ func approleAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error 
 		if _, ok := d.GetOk("token_period"); ok {
 			d.Set("token_period", nil)
 		}
+		if v, ok := resp.Data["period"]; ok {
+			d.Set("period", v)
+		}
 	}
 
-	for _, k := range []string{"bind_secret_id", "secret_id_num_uses", "secret_id_ttl", "policies", "period"} {
+	for _, k := range []string{"bind_secret_id", "secret_id_num_uses", "secret_id_ttl"} {
 		if err := d.Set(k, resp.Data[k]); err != nil {
 			return fmt.Errorf("error setting state key \"%s\": %s", k, err)
 		}


### PR DESCRIPTION
When upgrading a `vault_approle_auth_backend_role` that had `policies` and `period` specified but now uses `token_policies` and `token_period`, users could experience a perpetual diff as shown in https://github.com/terraform-providers/terraform-provider-vault/issues/533. This specifically effected users on Vault 1.4 and the Vault Terraform provider version 2.7+

In this PR we change from always reading `policies` and `period` to only conditionally read them if the user has `policies` or `period` (respectively) in their configuration. Also adds regression test that demonstrates #533

Fixes https://github.com/terraform-providers/terraform-provider-vault/issues/533