### PR TITLE
jwt_auth_backend: fix oidc_client_secret storage

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -241,6 +241,18 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("accessor", backend.Accessor)
 	for _, configOption := range matchingJwtMountConfigOptions {
+		// The oidc_client_secret is sensitive so it will not be in the response
+		// Our options are to always assume it must be updated or always assume it
+		//  matches our current state. This assumes it always matches our current
+		//  state so that HasChange isn't always true and we store the last applied
+		//  secret in the state file to know if the new secret should be applied.
+		// This does intentionally miss the edge case where the oidc_client_secret
+		//  is updated without Terraform. Since we cannot know the current state
+		//  of the oidc_secret, Terraform will show no changes necessary even if
+		//  the actual value in Vault does not match the value in state.
+		if configOption == "oidc_client_secret" {
+			continue
+		}
 		d.Set(configOption, config.Data[configOption])
 	}
 

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -63,6 +63,7 @@ func TestAccJWTAuthBackend_OIDC(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_discovery_url", "https://myco.auth0.com/"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "bound_issuer", "api://default"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_client_id", "client"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_client_secret", "secret"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "type", "oidc"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "default_role", "api"),
 				),
@@ -155,12 +156,6 @@ resource "vault_jwt_auth_backend" "oidc" {
   path = "%s"
   type = "oidc"
   default_role = "api"
-  lifecycle {
-	ignore_changes = [
-     # Ignore changes to odic_clie_secret inside the tests
-     "oidc_client_secret"
-    ]
-  }
 }
 `, path)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #449 

The `oidc_client_secret` is sensitive so it will not be in the response from Vault.

Our options are to a) always assume it must be updated (current) or b) always assume it matches what we last set it to (this change). This assumes it always matches what we last set it to so that `HasChange` isn't always true.

This does intentionally miss the edge case where the `oidc_client_secret` is updated without using Terraform. Since we cannot know the current state of `oidc_client_secret`, Terraform will show no changes are required even if the actual value in Vault does not match the current value in state.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Store `oidc_client_secret` value correctly for `jwt_auth_backend` to fix bug where `oidc_client_secret` always appears to require an update. 
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccJWTAuthBackend_OIDC'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccJWTAuthBackend_OIDC -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccJWTAuthBackend_OIDC
--- PASS: TestAccJWTAuthBackend_OIDC (0.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.186s
```
