### PR TITLE
Remove default empty vector for bound_audience

### DIFF
--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -339,8 +339,6 @@ func jwtAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error setting bound_audiences in state: %s", err)
 		}
-	} else {
-		d.Set("bound_audiences", make([]string, 0))
 	}
 
 	d.Set("user_claim", resp.Data["user_claim"].(string))


### PR DESCRIPTION
Remove default empty vector for bound_audience cuz is necessary nil to avoid aud check if a jwt don't contain it wich is the gitlab jwt case.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

Hi guys this is the case if hay create this role by hand:
```
vault write auth/jwt/role/gitlab - <<EOF
{
  "role_type": "jwt",
  "policies": ["default", "gitlab"],
  "token_explicit_max_ttl": 60,
  "user_claim": "user_email",
  "bound_claims_type": "glob",
  "bound_claims": {
    "project_path": "infrastructure/vault",
    "ref_type": "branch"
  }
}
EOF
```
the config will be:
```
vault read auth/jwt/role/gitlab
Key                        Value
---                        -----
allowed_redirect_uris      <nil>
bound_audiences            <nil>
bound_claims               map[project_path:infrastructure/vault ref_type:branch]
bound_subject              n/a
claim_mappings             <nil>
clock_skew_leeway          0
expiration_leeway          0
groups_claim               n/a
not_before_leeway          0
oidc_scopes                <nil>
role_type                  jwt
token_bound_cidrs          []
token_explicit_max_ttl     1m
token_max_ttl              0s
token_no_default_policy    false
token_num_uses             0
token_period               0s
token_policies             [default gitlab]
token_ttl                  0s
token_type                 default
user_claim                 email_user
verbose_oidc_logging       false
```

by the other hand if I create this with this provider
```
resource "vault_jwt_auth_backend_role" "gitlab_role" {
  backend        = vault_jwt_auth_backend.jwt.path
  role_type      = "jwt"
  role_name      = "gitlab"
  token_policies = ["default", "gitlab"]
  bound_claims = {
    project_path = "infrastructure/vault"
    ref_type     = "branch"
  }
  token_explicit_max_ttl = 60
  user_claim             = "email_user"
}
```

the output will be:

```
vault read auth/jwt/role/gitlab
Key                        Value
---                        -----
allowed_redirect_uris      <nil>
bound_audiences            []
bound_claims               map[project_path:infrastructure/vault ref_type:branch]
bound_subject              n/a
claim_mappings             <nil>
clock_skew_leeway          0
expiration_leeway          0
groups_claim               n/a
not_before_leeway          0
oidc_scopes                <nil>
role_type                  jwt
token_bound_cidrs          []
token_explicit_max_ttl     1m
token_max_ttl              0s
token_no_default_policy    false
token_num_uses             0
token_period               0s
token_policies             [default gitlab]
token_ttl                  0s
token_type                 default
user_claim                 email_user
verbose_oidc_logging       false
```
what's the problem with this default empty vector:
vault will try to validate the bound_audiences cuz is not <nil>
and in the case of gitlab jwt configured automatically set in any job as CI_JOB_JWT which wont contain the aud param the whole integration fails.


