### PR TITLE
Fix crash in vault_jwt_auth_backend_role when bound_audiences is nil

### DIFF
--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -333,10 +333,12 @@ func jwtAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	boundAuds := util.JsonStringArrayToStringArray(resp.Data["bound_audiences"].([]interface{}))
-	err = d.Set("bound_audiences", boundAuds)
-	if err != nil {
-		return fmt.Errorf("error setting bound_audiences in state: %s", err)
+	if resp.Data["bound_audiences"] != nil {
+		boundAuds := util.JsonStringArrayToStringArray(resp.Data["bound_audiences"].([]interface{}))
+		err = d.Set("bound_audiences", boundAuds)
+		if err != nil {
+			return fmt.Errorf("error setting bound_audiences in state: %s", err)
+		}
 	}
 
 	d.Set("user_claim", resp.Data["user_claim"].(string))

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -339,6 +339,8 @@ func jwtAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error setting bound_audiences in state: %s", err)
 		}
+	} else {
+		d.Set("bound_audiences", make([]string, 0))
 	}
 
 	d.Set("user_claim", resp.Data["user_claim"].(string))

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -288,10 +288,6 @@ func TestAccJWTAuthBackendRoleOIDC_full(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"bound_subject", "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@client"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
-						"bound_audiences.#", "1"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
-						"bound_audiences.2478800941", "https://myco.test"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"user_claim", "https://vault/user"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"groups_claim", "https://vault/groups"),
@@ -610,7 +606,7 @@ resource "vault_jwt_auth_backend" "jwt" {
   oidc_client_secret = "secret"
   lifecycle {
   ignore_changes = [
-     # Ignore changes to odic_clie_secret inside the tests
+     # Ignore changes to oidc_client_secret inside the tests
      "oidc_client_secret"
     ]
   }
@@ -624,7 +620,6 @@ resource "vault_jwt_auth_backend_role" "role" {
 
   bound_subject = "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@client"
   token_bound_cidrs = ["10.148.0.0/20", "10.150.0.0/20"]
-  bound_audiences = ["https://myco.test"]
   user_claim = "https://vault/user"
   groups_claim = "https://vault/groups"
   token_policies = ["default", "dev", "prod"]

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -45,7 +45,6 @@ resource "vault_jwt_auth_backend_role" "example" {
   role_name       = "test-role"
   token_policies  = ["default", "dev", "prod"]
 
-  bound_audiences       = ["https://myco.test"]
   user_claim            = "https://vault/user"
   role_type             = "oidc"
   allowed_redirect_uris = ["http://localhost:8200/ui/vault/auth/oidc/oidc/callback"]
@@ -60,8 +59,8 @@ The following arguments are supported:
 
 * `role_type` - (Optional) Type of role, either "oidc" (default) or "jwt".
 
-* `bound_audiences` - (Required) List of `aud` claims to match
-  against. Any match is sufficient.
+* `bound_audiences` - (Required for roles of type `jwt`, optional for roles of
+  type `oidc`) List of `aud` claims to match against. Any match is sufficient.
 
 * `user_claim` - (Required) The claim to use to uniquely identify
   the user; this will be used as the name for the Identity entity alias created


### PR DESCRIPTION
Closes #595

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```