### PR TITLE
Feature request for issue #858

### DIFF
--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -117,7 +117,7 @@ func gcpAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Enabling gcp auth backend %q", path)
 	err := client.Sys().EnableAuthWithOptions(path, &api.EnableAuthOptions{
-		Type:        gcpAuthType,
+		Type:        authType,
 		Description: desc,
 		Local:       local,
 	})

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -62,6 +62,12 @@ func gcpAuthBackendResource() *schema.Resource {
 					return strings.Trim(v.(string), "/")
 				},
 			},
+			"local": {
+				Type:        schema.TypeBool,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "Specifies if the auth method is local only",
+			},
 		},
 	}
 }
@@ -107,9 +113,14 @@ func gcpAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	authType := gcpAuthType
 	path := d.Get("path").(string)
 	desc := d.Get("description").(string)
+	local := d.Get("local").(bool)
 
 	log.Printf("[DEBUG] Enabling gcp auth backend %q", path)
-	err := client.Sys().EnableAuth(path, authType, desc)
+	err := client.Sys().EnableAuthWithOptions(path, &api.EnableAuthOptions{
+		Type:        gcpAuthType,
+		Description: desc,
+		Local:       local,
+	})
 	if err != nil {
 		return fmt.Errorf("error enabling gcp auth backend %q: %s", path, err)
 	}
@@ -163,7 +174,7 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("client_id", resp.Data["client_id"])
 	d.Set("project_id", resp.Data["project_id"])
 	d.Set("client_email", resp.Data["client_email"])
-
+	d.Set("local", resp.Data["local"])
 	return nil
 }
 

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -24,6 +24,12 @@ The following arguments are supported:
 
 * `credentials` - A JSON string containing the contents of a GCP credentials file. If this value is empty, Vault will try to use Application Default Credentials from the machine on which the Vault server is running.
 
+* `path` - (Optional) The path to mount the auth method — this defaults to 'gcp'.
+
+* `description` - (Optional) A description of the auth method.
+
+* `local` - (Optional) Specifies if the auth method is local only.
+
 For more details on the usage of each argument consult the [Vault GCP API documentation](https://www.vaultproject.io/api-docs/auth/gcp#configure).
 
 ## Attribute Reference


### PR DESCRIPTION
Added following changes:

- Added change to support additional parameter (local) for gcp auth engine mount.
-  Use non deprecated method EnableAuthWithOptions instead of the deprecated method EnableAuth on vault api.
- The change is related to issue #858 