### PR TITLE
Add resource that supports importing jwt config

### DIFF
--- a/codegen/endpoint_registry.go
+++ b/codegen/endpoint_registry.go
@@ -8,6 +8,9 @@ import "github.com/hashicorp/vault/sdk/framework"
 // IMPORTANT NOTE: To support high quality, only add one
 // endpoint per PR.
 var endpointRegistry = map[string]*additionalInfo{
+	"/auth/jwt/config": {
+		Type: tfTypeResource,
+	},
 	"/transform/alphabet/{name}": {
 		Type: tfTypeResource,
 	},

--- a/generated/resources/auth/jwt/config.go
+++ b/generated/resources/auth/jwt/config.go
@@ -1,0 +1,313 @@
+package jwt
+
+// DO NOT EDIT
+// This code is generated.
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+)
+
+const configEndpoint = "/auth/jwt/config"
+
+func ConfigResource() *schema.Resource {
+	fields := map[string]*schema.Schema{
+		"path": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: `The mount path for a back-end, for example, the path given in "$ vault auth enable -path=my-aws aws".`,
+			StateFunc: func(v interface{}) string {
+				return strings.Trim(v.(string), "/")
+			},
+		},
+		"bound_issuer": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The value against which to match the 'iss' claim in a JWT. Optional.`,
+		},
+		"default_role": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The default role to use if none is provided during login. If not set, a role is required during login.`,
+		},
+		"jwks_ca_pem": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.`,
+		},
+		"jwks_url": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".`,
+		},
+		"jwt_supported_algs": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: `A list of supported signing algorithms. Defaults to RS256.`,
+		},
+		"jwt_validation_pubkeys": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: `A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".`,
+		},
+		"oidc_client_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The OAuth Client ID configured with your OIDC provider.`,
+		},
+		"oidc_client_secret": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: `The OAuth Client Secret configured with your OIDC provider.`,
+		},
+		"oidc_discovery_ca_pem": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The CA certificate or chain of certificates, in PEM format, to use to validate connections to the OIDC Discovery URL. If not set, system certificates are used.`,
+		},
+		"oidc_discovery_url": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `OIDC Discovery URL, without any .well-known component (base path). Cannot be used with "jwks_url" or "jwt_validation_pubkeys".`,
+		},
+		"oidc_response_mode": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The response mode to be used in the OAuth2 request. Allowed values are 'query' and 'form_post'.`,
+		},
+		"oidc_response_types": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: `The response types to request. Allowed values are 'code' and 'id_token'. Defaults to 'code'.`,
+		},
+	}
+	return &schema.Resource{
+		Create: createConfigResource,
+		Update: updateConfigResource,
+		Read:   readConfigResource,
+		Exists: resourceConfigExists,
+		Delete: deleteConfigResource,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: fields,
+	}
+}
+func createConfigResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Get("path").(string)
+	vaultPath := util.ParsePath(path, configEndpoint, d)
+	log.Printf("[DEBUG] Creating %q", vaultPath)
+
+	data := map[string]interface{}{}
+	if v, ok := d.GetOkExists("bound_issuer"); ok {
+		data["bound_issuer"] = v
+	}
+	if v, ok := d.GetOkExists("default_role"); ok {
+		data["default_role"] = v
+	}
+	if v, ok := d.GetOkExists("jwks_ca_pem"); ok {
+		data["jwks_ca_pem"] = v
+	}
+	if v, ok := d.GetOkExists("jwks_url"); ok {
+		data["jwks_url"] = v
+	}
+	if v, ok := d.GetOkExists("jwt_supported_algs"); ok {
+		data["jwt_supported_algs"] = v
+	}
+	if v, ok := d.GetOkExists("jwt_validation_pubkeys"); ok {
+		data["jwt_validation_pubkeys"] = v
+	}
+	if v, ok := d.GetOkExists("oidc_client_id"); ok {
+		data["oidc_client_id"] = v
+	}
+	if v, ok := d.GetOkExists("oidc_client_secret"); ok {
+		data["oidc_client_secret"] = v
+	}
+	if v, ok := d.GetOkExists("oidc_discovery_ca_pem"); ok {
+		data["oidc_discovery_ca_pem"] = v
+	}
+	if v, ok := d.GetOkExists("oidc_discovery_url"); ok {
+		data["oidc_discovery_url"] = v
+	}
+	if v, ok := d.GetOkExists("oidc_response_mode"); ok {
+		data["oidc_response_mode"] = v
+	}
+	if v, ok := d.GetOkExists("oidc_response_types"); ok {
+		data["oidc_response_types"] = v
+	}
+
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return fmt.Errorf("error writing %q: %s", vaultPath, err)
+	}
+	d.SetId(vaultPath)
+	log.Printf("[DEBUG] Wrote %q", vaultPath)
+	return readConfigResource(d, meta)
+}
+
+func readConfigResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Reading %q", vaultPath)
+
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return fmt.Errorf("error reading %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Read %q", vaultPath)
+	if resp == nil {
+		log.Printf("[WARN] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+	pathParams, err := util.PathParameters(configEndpoint, vaultPath)
+	if err != nil {
+		return err
+	}
+	for paramName, paramVal := range pathParams {
+		if err := d.Set(paramName, paramVal); err != nil {
+			return fmt.Errorf("error setting state %q, %q: %s", paramName, paramVal, err)
+		}
+	}
+	if val, ok := resp.Data["bound_issuer"]; ok {
+		if err := d.Set("bound_issuer", val); err != nil {
+			return fmt.Errorf("error setting state key 'bound_issuer': %s", err)
+		}
+	}
+	if val, ok := resp.Data["default_role"]; ok {
+		if err := d.Set("default_role", val); err != nil {
+			return fmt.Errorf("error setting state key 'default_role': %s", err)
+		}
+	}
+	if val, ok := resp.Data["jwks_ca_pem"]; ok {
+		if err := d.Set("jwks_ca_pem", val); err != nil {
+			return fmt.Errorf("error setting state key 'jwks_ca_pem': %s", err)
+		}
+	}
+	if val, ok := resp.Data["jwks_url"]; ok {
+		if err := d.Set("jwks_url", val); err != nil {
+			return fmt.Errorf("error setting state key 'jwks_url': %s", err)
+		}
+	}
+	if val, ok := resp.Data["jwt_supported_algs"]; ok {
+		if err := d.Set("jwt_supported_algs", val); err != nil {
+			return fmt.Errorf("error setting state key 'jwt_supported_algs': %s", err)
+		}
+	}
+	if val, ok := resp.Data["jwt_validation_pubkeys"]; ok {
+		if err := d.Set("jwt_validation_pubkeys", val); err != nil {
+			return fmt.Errorf("error setting state key 'jwt_validation_pubkeys': %s", err)
+		}
+	}
+	if val, ok := resp.Data["oidc_client_id"]; ok {
+		if err := d.Set("oidc_client_id", val); err != nil {
+			return fmt.Errorf("error setting state key 'oidc_client_id': %s", err)
+		}
+	}
+	if val, ok := resp.Data["oidc_client_secret"]; ok {
+		if err := d.Set("oidc_client_secret", val); err != nil {
+			return fmt.Errorf("error setting state key 'oidc_client_secret': %s", err)
+		}
+	}
+	if val, ok := resp.Data["oidc_discovery_ca_pem"]; ok {
+		if err := d.Set("oidc_discovery_ca_pem", val); err != nil {
+			return fmt.Errorf("error setting state key 'oidc_discovery_ca_pem': %s", err)
+		}
+	}
+	if val, ok := resp.Data["oidc_discovery_url"]; ok {
+		if err := d.Set("oidc_discovery_url", val); err != nil {
+			return fmt.Errorf("error setting state key 'oidc_discovery_url': %s", err)
+		}
+	}
+	if val, ok := resp.Data["oidc_response_mode"]; ok {
+		if err := d.Set("oidc_response_mode", val); err != nil {
+			return fmt.Errorf("error setting state key 'oidc_response_mode': %s", err)
+		}
+	}
+	if val, ok := resp.Data["oidc_response_types"]; ok {
+		if err := d.Set("oidc_response_types", val); err != nil {
+			return fmt.Errorf("error setting state key 'oidc_response_types': %s", err)
+		}
+	}
+	return nil
+}
+
+func updateConfigResource(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Updating %q", vaultPath)
+
+	data := map[string]interface{}{}
+	if raw, ok := d.GetOk("bound_issuer"); ok {
+		data["bound_issuer"] = raw
+	}
+	if raw, ok := d.GetOk("default_role"); ok {
+		data["default_role"] = raw
+	}
+	if raw, ok := d.GetOk("jwks_ca_pem"); ok {
+		data["jwks_ca_pem"] = raw
+	}
+	if raw, ok := d.GetOk("jwks_url"); ok {
+		data["jwks_url"] = raw
+	}
+	if raw, ok := d.GetOk("jwt_supported_algs"); ok {
+		data["jwt_supported_algs"] = raw
+	}
+	if raw, ok := d.GetOk("jwt_validation_pubkeys"); ok {
+		data["jwt_validation_pubkeys"] = raw
+	}
+	if raw, ok := d.GetOk("oidc_client_id"); ok {
+		data["oidc_client_id"] = raw
+	}
+	if raw, ok := d.GetOk("oidc_client_secret"); ok {
+		data["oidc_client_secret"] = raw
+	}
+	if raw, ok := d.GetOk("oidc_discovery_ca_pem"); ok {
+		data["oidc_discovery_ca_pem"] = raw
+	}
+	if raw, ok := d.GetOk("oidc_discovery_url"); ok {
+		data["oidc_discovery_url"] = raw
+	}
+	if raw, ok := d.GetOk("oidc_response_mode"); ok {
+		data["oidc_response_mode"] = raw
+	}
+	if raw, ok := d.GetOk("oidc_response_types"); ok {
+		data["oidc_response_types"] = raw
+	}
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Updated %q", vaultPath)
+	return readConfigResource(d, meta)
+}
+
+func deleteConfigResource(_ *schema.ResourceData, _ interface{}) error {
+	// Terraform requires the delete is implemented whenever create is implemented,
+	// but this endpoint doesn't support delete. Thus, we've simply stubbed out delete
+	// here.
+	return nil
+}
+
+func resourceConfigExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Checking if %q exists", vaultPath)
+
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return true, fmt.Errorf("error checking if %q exists: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Checked if %q exists", vaultPath)
+	return resp != nil, nil
+}

