### PR TITLE
Do not use provider specific AWS region for aws_secret_backend

### DIFF
--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -126,9 +126,6 @@ func awsSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Wrote root credentials to %q", path+"/config/root")
 	d.SetPartial("access_key")
 	d.SetPartial("secret_key")
-	if region == "" {
-		d.Set("region", "us-east-1")
-	}
 	d.SetPartial("region")
 	d.Partial(false)
 

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -28,7 +28,7 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "max_lease_ttl_seconds", "86400"),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", accessKey),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", secretKey),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-east-1"),
+					resource.TestCheckNoResourceAttr("vault_aws_secret_backend.test", "region"),
 				),
 			},
 			{

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -45,7 +45,7 @@ overwrite the previously stored values. With versions of Vault newer than
 `access_key` will be detected and corrected, but drifts on the `secret_key`
 will not.
 
-* `region` - (Optional) The AWS region for API calls. Defaults to `us-east-1`.
+* `region` - (Optional) The AWS region for API calls.
 
 ~> **Important** The same limitation noted above for the `access_key` parameter
 also applies to the `region` parameter. Vault versions 1.2.3 and older will not


### PR DESCRIPTION
In cases where aws_secret_backend gets called to updated an AWS secret
backend config and a region is not specified `us-east-1` was getting set
in the request to Vault overriding any AWS_REGION or AWS_DEFAULT_REGION
configuration that may exist.

Fixes #817