### PR TITLE
resource/ssh_secret_backend_ca: detect misconfigured resource and remove from state

### DIFF
--- a/vault/resource_ssh_secret_backend_ca.go
+++ b/vault/resource_ssh_secret_backend_ca.go
@@ -2,10 +2,11 @@ package vault
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/vault/api"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
 )
 
 func sshSecretBackendCAResource() *schema.Resource {
@@ -13,7 +14,6 @@ func sshSecretBackendCAResource() *schema.Resource {
 		Create: sshSecretBackendCACreate,
 		Read:   sshSecretBackendCARead,
 		Delete: sshSecretBackendCADelete,
-		Exists: sshSecretBackendCAExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -89,6 +89,15 @@ func sshSecretBackendCARead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading CA information from SSH backend %q", backend)
 	secret, err := client.Logical().Read(backend + "/config/ca")
 	if err != nil {
+		if apiRespErr, ok := err.(*api.ResponseError); ok {
+			for _, e := range apiRespErr.Errors {
+				if e == "keys haven't been configured yet" {
+					log.Printf("[WARN] CA information not found in SSH backend %q, removing from state", backend)
+					d.SetId("")
+					return nil
+				}
+			}
+		}
 		return fmt.Errorf("Error reading CA information from SSH backend %q: %s", backend, err)
 	}
 	log.Printf("[DEBUG] Read CA information from SSH backend %q", backend)
@@ -118,18 +127,4 @@ func sshSecretBackendCADelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleted CA configuration for SSH backend %q", backend)
 
 	return nil
-}
-
-func sshSecretBackendCAExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
-
-	backend := d.Id()
-	log.Printf("[DEBUG] Checking if CA information exists for backend %q ", backend)
-	secret, err := client.Logical().Read(backend + "/config/ca")
-	if err != nil {
-		return true, fmt.Errorf("Error checking if CA information exists for backend %q: %s", backend, err)
-	}
-	log.Printf("[DEBUG] Checked if CA information exists for backend %q", backend)
-
-	return secret != nil, nil
 }


### PR DESCRIPTION
The [`vault_ssh_secret_backend_ca`][ca] resource depends on a SSH secret backend mounted at `path`. If `generate_signing_key` is used (which is the default) this resource generates the signing key pair internally at creation time. 

If the SSH secret engine gets _replaced_ (meaning recreated, at the same path), the generated keys are lost but the `backend_ca` resource does not detect this because the path has not changed. In follow up state refreshes, the resource throws an error from Vault that the keys are not present:

```
URL: GET https://vault.foo.com/v1/ssh-devel/config/ca
Code: 400. Errors:

* keys haven't been configured yet
```

(See https://github.com/terraform-providers/terraform-provider-vault/issues/846)

Unfortunately due to how Terraform works, because the `path` value does not change, the `vault_ssh_secret_backend_ca` does not get marked for update when the SSH resource is changed. Vault requires paths to be unique, but does not offer unique IDs for relationships, or at least the provider doesn't utilize them.

This PR does not completely fix this problem, however it improves error handling in the `vault_ssh_secret_backend_ca` resource such that if the `"keys haven't been configured yet"` error message is received, it removes the resource from state so that a future `terraform plan` can recreate it. 

Improves, but does not really "fix", #846

[ca]: https://www.terraform.io/docs/providers/vault/r/ssh_secret_backend_ca.html