### PR TITLE
fix: using the right serial_number response key

### DIFF
--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -278,7 +278,7 @@ func pkiSecretBackendRootCertCreate(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("certificate", resp.Data["certificate"])
 	d.Set("issuing_ca", resp.Data["issuing_ca"])
-	d.Set("serial", resp.Data["serial"])
+	d.Set("serial", resp.Data["serial_number"])
 
 	d.SetId(path)
 	return pkiSecretBackendRootCertRead(d, meta)

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -36,6 +36,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "country", "test"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "locality", "test"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "province", "test"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_root_cert.test", "serial"),
 				),
 			},
 		},

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -267,7 +267,7 @@ func pkiSecretBackendRootSignIntermediateCreate(d *schema.ResourceData, meta int
 	d.Set("certificate", resp.Data["certificate"])
 	d.Set("issuing_ca", resp.Data["issuing_ca"])
 	d.Set("ca_chain", resp.Data["ca_chain"])
-	d.Set("serial", resp.Data["serial"])
+	d.Set("serial", resp.Data["serial_number"])
 
 	d.SetId(fmt.Sprintf("%s/%s", backend, commonName))
 	return pkiSecretBackendRootSignIntermediateRead(d, meta)

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -31,6 +31,7 @@ func TestPkiSecretBackendRootSignIntermediate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_sign_intermediate.test", "country", "test"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_sign_intermediate.test", "locality", "test"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_sign_intermediate.test", "province", "test"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_root_sign_intermediate.test", "serial"),
 				),
 			},
 		},

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -212,7 +212,7 @@ func pkiSecretBackendSignCreate(d *schema.ResourceData, meta interface{}) error 
 	d.Set("certificate", resp.Data["certificate"])
 	d.Set("issuing_ca", resp.Data["issuing_ca"])
 	d.Set("ca_chain", resp.Data["ca_chain"])
-	d.Set("serial", resp.Data["serial"])
+	d.Set("serial", resp.Data["serial_number"])
 	d.Set("expiration", resp.Data["expiration"])
 
 	d.SetId(fmt.Sprintf("%s/%s/%s", backend, name, commonName))

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -180,6 +180,7 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "ttl", "1h"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "min_seconds_remaining", "3595"),
 					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "expiration"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "serial"),
 				),
 			},
 			{
@@ -195,6 +196,7 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "ttl", "1h"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "min_seconds_remaining", "3595"),
 					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "expiration"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "serial"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -206,6 +208,7 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "ttl", "1h"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_sign.test", "min_seconds_remaining", "3595"),
 					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "expiration"),
+					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_sign.test", "serial"),
 				),
 			},
 		},


### PR DESCRIPTION
The resources below are using the wrong json key and are always returning an empty string:
- vault_pki_secret_backend_root_cert
- vault_pki_secret_backend_root_sign_intermediate
- vault_pki_secret_backend_sign

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_sign` to return the right serial number
```
