### PR TITLE
vault_ssh_secret_backend_role: add algorithm_signer argument

### DIFF
--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -110,7 +110,7 @@ func sshSecretBackendRoleResource() *schema.Resource {
 			"algorithm_signer": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ssh-rsa",
+				Computed: true,
 			},
 			"max_ttl": {
 				Type:     schema.TypeString,
@@ -256,10 +256,7 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("allowed_user_key_lengths", role.Data["allowed_user_key_lengths"])
 	d.Set("max_ttl", role.Data["max_ttl"])
 	d.Set("ttl", role.Data["ttl"])
-
-	if v, ok := role.Data["algorithm_signer"]; ok {
-		d.Set("algorithm_signer", v.(string))
-	}
+	d.Set("algorithm_signer", role.Data["algorithm_signer"])
 
 	return nil
 }

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -107,6 +107,11 @@ func sshSecretBackendRoleResource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
+			"algorithm_signer": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ssh-rsa",
+			},
 			"max_ttl": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -178,6 +183,10 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 		data["allowed_user_key_lengths"] = v
 	}
 
+	if v, ok := d.GetOk("algorithm_signer"); ok {
+		data["algorithm_signer"] = v.(string)
+	}
+
 	if v, ok := d.GetOk("max_ttl"); ok {
 		data["max_ttl"] = v.(string)
 	}
@@ -247,6 +256,10 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("allowed_user_key_lengths", role.Data["allowed_user_key_lengths"])
 	d.Set("max_ttl", role.Data["max_ttl"])
 	d.Set("ttl", role.Data["ttl"])
+
+	if v, ok := role.Data["algorithm_signer"]; ok {
+		d.Set("algorithm_signer", v.(string))
+	}
 
 	return nil
 }

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -38,7 +38,7 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.%", "0"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", "ssh-rsa"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "0"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "0"),
 				),

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -38,6 +38,7 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.%", "0"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", "ssh-rsa"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "0"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "0"),
 				),
@@ -62,6 +63,7 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.rsa", "1"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", "rsa-sha2-256"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "86400"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "43200"),
 				),
@@ -120,6 +122,7 @@ func TestAccSSHSecretBackendRole_import(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.rsa", "1"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", "rsa-sha2-256"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "86400"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "43200"),
 				),
@@ -193,6 +196,7 @@ resource "vault_ssh_secret_backend_role" "test_role" {
 	key_id_format            = "{{role_name}}-test"
 	key_type                 = "ca"
 	allowed_user_key_lengths = { "rsa" = 1 }
+	algorithm_signer         = "rsa-sha2-256"
 	max_ttl                  = "86400"
 	ttl                      = "43200"
 }

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `key_id_format` - (Optional) Specifies a custom format for the key id of a signed certificate.
 
+* `algorithm_signer` - (Optional) When supplied, this value specifies a signing algorithm for the key. Possible values: ssh-rsa, rsa-sha2-256, rsa-sha2-512.
+
 * `allowed_user_key_lengths` - (Optional) Specifies a map of ssh key types and their expected sizes which are allowed to be signed by the CA type.
 
 * `max_ttl` - (Optional) Specifies the maximum Time To Live value.


### PR DESCRIPTION
The `algorithm_signer` argument was introduced in Vault 1.4.3. See also https://github.com/hashicorp/vault/pull/9096.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


###  Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
resource/vault_ssh_secret_backend_role: Support new `algorithm_signer` argument
```

### Output from acceptance testing:

```
$ TESTARGS="--run SSHSecretBackendRole" make testacc
...
=== RUN   TestAccSSHSecretBackendRole_basic
--- PASS: TestAccSSHSecretBackendRole_basic (0.27s)
=== RUN   TestAccSSHSecretBackendRoleOTP_basic
--- PASS: TestAccSSHSecretBackendRoleOTP_basic (0.16s)
=== RUN   TestAccSSHSecretBackendRole_import
--- PASS: TestAccSSHSecretBackendRole_import (0.18s)
...
```
