### PR TITLE
Use the path for data.vault_generic_secret ID

### DIFF
--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -86,7 +86,7 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("no secret found at %q", path)
 	}
 
-	d.SetId(secret.RequestID)
+	d.SetId(path)
 
 	// Ignoring error because this value came from JSON in the
 	// first place so no reason why it should fail to re-encode.


### PR DESCRIPTION
Terraform 0.13.0 introduces the values for data sources to be read as part of the `plan` phase. Once a generic secret is written to state, future plan or applies will change the ID because it's using the `RequestID` that read it as the ID. This is demonstrated in https://github.com/terraform-providers/terraform-provider-vault/issues/847

Here we change the data source to use the `path` attribute instead, which should remain unique. It's also unlikely that anyone would be using `data.vault_generic_secret.name.id` as an input value, as it's a UUID from Vault that identifies that specific request that read the value and provides no actual value outside of that. 

Fixes #847 