### PR TITLE
Add region passing for non commercial regions

### DIFF
--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -155,9 +155,17 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 	d.Set("lease_start_time", time.Now().Format(time.RFC3339))
 	d.Set("lease_renewable", secret.Renewable)
 
+	rootPath := backend + "/config/root"
+	regionData, err := client.Logical().ReadWithData(rootPath, data)
+	if err != nil {
+		return fmt.Errorf("error reading from Vault: %s", err)
+	}
+	region := regionData.Data["region"].(string)
+
 	awsConfig := &aws.Config{
 		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, securityToken),
 		HTTPClient:  cleanhttp.DefaultClient(),
+		Region:      &region,
 	}
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {

--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -156,7 +156,7 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 	d.Set("lease_renewable", secret.Renewable)
 
 	rootPath := backend + "/config/root"
-	regionData, err := client.Logical().ReadWithData(rootPath, data)
+	regionData, err := client.Logical().Read(rootPath)
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}

--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -72,7 +72,6 @@ func awsAccessCredentialsDataSource() *schema.Resource {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "us-east-1",
 				Description: "Region the read credentials belong to.",
 			},
 			"access_key": {
@@ -126,7 +125,6 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 	backend := d.Get("backend").(string)
 	credType := d.Get("type").(string)
 	role := d.Get("role").(string)
-	region := d.Get("region").(string)
 	path := backend + "/" + credType + "/" + role
 
 	arn := d.Get("role_arn").(string)
@@ -165,8 +163,13 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 	awsConfig := &aws.Config{
 		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, securityToken),
 		HTTPClient:  cleanhttp.DefaultClient(),
-		Region:      &region,
 	}
+
+	region := d.Get("region").(string)
+	if region != "" {
+		awsConfig.Region = &region
+	}
+
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {
 		return fmt.Errorf("error creating AWS session: %s", err)

--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -71,6 +71,7 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 					backend = "${vault_aws_secret_backend.aws.path}"
 					role = "${vault_aws_secret_backend_role.role.name}"
 					type = "sts"
+					region = "${vault_aws_secret_backend.aws.region}"
 				}`, mountPath, accessKey, secretKey, region),
 		},
 		"sts with role_arn": {
@@ -95,6 +96,7 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 					role     = "${vault_aws_secret_backend_role.role.name}"
 					type     = "sts"
 					role_arn = "arn:aws:iam::012345678901:role/foobar"
+					region = "${vault_aws_secret_backend.aws.region}"
 				}`, mountPath, accessKey, secretKey, region),
 		},
 	}
@@ -143,6 +145,7 @@ data "vault_aws_access_credentials" "test" {
     backend = "${vault_aws_secret_backend.aws.path}"
     role = "${vault_aws_secret_backend_role.role.name}"
     type = "creds"
+	region = "${vault_aws_secret_backend.aws.region}"
 }`, mountPath, accessKey, secretKey, region)
 }
 

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -79,6 +79,14 @@ func getTestAWSCreds(t *testing.T) (string, string) {
 	return accessKey, secretKey
 }
 
+func getTestAWSRegion(t *testing.T) (string) {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		t.Skip("AWS_DEFAULT_REGION not set")
+	}
+	return region
+}
+
 type azureTestConf struct {
 	SubscriptionID, TenantID, ClientID, ClientSecret, Scope string
 }

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -79,7 +79,7 @@ func getTestAWSCreds(t *testing.T) (string, string) {
 	return accessKey, secretKey
 }
 
-func getTestAWSRegion(t *testing.T) (string) {
+func getTestAWSRegion(t *testing.T) string {
 	region := os.Getenv("AWS_DEFAULT_REGION")
 	if region == "" {
 		t.Skip("AWS_DEFAULT_REGION not set")


### PR DESCRIPTION
This allows us to use non-inferrable regions with terraform and the vault provider.
Community Note

    Please vote on this pull request by adding a 👍 reaction to the original pull request comment to help the community and maintainers prioritize this request
    Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #679

Release note for CHANGELOG:

Add support for passing region information stored in vault backend to AWS Config

Output from acceptance testing:
(Note: You need numerous environment variables to be set for these acceptance tests to run.
```
TF_ACC=1
VAULT_TOKEN=????
```
The following env vars must be set based on information provided by your AWS instance. In order to truly test these changes, you'll need to get Access Keys from the us-gov-west-1 cloud, as those credentials were the ones that didn't work which prompted this change (You can also use cn-northwest-1 to test this if you'd like).
```
AWS_ACCESS_KEY_ID=????
AWS_SECRET_ACCESS_KEY=????
AWS_DEFAULT_REGION=(cn-northwest-1|us-gov-west-1|us-east-1)
```

```
$ go test -run="TestAccDataSourceAWSAccessCredentials" -v ./vault

=== RUN   TestAccDataSourceAWSAccessCredentials_basic
--- PASS: TestAccDataSourceAWSAccessCredentials_basic (54.20s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts
--- PASS: TestAccDataSourceAWSAccessCredentials_sts (1.49s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn (0.77s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn (0.72s)
PASS

Process finished with exit code 0
...
```