### PR TITLE
Feature request 852

### DIFF
--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -68,6 +68,14 @@ func gcpSecretBackendResource() *schema.Resource {
 				Default:     "",
 				Description: "Maximum possible lease duration for secrets in seconds",
 			},
+			"local": {
+				Type:        schema.TypeBool,
+				Required:    false,
+				Optional:    true,
+				Computed:    false,
+				ForceNew:    true,
+				Description: "Local mount flag that can be explicitly set to true to enforce local mount in HA environment",
+			},
 		},
 	}
 }
@@ -80,6 +88,7 @@ func gcpSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	defaultTTL := d.Get("default_lease_ttl_seconds").(int)
 	maxTTL := d.Get("max_lease_ttl_seconds").(int)
 	credentials := d.Get("credentials").(string)
+	local := d.Get("local").(bool)
 
 	configPath := gcpSecretBackendConfigPath(path)
 
@@ -92,6 +101,7 @@ func gcpSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 			DefaultLeaseTTL: fmt.Sprintf("%ds", defaultTTL),
 			MaxLeaseTTL:     fmt.Sprintf("%ds", maxTTL),
 		},
+		Local: local,
 	})
 	if err != nil {
 		return fmt.Errorf("error mounting to %q: %s", path, err)
@@ -146,6 +156,7 @@ func gcpSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", mount.Description)
 	d.Set("default_lease_ttl_seconds", mount.Config.DefaultLeaseTTL)
 	d.Set("max_lease_ttl_seconds", mount.Config.MaxLeaseTTL)
+	d.Set("local", mount.Local)
 
 	return nil
 }

--- a/vault/resource_gcp_secret_backend_test.go
+++ b/vault/resource_gcp_secret_backend_test.go
@@ -26,6 +26,7 @@ func TestGCPSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "default_lease_ttl_seconds", "3600"),
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "max_lease_ttl_seconds", "0"),
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "credentials", "{\"hello\":\"world\"}"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "local", "false"),
 				),
 			},
 			{
@@ -36,6 +37,7 @@ func TestGCPSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "default_lease_ttl_seconds", "1800"),
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "max_lease_ttl_seconds", "43200"),
 					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "credentials", "{\"how\":\"goes\"}"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "local", "true"),
 				),
 			},
 		},
@@ -91,5 +93,6 @@ EOF
   description = "test description"
   default_lease_ttl_seconds = 1800
   max_lease_ttl_seconds = 43200
+  local = true
 }`, path)
 }

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -48,6 +48,8 @@ issued by this backend. Defaults to '0'.
 * `max_lease_ttl_seconds` - (Optional) The maximum TTL that can be requested
 for credentials issued by this backend. Defaults to '0'.
 
+* `local` - (Optional) Boolean flag that can be explicitly set to true to enforce local mount in HA environment
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
Added change to support additional parameter (local) for gcp secret engine mount. The change is related to issue 852 (https://github.com/terraform-providers/terraform-provider-vault/issues/852).