### PR TITLE
Jwt auth import

### DIFF
--- a/vault/auth_mount.go
+++ b/vault/auth_mount.go
@@ -95,6 +95,16 @@ func authMountTune(client *api.Client, path string, configured interface{}) erro
 	return nil
 }
 
+func authMountTuneGet(client *api.Client, path string) (map[string]interface{}, error) {
+	tune, err := client.Sys().MountConfig(path)
+	if err != nil {
+		log.Printf("[ERROR] Error when reading tune config from path '%q/tune': %s", path, err)
+		return nil, err
+	}
+
+	return flattenAuthMethodTune(tune), nil
+}
+
 func authMountDisable(client *api.Client, path string) error {
 	log.Printf("[DEBUG] Disabling auth mount config from '%q'", path)
 	err := client.Sys().DisableAuth(path)

--- a/vault/auth_mount.go
+++ b/vault/auth_mount.go
@@ -98,7 +98,7 @@ func authMountTune(client *api.Client, path string, configured interface{}) erro
 func authMountTuneGet(client *api.Client, path string) (map[string]interface{}, error) {
 	tune, err := client.Sys().MountConfig(path)
 	if err != nil {
-		log.Printf("[ERROR] Error when reading tune config from path '%q/tune': %s", path, err)
+		log.Printf("[ERROR] Error when reading tune config from path %q: %s", path+"/tune", err)
 		return nil, err
 	}
 

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -221,13 +221,11 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Reading github auth tune from '%q/tune'", path)
-	tune, err := client.Sys().MountConfig(path)
+	rawTune, err := authMountTuneGet(client, path)
 	if err != nil {
-		log.Printf("[ERROR] Error when reading tune config from path '%q/tune': %s", path, err)
-		return err
+		return fmt.Errorf("error reading tune information from Vault: %s", err)
 	}
 
-	rawTune := flattenAuthMethodTune(tune)
 	if err := d.Set("tune", []map[string]interface{}{rawTune}); err != nil {
 		log.Printf("[ERROR] Error when setting tune config from path '%q/tune' to state: %s", path, err)
 		return err

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -12,6 +12,9 @@ import (
 
 func jwtAuthBackendResource() *schema.Resource {
 	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Create: jwtAuthBackendWrite,
 		Delete: jwtAuthBackendDelete,
 		Read:   jwtAuthBackendRead,
@@ -201,6 +204,15 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	path := getJwtPath(d)
 	log.Printf("[DEBUG] Reading auth %s from Vault", path)
 
+	if path == "" {
+		// In v2.11.0 and prior, path was not read and so not set in the state.
+		// if path is empty here, we're likely in a import scenario where path is
+		// empty. Because path is used as the ID in the resource, if path is empty
+		// use the ID value
+		path = d.Id()
+	}
+	d.Set("path", path)
+
 	backend, err := getJwtAuthBackendIfPresent(client, path)
 
 	if err != nil {
@@ -225,9 +237,21 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	d.Set("type", backend.Type)
+
 	d.Set("accessor", backend.Accessor)
 	for _, configOption := range matchingJwtMountConfigOptions {
 		d.Set(configOption, config.Data[configOption])
+	}
+
+	log.Printf("[DEBUG] Reading jwt auth tune from '%q/tune'", path)
+	rawTune, err := authMountTuneGet(client, "auth/"+path)
+	if err != nil {
+		return fmt.Errorf("error reading tune information from Vault: %s", err)
+	}
+	if err := d.Set("tune", []map[string]interface{}{rawTune}); err != nil {
+		log.Printf("[ERROR] Error when setting tune config from path '%q/tune' to state: %s", path, err)
+		return err
 	}
 
 	return nil

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -250,7 +250,7 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading tune information from Vault: %s", err)
 	}
 	if err := d.Set("tune", []map[string]interface{}{rawTune}); err != nil {
-		log.Printf("[ERROR] Error when setting tune config from path '%q/tune' to state: %s", path, err)
+		log.Printf("[ERROR] Error when setting tune config from path %q to state: %s", path+"/tune", err)
 		return err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-vault/issues/295 . This resource uses `path` for the ID, but because(?) it's a `ForceNew` attribute it was never read from the API. Attempting to import uses an ID input, but the path that was used for the READ operation was empty so no data was found. This will set the path to the `Id()` value if `path` is not found, so the READ should succeed. 

In order to import without changes needed, this PR also sets `tune` and `type` information. 


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates OR Closes #295

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
- Update jwt_auth_backed to enable importing existing backends. 
- Update jwt_auth_backed to read `type` and `tune` information
```

Output from acceptance testing:

```
[terraform-provider-vault][jwt_auth_import](4)$ make testacc TESTARGS='-run=TestAccJWT'                                                                                         ✭
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccJWT -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestAccJWTAuthBackendRole_import
--- PASS: TestAccJWTAuthBackendRole_import (0.14s)
=== RUN   TestAccJWTAuthBackendRole_basic
--- PASS: TestAccJWTAuthBackendRole_basic (0.11s)
=== RUN   TestAccJWTAuthBackendRole_update
--- PASS: TestAccJWTAuthBackendRole_update (0.18s)
=== RUN   TestAccJWTAuthBackendRole_full
--- PASS: TestAccJWTAuthBackendRole_full (0.11s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (0.83s)
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (0.19s)
=== RUN   TestAccJWTAuthBackendRole_fullDeprecated
--- PASS: TestAccJWTAuthBackendRole_fullDeprecated (0.19s)
=== RUN   TestAccJWTAuthBackend
--- PASS: TestAccJWTAuthBackend (0.96s)
=== RUN   TestAccJWTAuthBackend_OIDC
--- PASS: TestAccJWTAuthBackend_OIDC (0.22s)
=== RUN   TestAccJWTAuthBackend_negative
--- PASS: TestAccJWTAuthBackend_negative (0.03s)
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (0.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   3.773s


...
```
