### PR TITLE
3. Add a generated data source

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,10 @@ test: fmtcheck
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
+dev: fmtcheck
+	go build -o terraform-provider-vault
+	mv terraform-provider-vault ~/.terraform.d/plugins/
+
 generate:
 	result=$(cd generated && find . -type f -not -name '*_test.go' | grep -v 'registry.go' | xargs rm && cd - )
 	go run cmd/generate/main.go -openapi-doc=testdata/openapi.json

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,0 +1,28 @@
+# Generating Resources and Data Sources
+
+This code is part of a code generation package. It is intended to speed 
+up development while still yielding high quality code.
+
+## How to Generate Code and Docs
+- Please only PR 1 newly generated endpoint at a time to keep PRs small and focused.
+- Ensure `testdata/openapi.json` includes the endpoints you want to generate code.
+- If it doesn't:
+  - Make a new Vault dev binary from the `vault-enterprise` repo.
+  - Export a Vault license that includes the `transform` secrets engine: `export VAULT_LICENSE=foo`.
+  - In the Vault or Vault Enterprise repo, run `bash scripts/gen_openapi.sh`.
+  - Move the resulting file to `testdata/openapi.json`.
+- Add the 1 endpoint you wish to generate to `codegen/endpoint_registry.go`.
+- From the home directory of `terraform-provider-vault`, run:
+```
+make generate
+make fmt
+```
+- If you note any changes, you may need to hand-add code that implements 
+[best practices](https://www.terraform.io/docs/extend/best-practices/deprecations.html)
+for deprecations.
+- Hand-test the code while comparing it to Vault's API docs until you're satisfied that
+the generated code is correct.
+- Hand-write unit tests for the code.
+- Hand-add the new resource or data source to `generated/registry.go`.
+- Hand update the partially generated doc to complete it.
+- Add the doc to the sidebar/layout so it will appear in nav.

--- a/codegen/endpoint_registry.go
+++ b/codegen/endpoint_registry.go
@@ -8,6 +8,22 @@ import "github.com/hashicorp/vault/sdk/framework"
 // IMPORTANT NOTE: To support high quality, only add one
 // endpoint per PR.
 var endpointRegistry = map[string]*additionalInfo{
+	"/transform/decode/{role_name}": {
+		TemplateType: templateTypeDataSource,
+		AdditionalParameters: []*templatableParam{
+			{
+				OASParameter: &framework.OASParameter{
+					Name:        "decoded_value",
+					Description: "The result of decoding.",
+					Schema: &framework.OASSchema{
+						Type:         "string",
+						DisplayAttrs: &framework.DisplayAttributes{},
+					},
+				},
+				Computed: true,
+			},
+		},
+	},
 	"/transform/role/{name}": {
 		TemplateType: templateTypeResource,
 	},

--- a/codegen/endpoint_registry.go
+++ b/codegen/endpoint_registry.go
@@ -8,15 +8,62 @@ import "github.com/hashicorp/vault/sdk/framework"
 // IMPORTANT NOTE: To support high quality, only add one
 // endpoint per PR.
 var endpointRegistry = map[string]*additionalInfo{
+	"/transform/alphabet/{name}": {
+		TemplateType: templateTypeResource,
+	},
 	"/transform/decode/{role_name}": {
 		TemplateType: templateTypeDataSource,
 		AdditionalParameters: []*templatableParam{
 			{
 				OASParameter: &framework.OASParameter{
 					Name:        "decoded_value",
-					Description: "The result of decoding.",
+					Description: "The result of decoding a value.",
 					Schema: &framework.OASSchema{
 						Type:         "string",
+						DisplayAttrs: &framework.DisplayAttributes{},
+					},
+				},
+				Computed: true,
+			},
+			{
+				OASParameter: &framework.OASParameter{
+					Name:        "batch_results",
+					Description: "The result of decoding batch_input.",
+					Schema: &framework.OASSchema{
+						Type: "array",
+						Items: &framework.OASSchema{
+							Type: "object",
+						},
+						DisplayAttrs: &framework.DisplayAttributes{},
+					},
+				},
+				Computed: true,
+			},
+		},
+	},
+	"/transform/encode/{role_name}": {
+		TemplateType: templateTypeDataSource,
+		AdditionalParameters: []*templatableParam{
+			{
+				OASParameter: &framework.OASParameter{
+					Name:        "encoded_value",
+					Description: "The result of encoding a value.",
+					Schema: &framework.OASSchema{
+						Type:         "string",
+						DisplayAttrs: &framework.DisplayAttributes{},
+					},
+				},
+				Computed: true,
+			},
+			{
+				OASParameter: &framework.OASParameter{
+					Name:        "batch_results",
+					Description: "The result of encoding batch_input.",
+					Schema: &framework.OASSchema{
+						Type: "array",
+						Items: &framework.OASSchema{
+							Type: "object",
+						},
 						DisplayAttrs: &framework.DisplayAttributes{},
 					},
 				},
@@ -25,6 +72,9 @@ var endpointRegistry = map[string]*additionalInfo{
 		},
 	},
 	"/transform/role/{name}": {
+		TemplateType: templateTypeResource,
+	},
+	"/transform/template/{name}": {
 		TemplateType: templateTypeResource,
 	},
 	"/transform/transformation/{name}": {

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -53,8 +53,12 @@ func Run(logger hclog.Logger, paths map[string]*framework.OASPathItem) error {
 			logger.Error(err.Error())
 			os.Exit(1)
 		}
-		// TODO in separate PR - add fCreator.GenerateDoc() method
-		createdCount++
+		logger.Info(fmt.Sprintf("generating %s for %s\n", templateTypeDoc.String(), endpoint))
+		if err := fCreator.GenerateDoc(endpoint, paths[endpoint], addedInfo); err != nil {
+			logger.Error(err.Error())
+			os.Exit(1)
+		}
+		createdCount += 2
 	}
 	logger.Info(fmt.Sprintf("generated %d files\n", createdCount))
 	return nil
@@ -65,13 +69,26 @@ type fileCreator struct {
 	templateHandler *templateHandler
 }
 
-// GenerateCode is exported because it's the only non-internal method on the fileCreator.
+// GenerateCode is exported to indicate it's intended to be directly used.
 func (c *fileCreator) GenerateCode(endpoint string, endpointInfo *framework.OASPathItem, addedInfo *additionalInfo) error {
 	pathToFile := codeFilePath(addedInfo.TemplateType, endpoint)
 	return c.writeFile(pathToFile, endpoint, endpointInfo, addedInfo)
 }
 
-// TODO in a separate PR - add a GenerateDoc method.
+// GenerateDoc is exported to indicate it's intended to be directly used.
+func (c *fileCreator) GenerateDoc(endpoint string, endpointInfo *framework.OASPathItem, addedInfo *additionalInfo) error {
+	pathToFile := docFilePath(addedInfo.TemplateType, endpoint)
+	// If the doc already exists, no need to generate a new one, especially
+	// since these get hand-edited after being first created.
+	if _, err := os.Stat(pathToFile); err == nil {
+		// The file already exists, nothing further to do here.
+		return nil
+	}
+	// From here on, addedInfo will be used to select the template to
+	// use. Since we want it to be for docs, we need to update that now.
+	addedInfo.TemplateType = templateTypeDoc
+	return c.writeFile(pathToFile, endpoint, endpointInfo, addedInfo)
+}
 
 func (c *fileCreator) writeFile(pathToFile string, endpoint string, endpointInfo *framework.OASPathItem, addedInfo *additionalInfo) error {
 	parentDir := parentDir(pathToFile)

--- a/codegen/templates.go
+++ b/codegen/templates.go
@@ -16,8 +16,8 @@ import (
 var (
 	// templateRegistry holds templates for each type of file.
 	templateRegistry = map[templateType]string{
-		// TODO in separate PR - add templateTypeDoc
 		templateTypeDataSource: "/codegen/templates/datasource.go.tpl",
+		templateTypeDoc:        "/codegen/templates/doc.go.tpl",
 		templateTypeResource:   "/codegen/templates/resource.go.tpl",
 	}
 
@@ -91,22 +91,24 @@ func (h *templateHandler) toTemplatable(parentDir, endpoint string, endpointInfo
 		return parameters[i].Name < parameters[j].Name
 	})
 
-	// De-duplicate the parameters in place, because often parameters
-	// are at both the top-level and in the post body. This in-place
-	// approach is directly recommended here:
-	// https://github.com/golang/go/wiki/SliceTricks#in-place-deduplicate-comparable
-	j := 0
-	for i := 1; i < len(parameters); i++ {
-		if parameters[j] == parameters[i] {
-			continue
+	if len(parameters) > 2 {
+		// De-duplicate the parameters in place, because often parameters
+		// are at both the top-level and in the post body. This in-place
+		// approach is directly recommended here:
+		// https://github.com/golang/go/wiki/SliceTricks#in-place-deduplicate-comparable
+		j := 0
+		for i := 1; i < len(parameters); i++ {
+			if parameters[j] == parameters[i] {
+				continue
+			}
+			j++
+			// preserve the original data
+			// in[i], in[j] = in[j], in[i]
+			// only set what is required
+			parameters[j] = parameters[i]
 		}
-		j++
-		// preserve the original data
-		// in[i], in[j] = in[j], in[i]
-		// only set what is required
-		parameters[j] = parameters[i]
+		parameters = parameters[:j+1]
 	}
-	parameters = parameters[:j+1]
 
 	// The last field in the endpoint will be something like "name"
 	// or "roles" or whatever is at the end of an endpoint's path.

--- a/codegen/templates/datasource.go.tpl
+++ b/codegen/templates/datasource.go.tpl
@@ -1,0 +1,102 @@
+package {{ .DirName }}
+
+// DO NOT EDIT
+// This code is generated.
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+)
+
+const {{ .LowerCaseDifferentiator }}Endpoint = "{{ .Endpoint }}"
+
+func {{ .UpperCaseDifferentiator }}DataSource() *schema.Resource {
+	return &schema.Resource{
+        Read: read{{ .UpperCaseDifferentiator }}Resource,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Path to backend from which to retrieve data.",
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			{{- range .Parameters }}
+			"{{ .Name }}": {
+				{{- if (eq .Schema.Type "string") }}
+				Type:        schema.TypeString,
+				{{- end }}
+				{{- if (eq .Schema.Type "boolean") }}
+				Type:        schema.TypeBool,
+				{{- end }}
+				{{- if (eq .Schema.Type "integer") }}
+				Type:        schema.TypeInt,
+				{{- end }}
+				{{- if (eq .Schema.Type "array") }}
+                Type:        schema.TypeList,
+                {{- if (eq .Schema.Items.Type "string") }}
+                Elem:        &schema.Schema{Type: schema.TypeString},
+                {{- end }} {{/* end if item type string */}}
+                {{- if (eq .Schema.Items.Type "object") }}
+                Elem:        &schema.Schema{Type: schema.TypeMap},
+                {{- end }} {{/* end if item type object */}}
+                {{- end }} {{/* end if array */}}
+				{{- if .Required }}
+				Required:    true,
+				{{- else }}
+				Optional:    true,
+				{{- end }}
+				{{- if .IsPathParam }}
+                ForceNew:    true,
+                {{- end }}
+                {{- if .Computed }}
+                Computed:    true,
+                {{- end }}
+				Description: "{{ .Description }}",
+			},
+			{{- end }}
+		},
+	}
+}
+
+func read{{ .UpperCaseDifferentiator }}Resource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+    path := d.Get("path").(string)
+    vaultPath := util.ParsePath(path, {{ .LowerCaseDifferentiator }}Endpoint, d)
+    log.Printf("[DEBUG] Writing %q", vaultPath)
+
+    data := make(map[string]interface{})
+    {{- range .Parameters }}
+    {{- if not .Computed }}
+    if val, ok := d.GetOkExists("{{ .Name }}"); ok {
+        data["{{ .Name }}"] = val
+    }
+    {{- end }}
+    {{- end }}
+    log.Printf("[DEBUG] Writing %q", vaultPath)
+    resp, err := client.Logical().Write(vaultPath, data)
+    if err != nil {
+        return fmt.Errorf("error writing %q: %s", vaultPath, err)
+    }
+    if resp == nil {
+        d.SetId("")
+        return nil
+    }
+    d.SetId(vaultPath)
+
+    {{- range .Parameters }}
+    {{- if .Computed }}
+    if err := d.Set("{{ .Name }}", resp.Data["{{ .Name }}"]); err != nil {
+        return err
+    }
+    {{- end }}
+    {{- end }}
+    return nil
+}

--- a/codegen/templates/doc.go.tpl
+++ b/codegen/templates/doc.go.tpl
@@ -1,0 +1,31 @@
+---
+layout: "vault"
+page_title: "Vault: <TODO>"
+sidebar_current: "<TODO>"
+description: |-
+  <TODO>
+---
+
+# <TODO>
+
+<TODO>
+
+## Example Usage
+
+<TODO - this and HCL example below>
+```hcl
+resource "vault_jwt_auth_backend" "example" {
+    description  = "Demonstration of the Terraform JWT auth backend"
+    path = "jwt"
+    oidc_discovery_url = "https://myco.auth0.com/"
+    bound_issuer = "https://myco.auth0.com/"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+{{- range .Parameters }}
+* `{{ .Name }}` - {{ if .Required }}(Required){{ else }}(Optional){{ end }} {{ .Description }}
+{{- end }}

--- a/codegen/templates/resource.go.tpl
+++ b/codegen/templates/resource.go.tpl
@@ -43,8 +43,13 @@ func {{ .UpperCaseDifferentiator }}Resource() *schema.Resource {
 			{{- end }}
 			{{- if (eq .Schema.Type "array") }}
 			Type:        schema.TypeList,
+			{{- if (eq .Schema.Items.Type "string") }}
 			Elem:        &schema.Schema{Type: schema.TypeString},
-			{{- end }}
+			{{- end }} {{/* end if item type string */}}
+			{{- if (eq .Schema.Items.Type "object") }}
+            Elem:        &schema.Schema{Type: schema.TypeMap},
+            {{- end }} {{/* end if item type object */}}
+			{{- end }} {{/* end if array */}}
 			{{- if .Required }}
 			Required:    true,
 			{{- else }}

--- a/codegen/templates/resource.go.tpl
+++ b/codegen/templates/resource.go.tpl
@@ -13,7 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
-{{- if .SupportsWrite }}
+{{- if or .SupportsRead .SupportsWrite }}
 const {{ .LowerCaseDifferentiator }}Endpoint = "{{ .Endpoint }}"
 {{- else }}
 // This resource supports "{{ .Endpoint }}".
@@ -91,7 +91,7 @@ func {{ .UpperCaseDifferentiator }}Resource() *schema.Resource {
 func create{{ .UpperCaseDifferentiator }}Resource(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	path := d.Get("path").(string)
-	vaultPath := util.ParsePath(path, nameEndpoint, d)
+	vaultPath := util.ParsePath(path, {{ .LowerCaseDifferentiator }}Endpoint, d)
 	log.Printf("[DEBUG] Creating %q", vaultPath)
 
 	data := map[string]interface{}{}
@@ -136,7 +136,7 @@ func read{{ .UpperCaseDifferentiator }}Resource(d *schema.ResourceData, meta int
 		d.SetId("")
 		return nil
 	}
-	pathParams, err := util.PathParameters(nameEndpoint, vaultPath)
+	pathParams, err := util.PathParameters({{ .LowerCaseDifferentiator }}Endpoint, vaultPath)
     if err != nil {
         return err
     }

--- a/codegen/templates_test.go
+++ b/codegen/templates_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/vault/sdk/framework"
 )
 
-func TestClean(t *testing.T) {
+func TestFormat(t *testing.T) {
 	testCases := []struct {
 		input    string
 		expected string
@@ -27,7 +27,7 @@ func TestClean(t *testing.T) {
 		},
 		{
 			input:    "{role_name}",
-			expected: "rolename",
+			expected: "roleName",
 		},
 		{
 			input:    "{name}",
@@ -43,7 +43,7 @@ func TestClean(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		actual := clean(testCase.input)
+		actual := format(testCase.input)
 		if actual != testCase.expected {
 			t.Fatalf("input: %q; expected: %q; actual: %q", testCase.input, testCase.expected, actual)
 		}
@@ -166,14 +166,14 @@ func TestValidate(t *testing.T) {
 							Schema: &framework.OASSchema{
 								Type: "array",
 								Items: &framework.OASSchema{
-									Type: "object",
+									Type: "boolean",
 								},
 							},
 						},
 					},
 				},
 			},
-			expectedErr: "unsupported array type of object for foo",
+			expectedErr: "unsupported array type of boolean for foo",
 		},
 	}
 	for _, testCase := range testCases {

--- a/generated/datasources/transform/decode/role_name.go
+++ b/generated/datasources/transform/decode/role_name.go
@@ -1,0 +1,104 @@
+package decode
+
+// DO NOT EDIT
+// This code is generated.
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+)
+
+const roleNameEndpoint = "/transform/decode/{role_name}"
+
+func RoleNameDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: readRoleNameResource,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Path to backend from which to retrieve data.",
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"batch_input": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeMap},
+				Optional:    true,
+				Description: "Specifies a list of items to be decoded in a single batch. If this parameter is set, the top-level parameters 'value', 'transformation' and 'tweak' will be ignored. Each batch item within the list can specify these parameters instead.",
+			},
+			"decoded_value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The resulting value from the decode operation.",
+			},
+			"role_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the role.",
+			},
+			"transformation": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The transformation to perform. If no value is provided and the role contains a single transformation, this value will be inferred from the role.",
+			},
+			"tweak": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The tweak value to use. Only applicable for FPE transformations",
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The value in which to decode.",
+			},
+		},
+	}
+}
+
+func readRoleNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Get("path").(string)
+	vaultPath := util.ParsePath(path, roleNameEndpoint, d)
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+
+	data := make(map[string]interface{})
+	if val, ok := d.GetOkExists("batch_input"); ok {
+		data["batch_input"] = val
+	}
+	if val, ok := d.GetOkExists("role_name"); ok {
+		data["role_name"] = val
+	}
+	if val, ok := d.GetOkExists("transformation"); ok {
+		data["transformation"] = val
+	}
+	if val, ok := d.GetOkExists("tweak"); ok {
+		data["tweak"] = val
+	}
+	if val, ok := d.GetOkExists("value"); ok {
+		data["value"] = val
+	}
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+	resp, err := client.Logical().Write(vaultPath, data)
+	if err != nil {
+		return fmt.Errorf("error writing %q: %s", vaultPath, err)
+	}
+	if resp == nil {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(vaultPath)
+	if err := d.Set("decoded_value", resp.Data["decoded_value"]); err != nil {
+		return err
+	}
+	return nil
+}

--- a/generated/datasources/transform/decode/role_name.go
+++ b/generated/datasources/transform/decode/role_name.go
@@ -38,7 +38,7 @@ func RoleNameDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "The resulting value from the decode operation.",
+				Description: "The result of decoding.",
 			},
 			"role_name": {
 				Type:        schema.TypeString,

--- a/generated/datasources/transform/decode/role_name_test.go
+++ b/generated/datasources/transform/decode/role_name_test.go
@@ -1,0 +1,74 @@
+package decode
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role"
+	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation"
+	"github.com/terraform-providers/terraform-provider-vault/schema"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/terraform-providers/terraform-provider-vault/vault"
+)
+
+var roleNameTestProvider = func() *schema.Provider {
+	p := schema.NewProvider(vault.Provider())
+	p.RegisterResource("vault_mount", vault.MountResource())
+	p.RegisterResource("vault_transform_transformation_name", transformation.NameResource())
+	p.RegisterResource("vault_transform_role_name", role.NameResource())
+	p.RegisterDataSource("vault_transform_decode_role_name", RoleNameDataSource())
+	return p
+}()
+
+func TestDecodeRoleName(t *testing.T) {
+	isEnterprise := os.Getenv("TF_ACC_ENTERPRISE")
+	if isEnterprise == "" {
+		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")
+	}
+	path := acctest.RandomWithPrefix("transform")
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { util.TestAccPreCheck(t) },
+		Providers: map[string]terraform.ResourceProvider{
+			"vault": roleNameTestProvider.ResourceProvider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: basicConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vault_transform_decode_role_name.test", "decoded_value"),
+				),
+			},
+		},
+	})
+}
+
+func basicConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "transform" {
+  path = "%s"
+  type = "transform"
+}
+resource "vault_transform_transformation_name" "ccn-fpe" {
+  path = vault_mount.transform.path
+  name = "ccn-fpe"
+  type = "fpe"
+  template = "builtin/creditcardnumber"
+  tweak_source = "internal"
+  allowed_roles = ["payments"]
+}
+resource "vault_transform_role_name" "payments" {
+  path = vault_transform_transformation_name.ccn-fpe.path
+  name = "payments"
+  transformations = ["ccn-fpe"]
+}
+data "vault_transform_decode_role_name" "test" {
+    path      = vault_transform_role_name.payments.path
+    role_name = "payments"
+    value     = "9300-3376-4943-8903"
+}
+`, path)
+}

--- a/generated/datasources/transform/encode/role_name.go
+++ b/generated/datasources/transform/encode/role_name.go
@@ -1,4 +1,4 @@
-package decode
+package encode
 
 // DO NOT EDIT
 // This code is generated.
@@ -13,7 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
-const roleNameEndpoint = "/transform/decode/{role_name}"
+const roleNameEndpoint = "/transform/encode/{role_name}"
 
 func RoleNameDataSource() *schema.Resource {
 	return &schema.Resource{
@@ -32,20 +32,20 @@ func RoleNameDataSource() *schema.Resource {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeMap},
 				Optional:    true,
-				Description: "Specifies a list of items to be decoded in a single batch. If this parameter is set, the top-level parameters 'value', 'transformation' and 'tweak' will be ignored. Each batch item within the list can specify these parameters instead.",
+				Description: "Specifies a list of items to be encoded in a single batch. If this parameter is set, the parameters 'value', 'transformation' and 'tweak' will be ignored. Each batch item within the list can specify these parameters instead.",
 			},
 			"batch_results": {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeMap},
 				Optional:    true,
 				Computed:    true,
-				Description: "The result of decoding batch_input.",
+				Description: "The result of encoding batch_input.",
 			},
-			"decoded_value": {
+			"encoded_value": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "The result of decoding a value.",
+				Description: "The result of encoding a value.",
 			},
 			"role_name": {
 				Type:        schema.TypeString,
@@ -66,7 +66,7 @@ func RoleNameDataSource() *schema.Resource {
 			"value": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The value in which to decode.",
+				Description: "The value in which to encode.",
 			},
 		},
 	}
@@ -107,7 +107,7 @@ func readRoleNameResource(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("batch_results", resp.Data["batch_results"]); err != nil {
 		return err
 	}
-	if err := d.Set("decoded_value", resp.Data["decoded_value"]); err != nil {
+	if err := d.Set("encoded_value", resp.Data["encoded_value"]); err != nil {
 		return err
 	}
 	return nil

--- a/generated/datasources/transform/encode/role_name_test.go
+++ b/generated/datasources/transform/encode/role_name_test.go
@@ -1,4 +1,4 @@
-package decode
+package encode
 
 import (
 	"fmt"
@@ -20,11 +20,11 @@ var roleNameTestProvider = func() *schema.Provider {
 	p.RegisterResource("vault_mount", vault.MountResource())
 	p.RegisterResource("vault_transform_transformation_name", transformation.NameResource())
 	p.RegisterResource("vault_transform_role_name", role.NameResource())
-	p.RegisterDataSource("vault_transform_decode_role_name", RoleNameDataSource())
+	p.RegisterDataSource("vault_transform_encode_role_name", RoleNameDataSource())
 	return p
 }()
 
-func TestDecodeBasic(t *testing.T) {
+func TestEncodeBasic(t *testing.T) {
 	isEnterprise := os.Getenv("TF_ACC_ENTERPRISE")
 	if isEnterprise == "" {
 		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")
@@ -39,7 +39,7 @@ func TestDecodeBasic(t *testing.T) {
 			{
 				Config: basicConfig(path),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.vault_transform_decode_role_name.test", "decoded_value"),
+					resource.TestCheckResourceAttrSet("data.vault_transform_encode_role_name.test", "encoded_value"),
 				),
 			},
 		},
@@ -65,15 +65,15 @@ resource "vault_transform_role_name" "payments" {
   name = "payments"
   transformations = ["ccn-fpe"]
 }
-data "vault_transform_decode_role_name" "test" {
+data "vault_transform_encode_role_name" "test" {
     path      = vault_transform_role_name.payments.path
     role_name = "payments"
-    value     = "9300-3376-4943-8903"
+    value     = "1111-2222-3333-4444"
 }
 `, path)
 }
 
-func TestDecodeBatch(t *testing.T) {
+func TestEncodeBatch(t *testing.T) {
 	isEnterprise := os.Getenv("TF_ACC_ENTERPRISE")
 	if isEnterprise == "" {
 		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")
@@ -88,8 +88,8 @@ func TestDecodeBatch(t *testing.T) {
 			{
 				Config: batchConfig(path),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.vault_transform_decode_role_name.test", "batch_results.#", "1"),
-					resource.TestCheckResourceAttrSet("data.vault_transform_decode_role_name.test", "batch_results.0.decoded_value"),
+					resource.TestCheckResourceAttr("data.vault_transform_encode_role_name.test", "batch_results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.vault_transform_encode_role_name.test", "batch_results.0.encoded_value"),
 				),
 			},
 		},
@@ -115,10 +115,10 @@ resource "vault_transform_role_name" "payments" {
   name = "payments"
   transformations = ["ccn-fpe"]
 }
-data "vault_transform_decode_role_name" "test" {
+data "vault_transform_encode_role_name" "test" {
     path      = vault_transform_role_name.payments.path
     role_name = "payments"
-    batch_input = [{"value":"9300-3376-4943-8903"}]
+    batch_input = [{"value":"1111-2222-3333-4444"}]
 }
 `, path)
 }

--- a/generated/registry.go
+++ b/generated/registry.go
@@ -3,17 +3,23 @@ package generated
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode"
+	"github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode"
+	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet"
 	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role"
+	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template"
 	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation"
 )
 
 // Please alphabetize.
 var DataSourceRegistry = map[string]*schema.Resource{
+	"vault_transform_encode_role_name": encode.RoleNameDataSource(),
 	"vault_transform_decode_role_name": decode.RoleNameDataSource(),
 }
 
 // Please alphabetize.
 var ResourceRegistry = map[string]*schema.Resource{
+	"vault_transform_alphabet_name":       alphabet.NameResource(),
 	"vault_transform_role_name":           role.NameResource(),
+	"vault_transform_template_name":       template.NameResource(),
 	"vault_transform_transformation_name": transformation.NameResource(),
 }

--- a/generated/registry.go
+++ b/generated/registry.go
@@ -2,10 +2,17 @@ package generated
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode"
 	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role"
 	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation"
 )
 
+// Please alphabetize.
+var DataSourceRegistry = map[string]*schema.Resource{
+	"vault_transform_decode_role_name": decode.RoleNameDataSource(),
+}
+
+// Please alphabetize.
 var ResourceRegistry = map[string]*schema.Resource{
 	"vault_transform_role_name":           role.NameResource(),
 	"vault_transform_transformation_name": transformation.NameResource(),

--- a/generated/resources/transform/alphabet/name.go
+++ b/generated/resources/transform/alphabet/name.go
@@ -1,0 +1,149 @@
+package alphabet
+
+// DO NOT EDIT
+// This code is generated.
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+)
+
+const nameEndpoint = "/transform/alphabet/{name}"
+
+func NameResource() *schema.Resource {
+	fields := map[string]*schema.Schema{
+		"path": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Path to backend to configure.",
+			StateFunc: func(v interface{}) string {
+				return strings.Trim(v.(string), "/")
+			},
+		},
+		"alphabet": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "A string of characters that contains the alphabet set.",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The name of the alphabet.",
+			ForceNew:    true,
+		},
+	}
+	return &schema.Resource{
+		Create: createNameResource,
+		Update: updateNameResource,
+		Read:   readNameResource,
+		Exists: resourceNameExists,
+		Delete: deleteNameResource,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: fields,
+	}
+}
+func createNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Get("path").(string)
+	vaultPath := util.ParsePath(path, nameEndpoint, d)
+	log.Printf("[DEBUG] Creating %q", vaultPath)
+
+	data := map[string]interface{}{}
+	if v, ok := d.GetOkExists("alphabet"); ok {
+		data["alphabet"] = v
+	}
+	data["name"] = d.Get("name")
+
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return fmt.Errorf("error writing %q: %s", vaultPath, err)
+	}
+	d.SetId(vaultPath)
+	log.Printf("[DEBUG] Wrote %q", vaultPath)
+	return readNameResource(d, meta)
+}
+
+func readNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Reading %q", vaultPath)
+
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return fmt.Errorf("error reading %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Read %q", vaultPath)
+	if resp == nil {
+		log.Printf("[WARN] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+	pathParams, err := util.PathParameters(nameEndpoint, vaultPath)
+	if err != nil {
+		return err
+	}
+	for paramName, paramVal := range pathParams {
+		if err := d.Set(paramName, paramVal); err != nil {
+			return fmt.Errorf("error setting state %q, %q: %s", paramName, paramVal, err)
+		}
+	}
+	if val, ok := resp.Data["alphabet"]; ok {
+		if err := d.Set("alphabet", val); err != nil {
+			return fmt.Errorf("error setting state key 'alphabet': %s", err)
+		}
+	}
+	return nil
+}
+
+func updateNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Updating %q", vaultPath)
+
+	data := map[string]interface{}{}
+	if d.HasChange("alphabet") {
+		data["alphabet"] = d.Get("alphabet")
+	}
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Updated %q", vaultPath)
+	return readNameResource(d, meta)
+}
+
+func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Deleting %q", vaultPath)
+
+	if _, err := client.Logical().Delete(vaultPath); err != nil && !util.Is404(err) {
+		return fmt.Errorf("error deleting %q", vaultPath)
+	} else if err != nil {
+		log.Printf("[DEBUG] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+	log.Printf("[DEBUG] Deleted template auth backend role %q", vaultPath)
+	return nil
+}
+
+func resourceNameExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Checking if %q exists", vaultPath)
+
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return true, fmt.Errorf("error checking if %q exists: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Checked if %q exists", vaultPath)
+	return resp != nil, nil
+}

--- a/generated/resources/transform/alphabet/name_test.go
+++ b/generated/resources/transform/alphabet/name_test.go
@@ -1,0 +1,93 @@
+package alphabet
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/vault/api"
+	"github.com/terraform-providers/terraform-provider-vault/schema"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/terraform-providers/terraform-provider-vault/vault"
+)
+
+var nameTestProvider = func() *schema.Provider {
+	p := schema.NewProvider(vault.Provider())
+	p.RegisterResource("vault_mount", vault.MountResource())
+	p.RegisterResource("vault_transform_alphabet_name", NameResource())
+	return p
+}()
+
+func TestAlphabetName(t *testing.T) {
+	isEnterprise := os.Getenv("TF_ACC_ENTERPRISE")
+	if isEnterprise == "" {
+		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")
+	}
+	path := acctest.RandomWithPrefix("transform")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { util.TestAccPreCheck(t) },
+		Providers: map[string]terraform.ResourceProvider{
+			"vault": nameTestProvider.ResourceProvider(),
+		},
+		CheckDestroy: destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: basicConfig(path, "numerics", "0123456789"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_transform_alphabet_name.test", "path", path),
+					resource.TestCheckResourceAttr("vault_transform_alphabet_name.test", "name", "numerics"),
+					resource.TestCheckResourceAttr("vault_transform_alphabet_name.test", "alphabet", "0123456789"),
+				),
+			},
+			{
+				Config: basicConfig(path, "numerics", "012345678"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_transform_alphabet_name.test", "path", path),
+					resource.TestCheckResourceAttr("vault_transform_alphabet_name.test", "name", "numerics"),
+					resource.TestCheckResourceAttr("vault_transform_alphabet_name.test", "alphabet", "012345678"),
+				),
+			},
+			{
+				ResourceName:      "vault_transform_alphabet_name.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func destroy(s *terraform.State) error {
+	client := nameTestProvider.SchemaProvider().Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_transform_alphabet_name" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for alphabet %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("alphabet %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func basicConfig(path, name, alphabet string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mount_transform" {
+  path = "%s"
+  type = "transform"
+}
+resource "vault_transform_alphabet_name" "test" {
+  path = vault_mount.mount_transform.path
+  name = "%s"
+  alphabet = "%s"
+}
+`, path, name, alphabet)
+}

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -1,0 +1,181 @@
+package template
+
+// DO NOT EDIT
+// This code is generated.
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+)
+
+const nameEndpoint = "/transform/template/{name}"
+
+func NameResource() *schema.Resource {
+	fields := map[string]*schema.Schema{
+		"path": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Path to backend to configure.",
+			StateFunc: func(v interface{}) string {
+				return strings.Trim(v.(string), "/")
+			},
+		},
+		"alphabet": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The alphabet to use for this template. This is only used during FPE transformations.",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The name of the template.",
+			ForceNew:    true,
+		},
+		"pattern": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The pattern used for matching. Currently, only regular expression pattern is supported.",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The pattern type to use for match detection. Currently, only regex is supported.",
+		},
+	}
+	return &schema.Resource{
+		Create: createNameResource,
+		Update: updateNameResource,
+		Read:   readNameResource,
+		Exists: resourceNameExists,
+		Delete: deleteNameResource,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: fields,
+	}
+}
+func createNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Get("path").(string)
+	vaultPath := util.ParsePath(path, nameEndpoint, d)
+	log.Printf("[DEBUG] Creating %q", vaultPath)
+
+	data := map[string]interface{}{}
+	if v, ok := d.GetOkExists("alphabet"); ok {
+		data["alphabet"] = v
+	}
+	data["name"] = d.Get("name")
+	if v, ok := d.GetOkExists("pattern"); ok {
+		data["pattern"] = v
+	}
+	if v, ok := d.GetOkExists("type"); ok {
+		data["type"] = v
+	}
+
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return fmt.Errorf("error writing %q: %s", vaultPath, err)
+	}
+	d.SetId(vaultPath)
+	log.Printf("[DEBUG] Wrote %q", vaultPath)
+	return readNameResource(d, meta)
+}
+
+func readNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Reading %q", vaultPath)
+
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return fmt.Errorf("error reading %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Read %q", vaultPath)
+	if resp == nil {
+		log.Printf("[WARN] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+	pathParams, err := util.PathParameters(nameEndpoint, vaultPath)
+	if err != nil {
+		return err
+	}
+	for paramName, paramVal := range pathParams {
+		if err := d.Set(paramName, paramVal); err != nil {
+			return fmt.Errorf("error setting state %q, %q: %s", paramName, paramVal, err)
+		}
+	}
+	if val, ok := resp.Data["alphabet"]; ok {
+		if err := d.Set("alphabet", val); err != nil {
+			return fmt.Errorf("error setting state key 'alphabet': %s", err)
+		}
+	}
+	if val, ok := resp.Data["pattern"]; ok {
+		if err := d.Set("pattern", val); err != nil {
+			return fmt.Errorf("error setting state key 'pattern': %s", err)
+		}
+	}
+	if val, ok := resp.Data["type"]; ok {
+		if err := d.Set("type", val); err != nil {
+			return fmt.Errorf("error setting state key 'type': %s", err)
+		}
+	}
+	return nil
+}
+
+func updateNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Updating %q", vaultPath)
+
+	data := map[string]interface{}{}
+	if d.HasChange("alphabet") {
+		data["alphabet"] = d.Get("alphabet")
+	}
+	if d.HasChange("pattern") {
+		data["pattern"] = d.Get("pattern")
+	}
+	if d.HasChange("type") {
+		data["type"] = d.Get("type")
+	}
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Updated %q", vaultPath)
+	return readNameResource(d, meta)
+}
+
+func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Deleting %q", vaultPath)
+
+	if _, err := client.Logical().Delete(vaultPath); err != nil && !util.Is404(err) {
+		return fmt.Errorf("error deleting %q", vaultPath)
+	} else if err != nil {
+		log.Printf("[DEBUG] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+	log.Printf("[DEBUG] Deleted template auth backend role %q", vaultPath)
+	return nil
+}
+
+func resourceNameExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Checking if %q exists", vaultPath)
+
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return true, fmt.Errorf("error checking if %q exists: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Checked if %q exists", vaultPath)
+	return resp != nil, nil
+}

--- a/generated/resources/transform/template/name_test.go
+++ b/generated/resources/transform/template/name_test.go
@@ -1,0 +1,106 @@
+package template
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/vault/api"
+	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet"
+	"github.com/terraform-providers/terraform-provider-vault/schema"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/terraform-providers/terraform-provider-vault/vault"
+)
+
+var nameTestProvider = func() *schema.Provider {
+	p := schema.NewProvider(vault.Provider())
+	p.RegisterResource("vault_mount", vault.MountResource())
+	p.RegisterResource("vault_transform_alphabet_name", alphabet.NameResource())
+	p.RegisterResource("vault_transform_template_name", NameResource())
+	return p
+}()
+
+func TestTemplateName(t *testing.T) {
+	isEnterprise := os.Getenv("TF_ACC_ENTERPRISE")
+	if isEnterprise == "" {
+		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")
+	}
+	path := acctest.RandomWithPrefix("transform")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { util.TestAccPreCheck(t) },
+		Providers: map[string]terraform.ResourceProvider{
+			"vault": nameTestProvider.ResourceProvider(),
+		},
+		CheckDestroy: destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: basicConfig(path, "regex", `(\\d{4})-(\\d{4})-(\\d{4})-(\\d{4})`, "numerics"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "path", path),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "name", "ccn"),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "type", "regex"),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "pattern", `(\d{4})-(\d{4})-(\d{4})-(\d{4})`),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "alphabet", "numerics"),
+				),
+			},
+			{
+				Config: basicConfig(path, "regex", `(\\d{9})`, "builtin/numeric"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "path", path),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "name", "ccn"),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "type", "regex"),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "pattern", `(\d{9})`),
+					resource.TestCheckResourceAttr("vault_transform_template_name.test", "alphabet", "builtin/numeric"),
+				),
+			},
+			{
+				ResourceName:      "vault_transform_template_name.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func destroy(s *terraform.State) error {
+	client := nameTestProvider.SchemaProvider().Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_transform_template_name" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for alphabet %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("alphabet %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func basicConfig(path, tp, pattern, alphabet string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "transform" {
+  path = "%s"
+  type = "transform"
+}
+resource "vault_transform_alphabet_name" "numerics" {
+  path = vault_mount.transform.path
+  name = "numerics"
+  alphabet = "0123456789"
+}
+resource "vault_transform_template_name" "test" {
+  path = vault_transform_alphabet_name.numerics.path
+  name = "ccn"
+  type = "%s"
+  pattern = "%s"
+  alphabet = "%s"
+}
+`, path, tp, pattern, alphabet)
+}

