### PR TITLE
Clarify aws_auth_backend_role docs 

### DIFF
--- a/website/docs/r/aws_auth_backend_role.html.md
+++ b/website/docs/r/aws_auth_backend_role.html.md
@@ -107,8 +107,9 @@ The following arguments are supported:
   `inferred_entity_type` is set. This only applies when `auth_type` is set to
   `iam`.
 
-* `resolve_aws_unique_ids` - (Optional, Forces new resource) If set to `true`, the
-  `bound_iam_principal_arns` are resolved to [AWS Unique
+* `resolve_aws_unique_ids` - (Optional, Forces new resource) Only valid when
+  `auth_type` is `iam`. If set to `true`, the `bound_iam_principal_arns` are
+  resolved to [AWS Unique
   IDs](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids)
   for the bound principal ARN. This field is ignored when a
   `bound_iam_principal_arn` ends in a wildcard. Resolving to unique IDs more


### PR DESCRIPTION
Update the documentation for resource [aws_auth_backend_role][backend_role] and usage of `resolve_aws_unique_ids` with respect to the `auth_type` value.

This PR will resolve https://github.com/terraform-providers/terraform-provider-vault/issues/853 in that I feel we can close the issue. A future SDK enhancement can make multi-attribute validation a thing, but it's not clear if/when that could land (see https://github.com/hashicorp/terraform-plugin-sdk/issues/233).

[backend_role]: https://www.terraform.io/docs/providers/vault/r/aws_auth_backend_role.html