### PR TITLE
Revert PR (#832)

### DIFF
--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -155,17 +155,9 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 	d.Set("lease_start_time", time.Now().Format(time.RFC3339))
 	d.Set("lease_renewable", secret.Renewable)
 
-	rootPath := backend + "/config/root"
-	regionData, err := client.Logical().Read(rootPath)
-	if err != nil {
-		return fmt.Errorf("error reading from Vault: %s", err)
-	}
-	region := regionData.Data["region"].(string)
-
 	awsConfig := &aws.Config{
 		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, securityToken),
 		HTTPClient:  cleanhttp.DefaultClient(),
-		Region:      &region,
 	}
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {

--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -19,21 +19,19 @@ import (
 func TestAccDataSourceAWSAccessCredentials_basic(t *testing.T) {
 	mountPath := acctest.RandomWithPrefix("tf-test-aws")
 	accessKey, secretKey := getTestAWSCreds(t)
-	region := getTestAWSRegion(t)
-
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSAccessCredentialsConfig_basic(mountPath, accessKey, secretKey, region),
+				Config: testAccDataSourceAWSAccessCredentialsConfig_basic(mountPath, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
 					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
 					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "security_token", ""),
 					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "creds"),
 					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
-					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(region),
+					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(),
 				),
 			},
 		},
@@ -43,7 +41,6 @@ func TestAccDataSourceAWSAccessCredentials_basic(t *testing.T) {
 func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 	mountPath := acctest.RandomWithPrefix("aws")
 	accessKey, secretKey := getTestAWSCreds(t)
-	region := getTestAWSRegion(t)
 
 	type testCase struct {
 		config string
@@ -57,7 +54,6 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 					description = "Obtain AWS credentials."
 					access_key = "%s"
 					secret_key = "%s"
-					region = "%s"
 				}
 				
 				resource "vault_aws_secret_backend_role" "role" {
@@ -71,7 +67,7 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 					backend = "${vault_aws_secret_backend.aws.path}"
 					role = "${vault_aws_secret_backend_role.role.name}"
 					type = "sts"
-				}`, mountPath, accessKey, secretKey, region),
+				}`, mountPath, accessKey, secretKey),
 		},
 		"sts with role_arn": {
 			config: fmt.Sprintf(`
@@ -80,7 +76,6 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 					description = "Obtain AWS credentials."
 					access_key = "%s"
 					secret_key = "%s"
-					region = "%s"
 				}
 				
 				resource "vault_aws_secret_backend_role" "role" {
@@ -95,7 +90,7 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 					role     = "${vault_aws_secret_backend_role.role.name}"
 					type     = "sts"
 					role_arn = "arn:aws:iam::012345678901:role/foobar"
-				}`, mountPath, accessKey, secretKey, region),
+				}`, mountPath, accessKey, secretKey),
 		},
 	}
 
@@ -113,7 +108,7 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 							resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "security_token"),
 							resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
 							resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
-							testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(region),
+							testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(),
 						),
 					},
 				},
@@ -122,14 +117,13 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 	}
 }
 
-func testAccDataSourceAWSAccessCredentialsConfig_basic(mountPath, accessKey, secretKey, region string) string {
+func testAccDataSourceAWSAccessCredentialsConfig_basic(mountPath, accessKey, secretKey string) string {
 	return fmt.Sprintf(`
 resource "vault_aws_secret_backend" "aws" {
     path = "%s"
     description = "Obtain AWS credentials."
     access_key = "%s"
     secret_key = "%s"
-	region = "%s"
 }
 
 resource "vault_aws_secret_backend_role" "role" {
@@ -143,10 +137,10 @@ data "vault_aws_access_credentials" "test" {
     backend = "${vault_aws_secret_backend.aws.path}"
     role = "${vault_aws_secret_backend_role.role.name}"
     type = "creds"
-}`, mountPath, accessKey, secretKey, region)
+}`, mountPath, accessKey, secretKey)
 }
 
-func testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(region string) resource.TestCheckFunc {
+func testAccDataSourceAWSAccessCredentialsCheck_tokenWorks() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState := s.Modules[0].Resources["data.vault_aws_access_credentials.test"]
 		if resourceState == nil {
@@ -166,7 +160,6 @@ func testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(region string) resour
 		awsConfig := &aws.Config{
 			Credentials: credentials.NewStaticCredentials(accessKey, secretKey, securityToken),
 			HTTPClient:  cleanhttp.DefaultClient(),
-			Region:      &region,
 		}
 		sess, err := session.NewSession(awsConfig)
 		if err != nil {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -79,14 +79,6 @@ func getTestAWSCreds(t *testing.T) (string, string) {
 	return accessKey, secretKey
 }
 
-func getTestAWSRegion(t *testing.T) string {
-	region := os.Getenv("AWS_DEFAULT_REGION")
-	if region == "" {
-		t.Skip("AWS_DEFAULT_REGION not set")
-	}
-	return region
-}
-
 type azureTestConf struct {
 	SubscriptionID, TenantID, ClientID, ClientSecret, Scope string
 }


### PR DESCRIPTION
PR 832 inadvertently introduced issues when the token policy did not
have the required permissions to read the root configuration.

This reverts commit f8b83fbd30ae3934b79b1cbc833532ce99ab94e0.