--- a/generated/resources/transform/transformation/name_test.go
+++ b/generated/resources/transform/transformation/name_test.go
@@ -21,7 +21,7 @@ var nameTestProvider = func() *schema.Provider {
 	return p
 }()
 
-func TestRoleName(t *testing.T) {
+func TestTransformationName(t *testing.T) {
 	isEnterprise := os.Getenv("TF_ACC_ENTERPRISE")
 	if isEnterprise == "" {
 		t.Skip("TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault")

--- a/main.go
+++ b/main.go
@@ -9,6 +9,9 @@ import (
 
 func main() {
 	p := schema.NewProvider(vault.Provider())
+	for name, resource := range generated.DataSourceRegistry {
+		p.RegisterDataSource(name, resource)
+	}
 	for name, resource := range generated.ResourceRegistry {
 		p.RegisterResource(name, resource)
 	}

--- a/website/docs/generated/datasources/transform/decode/role_name.md
+++ b/website/docs/generated/datasources/transform/decode/role_name.md
@@ -1,0 +1,52 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_decode_role_name data source"
+sidebar_current: "docs-vault-datasource-transform-decode"
+description: |-
+  "/transform/decode/{role_name}"
+---
+
+# vault\_transform\_decode\_role\_name
+
+This data source supports the "/transform/decode/{role_name}" Vault endpoint.
+
+It decodes the provided value using a named role.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "transform" {
+  path = "transform"
+  type = "transform"
+}
+resource "vault_transform_transformation_name" "ccn-fpe" {
+  path = vault_mount.transform.path
+  name = "ccn-fpe"
+  type = "fpe"
+  template = "builtin/creditcardnumber"
+  tweak_source = "internal"
+  allowed_roles = ["payments"]
+}
+resource "vault_transform_role_name" "payments" {
+  path = vault_transform_transformation_name.ccn-fpe.path
+  name = "payments"
+  transformations = ["ccn-fpe"]
+}
+data "vault_transform_decode_role_name" "test" {
+    path      = vault_transform_role_name.payments.path
+    role_name = "payments"
+    value     = "9300-3376-4943-8903"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `batch_input` - (Optional) Specifies a list of items to be decoded in a single batch. If this parameter is set, the top-level parameters 'value', 'transformation' and 'tweak' will be ignored. Each batch item within the list can specify these parameters instead.
+* `batch_results` - (Optional) The result of decoding a batch.
+* `decoded_value` - (Optional) The result of decoding a value.
+* `role_name` - (Required) The name of the role.
+* `transformation` - (Optional) The transformation to perform. If no value is provided and the role contains a single transformation, this value will be inferred from the role.
+* `tweak` - (Optional) The tweak value to use. Only applicable for FPE transformations
+* `value` - (Optional) The value in which to decode.

--- a/website/docs/generated/datasources/transform/encode/role_name.md
+++ b/website/docs/generated/datasources/transform/encode/role_name.md
@@ -1,0 +1,52 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_encode_role_name data source"
+sidebar_current: "docs-vault-datasource-transform-encode"
+description: |-
+  "/transform/encode/{role_name}"
+---
+
+# vault\_transform\_encode\_role\_name
+
+This data source supports the "/transform/encode/{role_name}" Vault endpoint.
+
+It encodes the provided value using a named role.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "transform" {
+  path = "transform"
+  type = "transform"
+}
+resource "vault_transform_transformation_name" "ccn-fpe" {
+  path = vault_mount.transform.path
+  name = "ccn-fpe"
+  type = "fpe"
+  template = "builtin/creditcardnumber"
+  tweak_source = "internal"
+  allowed_roles = ["payments"]
+}
+resource "vault_transform_role_name" "payments" {
+  path = vault_transform_transformation_name.ccn-fpe.path
+  name = "payments"
+  transformations = ["ccn-fpe"]
+}
+data "vault_transform_encode_role_name" "test" {
+    path      = vault_transform_role_name.payments.path
+    role_name = "payments"
+    batch_input = [{"value":"1111-2222-3333-4444"}]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `batch_input` - (Optional) Specifies a list of items to be encoded in a single batch. If this parameter is set, the parameters 'value', 'transformation' and 'tweak' will be ignored. Each batch item within the list can specify these parameters instead.
+* `batch_results` - (Optional) The result of encoding a batch.
+* `encoded_value` - (Optional) The result of encoding a value.
+* `role_name` - (Required) The name of the role.
+* `transformation` - (Optional) The transformation to perform. If no value is provided and the role contains a single transformation, this value will be inferred from the role.
+* `tweak` - (Optional) The tweak value to use. Only applicable for FPE transformations
+* `value` - (Optional) The value in which to encode.

--- a/website/docs/generated/resources/transform/alphabet/name.md
+++ b/website/docs/generated/resources/transform/alphabet/name.md
@@ -1,0 +1,35 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_alphabet_name resource"
+sidebar_current: "docs-vault-resource-transform-alphabet-name"
+description: |-
+  "/transform/alphabet/{name}"
+---
+
+# vault\_transform\_alphabet\_name
+
+This resource supports the "/transform/alphabet/{name}" Vault endpoint.
+
+It queries an existing alphabet by the given name.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "mount_transform" {
+  path = "transform"
+  type = "transform"
+}
+
+resource "vault_transform_alphabet_name" "test" {
+  path = vault_mount.mount_transform.path
+  name = "numerics"
+  alphabet = "0123456789"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `alphabet` - (Optional) A string of characters that contains the alphabet set.
+* `name` - (Required) The name of the alphabet.

--- a/website/docs/generated/resources/transform/role/name.md
+++ b/website/docs/generated/resources/transform/role/name.md
@@ -1,0 +1,35 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_role_name resource"
+sidebar_current: "docs-vault-resource-transform-role-name"
+description: |-
+  "/transform/role/{name}"
+---
+
+# vault\_transform\_role\_name
+
+This resource supports the "/transform/role/{name}" Vault endpoint.
+
+It creates or updates the role with the given name. If a role with the name does not exist, it will be created. 
+If the role exists, it will be updated with the new attributes.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "mount_transform" {
+  path = "transform"
+  type = "transform"
+}
+resource "vault_transform_role_name" "test" {
+  path = vault_mount.mount_transform.path
+  name = "payments"
+  transformations = ["ccn-fpe"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `name` - (Required) The name of the role.
+* `transformations` - (Optional) A comma separated string or slice of transformations to use.

--- a/website/docs/generated/resources/transform/template/name.md
+++ b/website/docs/generated/resources/transform/template/name.md
@@ -1,0 +1,50 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_template_name resource"
+sidebar_current: "docs-vault-resource-transform-template-name"
+description: |-
+  "/transform/template/{name}"
+---
+
+# vault\_transform\_template\_name
+
+This resource supports the "/transform/template/{name}" Vault endpoint.
+
+It creates or updates a template with the given name. If a template with the name does not exist, 
+it will be created. If the template exists, it will be updated with the new attributes.
+
+## Example Usage
+
+Please note that the `pattern` below holds a regex. The regex shown
+is identical to the one in our [Setup](https://www.vaultproject.io/docs/secrets/transform#setup)
+docs, `(\d{4})-(\d{4})-(\d{4})-(\d{4})`. However, due to HCL, the 
+backslashes must be escaped to appear correctly in Vault. For further
+assistance escaping your own custom regex, see [String Literals](https://www.terraform.io/docs/configuration/expressions.html#string-literals).
+
+```hcl
+resource "vault_mount" "transform" {
+  path = "transform"
+  type = "transform"
+}
+resource "vault_transform_alphabet_name" "numerics" {
+  path = vault_mount.transform.path
+  name = "numerics"
+  alphabet = "0123456789"
+}
+resource "vault_transform_template_name" "test" {
+  path = vault_transform_alphabet_name.numerics.path
+  name = "ccn"
+  type = "regex"
+  pattern = "(\\d{4})-(\\d{4})-(\\d{4})-(\\d{4})"
+  alphabet = "numerics"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `alphabet` - (Optional) The alphabet to use for this template. This is only used during FPE transformations.
+* `name` - (Required) The name of the template.
+* `pattern` - (Optional) The pattern used for matching. Currently, only regular expression pattern is supported.
+* `type` - (Optional) The pattern type to use for match detection. Currently, only regex is supported.

--- a/website/docs/generated/resources/transform/transformation/name.md
+++ b/website/docs/generated/resources/transform/transformation/name.md
@@ -1,0 +1,43 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_transformation_name resource"
+sidebar_current: "docs-vault-resource-transform-transformation-name"
+description: |-
+  "/transform/transformation/{name}"
+---
+
+# vault\_transform\_transformation\_name
+
+This resource supports the "/transform/transformation/{name}" Vault endpoint.
+
+It creates or updates a transformation with the given name. If a transformation with the name does not exist, 
+it will be created. If the transformation exists, it will be updated with the new attributes.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "mount_transform" {
+  path = "transform"
+  type = "transform"
+}
+resource "vault_transform_transformation_name" "test" {
+  path = vault_mount.mount_transform.path
+  name = "ccn-fpe"
+  type = "fpe"
+  template = "ccn"
+  tweak_source = "internal"
+  allowed_roles = ["payments"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `allowed_roles` - (Optional) The set of roles allowed to perform this transformation.
+* `masking_character` - (Optional) The character used to replace data when in masking mode
+* `name` - (Required) The name of the transformation.
+* `template` - (Optional) The name of the template to use.
+* `templates` - (Optional) Templates configured for transformation.
+* `tweak_source` - (Optional) The source of where the tweak value comes from. Only valid when in FPE mode.
+* `type` - (Optional) The type of transformation to perform.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -33,6 +33,14 @@
                             <a href="/docs/providers/vault/d/azure_access_credentials.html">vault_azure_access_credentials</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-datasource-transform-decode") %>>
+                            <a href="/docs/providers/vault/generated/datasources/transform/decode/role_name.html">vault_transform_decode_role_name</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-datasource-transform-encode") %>>
+                            <a href="/docs/providers/vault/generated/datasources/transform/encode/role_name.html">vault_transform_encode_role_name</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-datasource-generic-secret") %>>
                             <a href="/docs/providers/vault/d/generic_secret.html">vault_generic_secret</a>
                         </li>
@@ -371,6 +379,18 @@
 
                         <li<%= sidebar_current("docs-vault-resource-rabbitmq-secret-backend-role") %>>
                             <a href="/docs/providers/vault/r/rabbitmq_secret_backend_role.html">vault_rabbitmq_secret_backend_role</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-transform-alphabet-name") %>>
+                            <a href="/docs/providers/vault/generated/resources/transform/alphabet/name.html">vault_transform_role_name</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-transform-role-name") %>>
+                            <a href="/docs/providers/vault/generated/resources/transform/role/name.html">vault_transform_role_name</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-transform-transformation-name") %>>
+                            <a href="/docs/providers/vault/generated/resources/transform/transformation/name.html">vault_transit_secret_backend_key</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transit-secret-backend-key") %>>


### PR DESCRIPTION
This PR adds code to generate data sources along with the first generated data source.

<details>
<summary>Example terraform config</summary>

```
provider "vault" {}

resource "vault_mount" "transform" {
  path = "transform"
  type = "transform"
}

resource "vault_transform_transformation_name" "ccn-fpe" {
  path = vault_mount.transform.path
  name = "ccn-fpe"
  type = "fpe"
  template = "builtin/creditcardnumber"
  tweak_source = "internal"
  allowed_roles = ["payments"]
}

resource "vault_transform_role_name" "payments" {
  path = vault_transform_transformation_name.ccn-fpe.path
  name = "payments"
  transformations = ["ccn-fpe"]
}

data "vault_transform_decode_role_name" "test" {
    path      = vault_transform_role_name.payments.path
    role_name = "payments"
    value     = "9300-3376-4943-8903"
}
```

</details>

<details>
<summary>Example state file</summary>

```
{
  "version": 4,
  "terraform_version": "0.12.20",
  "serial": 5,
  "lineage": "85599a3c-e2ce-92d3-2942-eea93eec3db3",
  "outputs": {},
  "resources": [
    {
      "mode": "data",
      "type": "vault_transform_decode_role_name",
      "name": "test",
      "provider": "provider.vault",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "batch_input": null,
            "decoded_value": "1521-6636-0426-7326",
            "id": "/transform/decode/payments",
            "path": "transform",
            "role_name": "payments",
            "transformation": null,
            "tweak": null,
            "value": "9300-3376-4943-8903"
          }
        }
      ]
    },
    {
      "mode": "managed",
      "type": "vault_mount",
      "name": "transform",
      "provider": "provider.vault",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "accessor": "transform_9498d920",
            "default_lease_ttl_seconds": 0,
            "description": "",
            "id": "transform",
            "local": false,
            "max_lease_ttl_seconds": 0,
            "options": null,
            "path": "transform",
            "seal_wrap": false,
            "type": "transform"
          },
          "private": "bnVsbA=="
        }
      ]
    },
    {
      "mode": "managed",
      "type": "vault_transform_role_name",
      "name": "payments",
      "provider": "provider.vault",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "/transform/role/payments",
            "name": "payments",
            "path": "transform",
            "transformations": [
              "ccn-fpe"
            ]
          },
          "private": "bnVsbA==",
          "dependencies": [
            "vault_mount.transform",
            "vault_transform_transformation_name.ccn-fpe"
          ]
        }
      ]
    },
    {
      "mode": "managed",
      "type": "vault_transform_transformation_name",
      "name": "ccn-fpe",
      "provider": "provider.vault",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "allowed_roles": [
              "payments"
            ],
            "id": "/transform/transformation/ccn-fpe",
            "masking_character": null,
            "name": "ccn-fpe",
            "path": "transform",
            "template": "builtin/creditcardnumber",
            "templates": [
              "builtin/creditcardnumber"
            ],
            "tweak_source": "internal",
            "type": "fpe"
          },
          "private": "bnVsbA==",
          "dependencies": [
            "vault_mount.transform"
          ]
        }
      ]
    }
  ]
}
```

</details>

<details>
<summary>Acceptance test output at info log level</summary>

```
GOROOT=/usr/local/go #gosetup
GOPATH=/home/tbex/go #gosetup
/usr/local/go/bin/go test -c -o /tmp/___TestDecodeRoleName_in_github_com_terraform_providers_terraform_provider_vault_generated_datasources_transform_decode github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode #gosetup
/usr/local/go/bin/go tool test2json -t /tmp/___TestDecodeRoleName_in_github_com_terraform_providers_terraform_provider_vault_generated_datasources_transform_decode -test.v -test.run ^TestDecodeRoleName$ #gosetup
=== RUN   TestDecodeRoleName
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeValidate
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeRefresh
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypePlan
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [WARN] Test: Step plan: DIFF:

