### PR TITLE
token: revoke expired tokens

### DIFF
--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -318,7 +318,15 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("policies", policies)
 	d.Set("no_parent", resp.Data["orphan"])
-	d.Set("renewable", resp.Data["renewable"])
+
+	// root tokens don't have the renewable key.
+	renewable := resp.Data["renewable"].(*bool)
+	if renewable != nil {
+		d.Set("renewable", *renewable)
+	} else {
+		d.Set("renewable", false)
+	}
+
 	d.Set("display_name", strings.TrimPrefix(resp.Data["display_name"].(string), "token-"))
 	d.Set("num_uses", resp.Data["num_uses"])
 	if _, ok := d.GetOk("pgp_key"); !ok {
@@ -341,14 +349,28 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 
 	expireTimeStr, ok := resp.Data["expire_time"].(string)
 	if !ok {
-		return fmt.Errorf("error expire_time is %T", resp.Data["expire_time"])
-	}
+		// A root token have a nil expire_time as well, but renewable is missing.
+		if renewable != nil {
+			log.Printf("[WARN] Token is expired, revoking and removing from state")
 
-	expireTime, err := time.Parse(time.RFC3339Nano, expireTimeStr)
-	if err != nil {
-		return fmt.Errorf("error parsing expire_time: %s", err)
+			err := client.Auth().Token().RevokeAccessor(id)
+			if err != nil {
+				log.Printf("[WARN] Token %s could not be revoked. %s", id, err)
+			}
+
+			d.SetId("")
+			return nil
+		}
+
+		d.Set("lease_duration", 0)
+	} else {
+		expireTime, err := time.Parse(time.RFC3339Nano, expireTimeStr)
+		if err != nil {
+			return fmt.Errorf("error parsing expire_time: %s", err)
+		}
+
+		d.Set("lease_duration", int(expireTime.Sub(issueTime).Seconds()))
 	}
-	d.Set("lease_duration", int(expireTime.Sub(issueTime).Seconds()))
 
 	if d.Get("renewable").(bool) && tokenCheckLease(d) {
 		if id == "" {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #740

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Expired Vault tokens might still exist and will have `expire_time` set to nil. In that case, they will be revoked (when possible) and removed from the local state. Expired token will then be recreated by Terraform.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