--- a/generated/resources/auth/jwt/config_test.go
+++ b/generated/resources/auth/jwt/config_test.go
@@ -1,0 +1,77 @@
+package jwt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-vault/schema"
+	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/terraform-providers/terraform-provider-vault/vault"
+)
+
+var configTestProvider = func() *schema.Provider {
+	p := schema.NewProvider(vault.Provider())
+	p.RegisterResource("vault_auth_backend", vault.AuthBackendResource())
+	p.RegisterResource("vault_auth_jwt_config", ConfigResource())
+	return p
+}()
+
+func TestConfig(t *testing.T) {
+	path := acctest.RandomWithPrefix("jwt")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { util.TestAccPreCheck(t) },
+		Providers: map[string]terraform.ResourceProvider{
+			"vault": configTestProvider.ResourceProvider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: basicConfig(path, "https://myco.auth0.com/", "m5i8bj3iofytj", "f4ubv72nfiu23hnsj", "demo"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "path", path),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "oidc_discovery_url", "https://myco.auth0.com/"),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "oidc_client_id", "m5i8bj3iofytj"),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "oidc_client_secret", "f4ubv72nfiu23hnsj"),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "default_role", "demo"),
+				),
+			},
+			{
+				Config: basicConfig(path, "https://myco.auth0.com/", "b5i8bj3iofytj", "b4ubv72nfiu23hnsj", "demo1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "path", path),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "oidc_discovery_url", "https://myco.auth0.com/"),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "oidc_client_id", "b5i8bj3iofytj"),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "oidc_client_secret", "b4ubv72nfiu23hnsj"),
+					resource.TestCheckResourceAttr("vault_auth_jwt_config.jwt", "default_role", "demo1"),
+				),
+			},
+			{
+				ResourceName:      "vault_auth_jwt_config.jwt",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// We ignore that the oidc_client_secret is not returned because, since
+				// it's sensitive, Vault doesn't return it even when it's set.
+				ImportStateVerifyIgnore: []string{"oidc_client_secret"},
+			},
+		},
+	})
+}
+
+func basicConfig(path, oidcDiscURL, oidcClientID, oidcClientSecret, defaultRole string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "mount_jwt" {
+  path = "%s"
+  type = "jwt"
+}
+resource "vault_auth_jwt_config" "jwt" {
+  path = vault_auth_backend.mount_jwt.path
+  oidc_discovery_url = "%s"
+  oidc_client_id = "%s"
+  oidc_client_secret = "%s"
+  default_role = "%s"
+}
+`, path, oidcDiscURL, oidcClientID, oidcClientSecret, defaultRole)
+}

--- a/generated/resources/transform/alphabet/name.go
+++ b/generated/resources/transform/alphabet/name.go
@@ -29,12 +29,12 @@ func NameResource() *schema.Resource {
 		"alphabet": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "A string of characters that contains the alphabet set.",
+			Description: `A string of characters that contains the alphabet set.`,
 		},
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The name of the alphabet.",
+			Description: `The name of the alphabet.`,
 			ForceNew:    true,
 		},
 	}
@@ -109,8 +109,8 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
 	data := map[string]interface{}{}
-	if d.HasChange("alphabet") {
-		data["alphabet"] = d.Get("alphabet")
+	if raw, ok := d.GetOk("alphabet"); ok {
+		data["alphabet"] = raw
 	}
 	if _, err := client.Logical().Write(vaultPath, data); err != nil {
 		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)

--- a/generated/resources/transform/role/name.go
+++ b/generated/resources/transform/role/name.go
@@ -29,14 +29,14 @@ func NameResource() *schema.Resource {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The name of the role.",
+			Description: `The name of the role.`,
 			ForceNew:    true,
 		},
 		"transformations": {
 			Type:        schema.TypeList,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Optional:    true,
-			Description: "A comma separated string or slice of transformations to use.",
+			Description: `A comma separated string or slice of transformations to use.`,
 		},
 	}
 	return &schema.Resource{
@@ -110,8 +110,8 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
 	data := map[string]interface{}{}
-	if d.HasChange("transformations") {
-		data["transformations"] = d.Get("transformations")
+	if raw, ok := d.GetOk("transformations"); ok {
+		data["transformations"] = raw
 	}
 	if _, err := client.Logical().Write(vaultPath, data); err != nil {
 		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -29,23 +29,23 @@ func NameResource() *schema.Resource {
 		"alphabet": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The alphabet to use for this template. This is only used during FPE transformations.",
+			Description: `The alphabet to use for this template. This is only used during FPE transformations.`,
 		},
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The name of the template.",
+			Description: `The name of the template.`,
 			ForceNew:    true,
 		},
 		"pattern": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The pattern used for matching. Currently, only regular expression pattern is supported.",
+			Description: `The pattern used for matching. Currently, only regular expression pattern is supported.`,
 		},
 		"type": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The pattern type to use for match detection. Currently, only regex is supported.",
+			Description: `The pattern type to use for match detection. Currently, only regex is supported.`,
 		},
 	}
 	return &schema.Resource{
@@ -135,14 +135,14 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
 	data := map[string]interface{}{}
-	if d.HasChange("alphabet") {
-		data["alphabet"] = d.Get("alphabet")
+	if raw, ok := d.GetOk("alphabet"); ok {
+		data["alphabet"] = raw
 	}
-	if d.HasChange("pattern") {
-		data["pattern"] = d.Get("pattern")
+	if raw, ok := d.GetOk("pattern"); ok {
+		data["pattern"] = raw
 	}
-	if d.HasChange("type") {
-		data["type"] = d.Get("type")
+	if raw, ok := d.GetOk("type"); ok {
+		data["type"] = raw
 	}
 	if _, err := client.Logical().Write(vaultPath, data); err != nil {
 		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)

--- a/generated/resources/transform/transformation/name.go
+++ b/generated/resources/transform/transformation/name.go
@@ -30,40 +30,40 @@ func NameResource() *schema.Resource {
 			Type:        schema.TypeList,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Optional:    true,
-			Description: "The set of roles allowed to perform this transformation.",
+			Description: `The set of roles allowed to perform this transformation.`,
 		},
 		"masking_character": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The character used to replace data when in masking mode",
+			Description: `The character used to replace data when in masking mode`,
 		},
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The name of the transformation.",
+			Description: `The name of the transformation.`,
 			ForceNew:    true,
 		},
 		"template": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The name of the template to use.",
+			Description: `The name of the template to use.`,
 		},
 		"templates": {
 			Type:        schema.TypeList,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Optional:    true,
 			Computed:    true,
-			Description: "Templates configured for transformation.",
+			Description: `Templates configured for transformation.`,
 		},
 		"tweak_source": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The source of where the tweak value comes from. Only valid when in FPE mode.",
+			Description: `The source of where the tweak value comes from. Only valid when in FPE mode.`,
 		},
 		"type": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The type of transformation to perform.",
+			Description: `The type of transformation to perform.`,
 		},
 	}
 	return &schema.Resource{
@@ -174,20 +174,20 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
 	data := map[string]interface{}{}
-	if d.HasChange("allowed_roles") {
-		data["allowed_roles"] = d.Get("allowed_roles")
+	if raw, ok := d.GetOk("allowed_roles"); ok {
+		data["allowed_roles"] = raw
 	}
-	if d.HasChange("masking_character") {
-		data["masking_character"] = d.Get("masking_character")
+	if raw, ok := d.GetOk("masking_character"); ok {
+		data["masking_character"] = raw
 	}
-	if d.HasChange("template") {
-		data["template"] = d.Get("template")
+	if raw, ok := d.GetOk("template"); ok {
+		data["template"] = raw
 	}
-	if d.HasChange("tweak_source") {
-		data["tweak_source"] = d.Get("tweak_source")
+	if raw, ok := d.GetOk("tweak_source"); ok {
+		data["tweak_source"] = raw
 	}
-	if d.HasChange("type") {
-		data["type"] = d.Get("type")
+	if raw, ok := d.GetOk("type"); ok {
+		data["type"] = raw
 	}
 	if _, err := client.Logical().Write(vaultPath, data); err != nil {
 		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)

--- a/generated/terraform_registry.go
+++ b/generated/terraform_registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode"
 	"github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode"
+	"github.com/terraform-providers/terraform-provider-vault/generated/resources/auth/jwt"
 	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet"
 	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role"
 	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template"
@@ -18,6 +19,7 @@ var DataSourceRegistry = map[string]*schema.Resource{
 
 // Please alphabetize.
 var ResourceRegistry = map[string]*schema.Resource{
+	"vault_auth_jwt_config":               jwt.ConfigResource(),
 	"vault_transform_alphabet_name":       alphabet.NameResource(),
 	"vault_transform_role_name":           role.NameResource(),
 	"vault_transform_template_name":       template.NameResource(),

--- a/util/util.go
+++ b/util/util.go
@@ -202,13 +202,26 @@ func SliceRemoveIfPresent(list []interface{}, search interface{}) []interface{} 
 //   - parameters will include path parameters
 func ParsePath(userSuppliedPath, endpoint string, d *schema.ResourceData) string {
 	fields := strings.Split(endpoint, "/")
-	// The second field should be the one the user supplied rather
+	if fields[0] == "" {
+		// There was a leading slash that should be trimmed.
+		fields = fields[1:]
+	}
+	isAuthPath := false
+	if fields[0] == "auth" {
+		fields = fields[1:]
+		isAuthPath = true
+	}
+
+	// The first field should be the one the user supplied rather
 	// than the default one shown.
-	fields[1] = userSuppliedPath
+	fields[0] = userSuppliedPath
 
 	// Since endpoints start with a "/", the first field is always
 	// an extraneous "" and should be dropped.
-	recomprised := "/" + strings.Join(fields[1:], "/")
+	recomprised := "/" + strings.Join(fields, "/")
+	if isAuthPath {
+		recomprised = "/auth" + recomprised
+	}
 
 	// For a recomprised string like "/my-transform/role/{name}",
 	// this will return the fields of "/transform/role/" and

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -149,14 +149,49 @@ func TestSliceRemoveIfPresent_struct(t *testing.T) {
 }
 
 func TestParsePath(t *testing.T) {
-	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
-		"name": {Type: schema.TypeString},
-	}, map[string]interface{}{
-		"name": "foo",
-	})
-	result := ParsePath("my/transform/hello", "/transform/role/{name}", d)
-	if result != "/my/transform/hello/role/foo" {
-		t.Fatalf("received unexpected result: %s", result)
+	testCases := []struct {
+		inputUserSuppliedPath, inputEndpoint string
+		inputData                            *schema.ResourceData
+		expected                             string
+	}{
+		{
+			inputUserSuppliedPath: "my/transform/hello",
+			inputEndpoint:         "/transform/role/{name}",
+			inputData: schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+				"name": {Type: schema.TypeString},
+			}, map[string]interface{}{
+				"name": "foo",
+			}),
+			expected: "/my/transform/hello/role/foo",
+		},
+		{
+			inputUserSuppliedPath: "jwt-1914071788362821795",
+			inputEndpoint:         "/auth/jwt/config",
+			inputData:             &schema.ResourceData{},
+			expected:              "/auth/jwt-1914071788362821795/config",
+		},
+		{
+			inputUserSuppliedPath: "accounting-transit",
+			inputEndpoint:         "/transit/export/{type}/{name}/{version}",
+			inputData: schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+				"name":    {Type: schema.TypeString},
+				"type":    {Type: schema.TypeString},
+				"version": {Type: schema.TypeString},
+			}, map[string]interface{}{
+				"version": "1",
+				"type":    "encryption-key",
+				"name":    "my-key",
+			}),
+			expected: "/accounting-transit/export/encryption-key/my-key/1",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.inputUserSuppliedPath, func(t *testing.T) {
+			actual := ParsePath(testCase.inputUserSuppliedPath, testCase.inputEndpoint, testCase.inputData)
+			if actual != testCase.expected {
+				t.Fatalf("expected %q, received %q", testCase.expected, actual)
+			}
+		})
 	}
 }
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -249,7 +249,7 @@ var (
 			},
 		},
 		"vault_auth_backend": {
-			Resource:      authBackendResource(),
+			Resource:      AuthBackendResource(),
 			PathInventory: []string{"/sys/auth/{path}"},
 		},
 		"vault_token": {

--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
-func authBackendResource() *schema.Resource {
+func AuthBackendResource() *schema.Resource {
 	return &schema.Resource{
 		SchemaVersion: 1,
 

--- a/website/docs/generated/resources/auth/jwt/config.md
+++ b/website/docs/generated/resources/auth/jwt/config.md
@@ -1,0 +1,51 @@
+---
+layout: "vault"
+page_title: "Vault: vault_auth_jwt_config resource"
+sidebar_current: "docs-vault-resource-auth-jwt-config"
+description: |-
+  "/auth/jwt/config"
+---
+
+# vault\_auth\_jwt\_config
+
+This resource supports the "/auth/jwt/config" Vault endpoint.
+
+It configures the validation information to be used globally across all roles. 
+One (and only one) of oidc_discovery_url and jwt_validation_pubkeys must be set,
+which will be enforced by the Vault API.
+
+Delete is not supported at this endpoint, and so it's not possible to support
+it in this resource.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "mount_jwt" {
+  path = "jwt"
+  type = "jwt"
+}
+resource "vault_auth_jwt_config" "jwt" {
+  path = vault_auth_backend.mount_jwt.path
+  oidc_discovery_url = "https://myco.auth0.com/"
+  oidc_client_id = "m5i8bj3iofytj"
+  oidc_client_secret = "f4ubv72nfiu23hnsj"
+  default_role = "demo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `bound_issuer` - (Optional) The value against which to match the 'iss' claim in a JWT. Optional.
+* `default_role` - (Optional) The default role to use if none is provided during login. If not set, a role is required during login.
+* `jwks_ca_pem` - (Optional) The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.
+* `jwks_url` - (Optional) JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
+* `jwt_supported_algs` - (Optional) A list of supported signing algorithms. Defaults to RS256.
+* `jwt_validation_pubkeys` - (Optional) A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".
+* `oidc_client_id` - (Optional) The OAuth Client ID configured with your OIDC provider.
+* `oidc_client_secret` - (Optional) The OAuth Client Secret configured with your OIDC provider.
+* `oidc_discovery_ca_pem` - (Optional) The CA certificate or chain of certificates, in PEM format, to use to validate connections to the OIDC Discovery URL. If not set, system certificates are used.
+* `oidc_discovery_url` - (Optional) OIDC Discovery URL, without any .well-known component (base path). Cannot be used with "jwks_url" or "jwt_validation_pubkeys".
+* `oidc_response_mode` - (Optional) The response mode to be used in the OAuth2 request. Allowed values are 'query' and 'form_post'.
+* `oidc_response_types` - (Optional) The response types to request. Allowed values are 'code' and 'id_token'. Defaults to 'code'.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -249,6 +249,10 @@
                             <a href="/docs/providers/vault/r/identity_oidc_role.html">vault_identity_oidc_role</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-auth-jwt-config") %>>
+                            <a href="/docs/providers/vault/generated/resources/auth/jwt/config.html">vault_auth_jwt_config</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-jwt-auth-backend") %>>
                             <a href="/docs/providers/vault/r/jwt_auth_backend.html">vault_jwt_auth_backend</a>
                         </li>


### PR DESCRIPTION
Closes #295

This PR adds a resource that supports importing a pre-existing jwt config for the "auth/jwt/config" endpoint (as well as all other operations supported on that endpoint). Since the `vault_auth_backend` already supports importing, this means that any user will be able to import both a pre-existing jwt backend and its config.

The approach of creating a new resource was chosen because adding import support to `vault_jwt_auth_backend` was not trivial. That resource hits two combined endpoints - the auth mount endpoint and the jwt config endpoint. When adding import, it was not possible to support the "description" and "type" fields because they are not passed in with the data, nor are they both returned by any Vault endpoint. Perhaps there is some workaround that I don't know, but it seemed better to use a cleaner model of one resource per endpoint.