UPDATE: data.vault_transform_decode_role_name.test
  decoded_value: "" => "<computed>"
  id:            "" => "<computed>"
  path:          "" => "transform-638148575857956071"
  role_name:     "" => "payments"
  value:         "" => "9300-3376-4943-8903"
CREATE: vault_mount.transform
  accessor:                  "" => "<computed>"
  default_lease_ttl_seconds: "" => "<computed>"
  id:                        "" => "<computed>"
  max_lease_ttl_seconds:     "" => "<computed>"
  path:                      "" => "transform-638148575857956071"
  seal_wrap:                 "" => "<computed>"
  type:                      "" => "transform"
CREATE: vault_transform_role_name.payments
  id:                "" => "<computed>"
  name:              "" => "payments"
  path:              "" => "transform-638148575857956071"
  transformations.#: "" => "1"
  transformations.0: "" => "ccn-fpe"
CREATE: vault_transform_transformation_name.ccn-fpe
  allowed_roles.#: "" => "1"
  allowed_roles.0: "" => "payments"
  id:              "" => "<computed>"
  name:            "" => "ccn-fpe"
  path:            "" => "transform-638148575857956071"
  template:        "" => "builtin/creditcardnumber"
  templates:       "" => "<computed>"
  tweak_source:    "" => "internal"
  type:            "" => "fpe"



