### PR TITLE
Fix removal of policies, member_group_ids, and member_entity_ids from the vault_identity_group resource.

### DIFF
--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -102,17 +102,13 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 	}
 
 	if externalPolicies, ok := d.GetOk("external_policies"); !(ok && externalPolicies.(bool)) {
-		if policies, ok := d.GetOk("policies"); ok {
-			data["policies"] = policies.(*schema.Set).List()
-		}
+		data["policies"] = d.Get("policies").(*schema.Set).List()
 	}
 
-	if memberEntityIDs, ok := d.GetOk("member_entity_ids"); ok && d.Get("type").(string) == "internal" {
-		data["member_entity_ids"] = memberEntityIDs.(*schema.Set).List()
-	}
-
-	if memberGroupIDs, ok := d.GetOk("member_group_ids"); ok {
-		data["member_group_ids"] = memberGroupIDs.(*schema.Set).List()
+	// Member group and entity ids are not allowed on external groups
+	if d.Get("type").(string) == "internal" {
+		data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
+		data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
 	}
 
 	if metadata, ok := d.GetOk("metadata"); ok {

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -113,7 +113,7 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 		data["policies"] = d.Get("policies").(*schema.Set).List()
 	}
 
-	// Member group and entity ids are not allowed on external groups
+	// Member groups and entities can't be set for external groups
 	if d.Get("type").(string) == "internal" {
 		data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
 		data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -73,6 +73,14 @@ func identityGroupResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Description: "Group IDs to be assigned as group members.",
+				// Suppress the diff if group type is "external" because we cannot manage
+				// group members
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("type").(string) == "external" {
+						return true
+					}
+					return false
+				},
 			},
 
 			"member_entity_ids": {

--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -55,6 +55,13 @@ func TestAccIdentityGroupUpdate(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccIdentityGroupConfigUpdatePolicies(group),
+				Check: resource.ComposeTestCheckFunc(
+					testAccIdentityGroupCheckAttrs(),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "0"),
+				),
+			},
+			{
 				Config: testAccIdentityGroupConfigUpdateMembers(group, entity),
 				Check: resource.ComposeTestCheckFunc(
 					testAccIdentityGroupCheckAttrs(),
@@ -212,6 +219,19 @@ resource "vault_identity_group" "group" {
   name = "%s-2"
   type = "internal"
   policies = ["dev", "test"]
+  
+  metadata = {
+    version = "2"
+  }
+}`, groupName)
+}
+
+func testAccIdentityGroupConfigUpdatePolicies(groupName string) string {
+	return fmt.Sprintf(`
+resource "vault_identity_group" "group" {
+  name = "%s-2"
+  type = "internal"
+  policies = []
   metadata = {
     version = "2"
   }

--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -40,24 +40,33 @@ func TestAccIdentityGroupUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIdentityGroupConfig(group),
-				Check:  testAccIdentityGroupCheckAttrs(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccIdentityGroupCheckAttrs(),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "external"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "1"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.1785148924", "test"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "metadata.version", "1"),
+				),
 			},
 			{
 				Config: testAccIdentityGroupConfigUpdate(group),
 				Check: resource.ComposeTestCheckFunc(
 					testAccIdentityGroupCheckAttrs(),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "name", fmt.Sprintf("%s-2", group)),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "internal"),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "metadata.version", "2"),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "2"),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.326271447", "dev"),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.1785148924", "test"),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "member_entity_ids.#", "0"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "member_group_ids.#", "0"),
 				),
 			},
 			{
-				Config: testAccIdentityGroupConfigUpdatePolicies(group),
+				Config: testAccIdentityGroupConfigUpdateRemovePolicies(group),
 				Check: resource.ComposeTestCheckFunc(
 					testAccIdentityGroupCheckAttrs(),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "internal"),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "0"),
 				),
 			},
