### PR TITLE
jwt_auth_backend: fix validation error with unknown values

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -124,17 +124,23 @@ func jwtAuthBackendResource() *schema.Resource {
 }
 
 func jwtCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
-	var _ interface{}
-	var discUrlExists, jwksUrlExists, jwtPubKeysExists bool
-	_, discUrlExists = d.GetOk("oidc_discovery_url")
-	_, jwksUrlExists = d.GetOk("jwks_url")
-	_, jwtPubKeysExists = d.GetOk("jwt_validation_pubkeys")
-
-	if !(discUrlExists || jwksUrlExists || jwtPubKeysExists) {
-		return errors.New("exactly one of oidc_discovery_url, jwks_url or jwt_validation_pubkeys should be provided")
+	attributes := []string{
+		"oidc_discovery_url",
+		"jwks_url",
+		"jwt_validation_pubkeys",
 	}
 
-	return nil
+	for _, attr := range attributes {
+		if !d.NewValueKnown(attr) {
+			return nil
+		}
+
+		if _, ok := d.GetOk(attr); ok {
+			return nil
+		}
+	}
+
+	return errors.New("exactly one of oidc_discovery_url, jwks_url or jwt_validation_pubkeys should be provided")
 }
 
 var (

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -220,6 +220,18 @@ func TestAccJWTAuthBackend_missingMandatory(t *testing.T) {
 				Destroy:     false,
 				ExpectError: regexp.MustCompile("exactly one of oidc_discovery_url, jwks_url or jwt_validation_pubkeys should be provided"),
 			},
+			{
+				// oidc_discovery_url will be unknown until apply time
+				Config: fmt.Sprintf(`
+				resource "vault_identity_oidc_key" "key" {
+					name = "key"
+				}
+
+				resource "vault_jwt_auth_backend" "unknown" {
+					path = "%s"
+					oidc_discovery_url = coalesce("https://myco.auth0.com/", vault_identity_oidc_key.key.id)
+				}`, path),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR resolves a bug with `vault_jwt_auth_backend`, where the validation implemented via `CustomDiff` that asserts "exactly one of oidc_discovery_url, jwks_url or jwt_validation_pubkeys should be provided" fails when one of these values is set in configuration but not known until apply time.

It handles this by first checking [`NewValueKnown(key)`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/helper/schema?tab=doc#ResourceDiff.NewValueKnown) and returning early if a value is unknown.

This will happen any time these values are sourced from another resource that has not yet been created. We encountered this when pairing an [`okta_auth_server`](https://www.terraform.io/docs/providers/okta/r/auth_server.html) with Vault, but the effect would be the same for any other provider.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #718

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`vault_jwt_auth_backend`: Fix plan error when `oidc_discovery_url`, `jwks_url`, or `jwt_validation_pubkeys` is set to a value that is not known until apply time
```

Output from acceptance testing:

```
TESTARGS="-run TestAccJWTAuthBackend_missingMandatory" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccJWTAuthBackend_missingMandatory -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (0.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.237s
```