STATE:

<no state>
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeApply
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [WARN] Provider "vault" produced an unexpected new value for vault_mount.transform, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .local: was null, but now cty.False
      - .description: was null, but now cty.StringVal("")
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypePlan
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeRefresh
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypePlan
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [WARN] Test: Executing destroy step
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeValidate
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeRefresh
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypePlanDestroy
2020/05/08 16:25:38 [WARN] Test: Step plan: DIFF:

DESTROY: data.vault_transform_decode_role_name.test
  decoded_value: "6874-5087-2464-9601" => ""
  id:            "/transform-638148575857956071/decode/payments" => ""
  path:          "transform-638148575857956071" => ""
  role_name:     "payments" => ""
  value:         "9300-3376-4943-8903" => ""
DESTROY: vault_mount.transform
  accessor:                  "transform_c99d45a3" => ""
  default_lease_ttl_seconds: "0" => ""
  description:               "" => ""
  id:                        "transform-638148575857956071" => ""
  local:                     "false" => ""
  max_lease_ttl_seconds:     "0" => ""
  path:                      "transform-638148575857956071" => ""
  seal_wrap:                 "false" => ""
  type:                      "transform" => ""
DESTROY: vault_transform_role_name.payments
  id:                "/transform-638148575857956071/role/payments" => ""
  name:              "payments" => ""
  path:              "transform-638148575857956071" => ""
  transformations.#: "1" => ""
  transformations.0: "ccn-fpe" => ""