@@ -65,7 +74,22 @@ func TestAccIdentityGroupUpdate(t *testing.T) {
 				Config: testAccIdentityGroupConfigUpdateMembers(group, entity),
 				Check: resource.ComposeTestCheckFunc(
 					testAccIdentityGroupCheckAttrs(),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "internal"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "2"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.326271447", "dev"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.1785148924", "test"),
 					resource.TestCheckResourceAttr("vault_identity_group.group", "member_entity_ids.#", "1"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "member_group_ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccIdentityGroupConfigExternalMembers(group),
+				Check: resource.ComposeTestCheckFunc(
+					testAccIdentityGroupCheckAttrs(),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "external"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "1"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "member_entity_ids.#", "0"),
+					resource.TestCheckResourceAttr("vault_identity_group.group", "member_group_ids.#", "0"),
 				),
 			},
 		},
@@ -185,7 +209,7 @@ func testAccIdentityGroupCheckAttrs() resource.TestCheckFunc {
 							}
 						}
 						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
+							return fmt.Errorf("expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
 						}
 					}
 					match = true
@@ -219,14 +243,13 @@ resource "vault_identity_group" "group" {
   name = "%s-2"
   type = "internal"
   policies = ["dev", "test"]
-  
   metadata = {
     version = "2"
   }
 }`, groupName)
 }
 
-func testAccIdentityGroupConfigUpdatePolicies(groupName string) string {
+func testAccIdentityGroupConfigUpdateRemovePolicies(groupName string) string {
 	return fmt.Sprintf(`
 resource "vault_identity_group" "group" {
   name = "%s-2"
@@ -249,6 +272,7 @@ resource "vault_identity_group" "group" {
   }
 
   member_entity_ids = ["${vault_identity_entity.entity.id}"]
+  member_group_ids = ["${vault_identity_group.other_group.id}"]
 }
 
 resource "vault_identity_entity" "entity" {
@@ -258,7 +282,11 @@ resource "vault_identity_entity" "entity" {
     version = "2"
   }
 }
-`, groupName, entityName)
+
+resource "vault_identity_group" "other_group" {
+  name = "other_%s"
+}
+`, groupName, entityName, groupName)
 }
 
 func testAccIdentityGroupConfigExternalMembers(groupName string) string {
@@ -271,6 +299,7 @@ resource "vault_identity_group" "group" {
     version = "1"
   }
 
-  member_entity_ids = ["this will fail"]
+  member_entity_ids = ["member entities can't be set for external groups"]
+  member_group_ids = ["member groups can't be set for external groups"]
 }`, groupName)
 }

--- a/website/docs/r/identity_group.html.md
+++ b/website/docs/r/identity_group.html.md
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `metadata` - (Optional) A Map of additional metadata to associate with the group.
 
-* `member_group_ids` - (Optional) A list of Group IDs to be assigned as group members.
+* `member_group_ids` - (Optional) A list of Group IDs to be assigned as group members. Not allowed on `external` groups.
 
 * `member_entity_ids` - (Optional) A list of Entity IDs to be assigned as group members. Not allowed on `external` groups.
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #620

This PR fixes removal of `policies` from the `vault_identity_group` resource as described in #620. The same problem existed for both `member_group_ids` and `member_entity_ids`, so I fixed that in this PR as well.

Additionally, I noticed that `member_group_ids` can't be set for external groups (see [vault/identity_store_groups.go#L250](https://github.com/hashicorp/vault/blob/master/vault/identity_store_groups.go#L250)), so this PR now treats them similarly to `member_entity_ids` for external groups.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* Fix removal of `policies`, `member_group_ids`, and `member_entity_ids` from the `vault_identity_group` resource.
```

Output from acceptance testing:

```
$ TESTARGS="--run IdentityGroup" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run IdentityGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    0.580s [no tests to run]
=== RUN   TestDataSourceIdentityGroupName
--- PASS: TestDataSourceIdentityGroupName (0.14s)
=== RUN   TestDataSourceIdentityGroupAlias
--- PASS: TestDataSourceIdentityGroupAlias (0.14s)
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (0.11s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (0.19s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (0.17s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (0.18s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (0.09s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (0.37s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (0.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   1.891s
```