DESTROY: vault_transform_transformation_name.ccn-fpe
  allowed_roles.#: "1" => ""
  allowed_roles.0: "payments" => ""
  id:              "/transform-638148575857956071/transformation/ccn-fpe" => ""
  name:            "ccn-fpe" => ""
  path:            "transform-638148575857956071" => ""
  template:        "builtin/creditcardnumber" => ""
  templates.#:     "1" => ""
  templates.0:     "builtin/creditcardnumber" => ""
  tweak_source:    "internal" => ""
  type:            "fpe" => ""



STATE:

data.vault_transform_decode_role_name.test:
  ID = /transform-638148575857956071/decode/payments
  provider = provider.vault
  decoded_value = 6874-5087-2464-9601
  path = transform-638148575857956071
  role_name = payments
  value = 9300-3376-4943-8903

  Dependencies:
    vault_transform_role_name.payments
vault_mount.transform:
  ID = transform-638148575857956071
  provider = provider.vault
  accessor = transform_c99d45a3
  default_lease_ttl_seconds = 0
  description = 
  local = false
  max_lease_ttl_seconds = 0
  path = transform-638148575857956071
  seal_wrap = false
  type = transform
vault_transform_role_name.payments:
  ID = /transform-638148575857956071/role/payments
  provider = provider.vault
  name = payments
  path = transform-638148575857956071
  transformations.# = 1
  transformations.0 = ccn-fpe

  Dependencies:
    vault_transform_transformation_name.ccn-fpe
vault_transform_transformation_name.ccn-fpe:
  ID = /transform-638148575857956071/transformation/ccn-fpe
  provider = provider.vault
  allowed_roles.# = 1
  allowed_roles.0 = payments
  name = ccn-fpe
  path = transform-638148575857956071
  template = builtin/creditcardnumber
  templates.# = 1
  templates.0 = builtin/creditcardnumber
  tweak_source = internal
  type = fpe

  Dependencies:
    vault_mount.transform
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeApply
2020/05/08 16:25:38 DestroyEdgeTransformer: pruning unused resource node vault_mount.transform (prepare state)
2020/05/08 16:25:38 DestroyEdgeTransformer: pruning unused resource node vault_transform_transformation_name.ccn-fpe (prepare state)
2020/05/08 16:25:38 DestroyEdgeTransformer: pruning unused resource node vault_transform_role_name.payments (prepare state)
2020/05/08 16:25:38 DestroyEdgeTransformer: pruning unused resource node data.vault_transform_decode_role_name.test (prepare state)
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypePlanDestroy
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypeRefresh
2020/05/08 16:25:38 [INFO] Using Vault token with the following policies: root
2020/05/08 16:25:38 [INFO] terraform: building graph: GraphTypePlanDestroy
--- PASS: TestDecodeRoleName (0.22s)
PASS

Process finished with exit code 0
```

</details>