### PR TITLE
[k8s auth backend confiugration] Introduce disable_iss_validation and disable_local_ca_jwt params

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/go-autorest v11.7.1+incompatible
 	github.com/aws/aws-sdk-go v1.25.3
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/google/btree v1.0.0 // indirect
 	github.com/gosimple/slug v1.4.1
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/go-autorest v11.7.1+incompatible
 	github.com/aws/aws-sdk-go v1.25.3
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/google/btree v1.0.0 // indirect
 	github.com/gosimple/slug v1.4.1
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -49,6 +49,12 @@ func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional JWT issuer. If no issuer is specified, kubernetes.io/serviceaccount will be used as the default issuer.",
 			},
+			"disable_iss_validation": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Optional disable JWT issuer validation. Allows to skip ISS validation.",
+			},
 		},
 	}
 }
@@ -83,6 +89,7 @@ func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta inte
 	d.Set("pem_keys", pemKeys)
 
 	d.Set("issuer", resp.Data["issuer"])
+	d.Set("disable_iss_validation", resp.Data["disable_iss_validation"])
 
 	return nil
 }

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -55,6 +55,12 @@ func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional disable JWT issuer validation. Allows to skip ISS validation.",
 			},
+			"disable_local_ca_jwt": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Optional disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.",
+			},
 		},
 	}
 }
@@ -87,9 +93,9 @@ func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta inte
 	}
 
 	d.Set("pem_keys", pemKeys)
-
 	d.Set("issuer", resp.Data["issuer"])
 	d.Set("disable_iss_validation", resp.Data["disable_iss_validation"])
+	d.Set("disable_local_ca_jwt", resp.Data["disable_local_ca_jwt"])
 
 	return nil
 }

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -55,6 +55,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 	jwt := kubernetesJWT
 	issuer := "kubernetes/serviceaccount"
 	disableIssValidation := true
+	disableLocalCaJwt := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -62,7 +63,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -80,10 +81,12 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						"issuer", issuer),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_local_ca_jwt", strconv.FormatBool(disableLocalCaJwt)),
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer, disableIssValidation),
+				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -101,6 +104,8 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						"issuer", issuer),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_local_ca_jwt", strconv.FormatBool(disableLocalCaJwt)),
 				),
 			},
 		},
@@ -116,11 +121,11 @@ data "vault_kubernetes_auth_backend_config" "config" {
 }`, testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt), backend)
 }
 
-func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool) string {
+func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool) string {
 	return fmt.Sprintf(`
 %s
 
 data "vault_kubernetes_auth_backend_config" "config" {
   backend = "%s"
-}`, testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation), backend)
+}`, testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt), backend)
 }

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -53,6 +54,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 	backend := acctest.RandomWithPrefix("kubernetes")
 	jwt := kubernetesJWT
 	issuer := "kubernetes/serviceaccount"
+	disableIssValidation := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -60,7 +62,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -76,10 +78,12 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						"pem_keys.0", kubernetesPEMfile),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", issuer),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer),
+				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer, disableIssValidation),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -95,6 +99,8 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						"pem_keys.0", kubernetesPEMfile),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", issuer),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 				),
 			},
 		},
@@ -110,11 +116,11 @@ data "vault_kubernetes_auth_backend_config" "config" {
 }`, testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt), backend)
 }
 
-func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string) string {
+func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool) string {
 	return fmt.Sprintf(`
 %s
 
 data "vault_kubernetes_auth_backend_config" "config" {
   backend = "%s"
-}`, testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer), backend)
+}`, testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation), backend)
 }

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -66,6 +66,12 @@ func kubernetesAuthBackendConfigResource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional JWT issuer. If no issuer is specified, kubernetes.io/serviceaccount will be used as the default issuer.",
 			},
+			"disable_iss_validation": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Optional disable JWT issuer validation. Allows to skip ISS validation.",
+			},
 		},
 	}
 }
@@ -103,6 +109,10 @@ func kubernetesAuthBackendConfigCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("issuer"); ok {
 		data["issuer"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("disable_iss_validation"); ok {
+		data["disable_iss_validation"] = v
 	}
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
@@ -155,6 +165,7 @@ func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("kubernetes_host", resp.Data["kubernetes_host"])
 	d.Set("kubernetes_ca_cert", resp.Data["kubernetes_ca_cert"])
 	d.Set("issuer", resp.Data["issuer"])
+	d.Set("disable_iss_validation", resp.Data["disable_iss_validation"])
 
 	iPemKeys := resp.Data["pem_keys"].([]interface{})
 	pemKeys := make([]string, 0, len(iPemKeys))
@@ -195,6 +206,10 @@ func kubernetesAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("issuer"); ok {
 		data["issuer"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("disable_iss_validation"); ok {
+		data["disable_iss_validation"] = v
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -72,6 +72,12 @@ func kubernetesAuthBackendConfigResource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional disable JWT issuer validation. Allows to skip ISS validation.",
 			},
+			"disable_local_ca_jwt": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Optional disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.",
+			},
 		},
 	}
 }
@@ -113,6 +119,10 @@ func kubernetesAuthBackendConfigCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("disable_iss_validation"); ok {
 		data["disable_iss_validation"] = v
+	}
+
+	if v, ok := d.GetOk("disable_local_ca_jwt"); ok {
+		data["disable_local_ca_jwt"] = v
 	}
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
@@ -166,6 +176,7 @@ func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("kubernetes_ca_cert", resp.Data["kubernetes_ca_cert"])
 	d.Set("issuer", resp.Data["issuer"])
 	d.Set("disable_iss_validation", resp.Data["disable_iss_validation"])
+	d.Set("disable_local_ca_jwt", resp.Data["disable_local_ca_jwt"])
 
 	iPemKeys := resp.Data["pem_keys"].([]interface{})
 	pemKeys := make([]string, 0, len(iPemKeys))
@@ -210,6 +221,10 @@ func kubernetesAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("disable_iss_validation"); ok {
 		data["disable_iss_validation"] = v
+	}
+
+	if v, ok := d.GetOk("disable_local_ca_jwt"); ok {
+		data["disable_local_ca_jwt"] = v
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -64,6 +65,7 @@ func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
 	backend := acctest.RandomWithPrefix("kubernetes")
 	jwt := kubernetesJWT
 	issuer := "kubernetes/serviceaccount"
+	disableIssValidation := false
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,7 +73,7 @@ func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -87,6 +89,8 @@ func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
 						"pem_keys.#", "1"),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", issuer),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 				),
 			},
 			{
@@ -208,6 +212,7 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 	backend := acctest.RandomWithPrefix("kubernetes")
 	jwt := kubernetesJWT
 	issuer := "api"
+	disableIssValidation := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -215,7 +220,7 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -231,6 +236,8 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 						"pem_keys.0", kubernetesPEMfile),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", "api"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 				),
 			},
 		},
@@ -243,6 +250,8 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 	newJWT := kubernetesAnotherJWT
 	oldIssuer := "kubernetes/serviceaccount"
 	newIssuer := "api"
+	oldDisableIssValidation := false
+	newDisableIssValidation := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -250,7 +259,7 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, oldJWT, oldIssuer),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, oldJWT, oldIssuer, oldDisableIssValidation),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -266,10 +275,14 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 						"pem_keys.0", kubernetesPEMfile),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", oldIssuer),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"issuer", oldIssuer),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_iss_validation", strconv.FormatBool(oldDisableIssValidation)),
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, newDisableIssValidation),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -285,6 +298,8 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 						"pem_keys.0", kubernetesPEMfile),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", newIssuer),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_iss_validation", strconv.FormatBool(newDisableIssValidation)),
 				),
 			},
 		},
@@ -306,7 +321,7 @@ resource "vault_kubernetes_auth_backend_config" "config" {
 }`, backend, kubernetesCAcert, jwt)
 }
 
-func testAccKubernetesAuthBackendConfigConfig_full(backend, jwt string, issuer string) string {
+func testAccKubernetesAuthBackendConfigConfig_full(backend, jwt string, issuer string, disableIssValidation bool) string {
 	return fmt.Sprintf(`
 resource "vault_auth_backend" "kubernetes" {
   type = "kubernetes"
@@ -320,5 +335,6 @@ resource "vault_kubernetes_auth_backend_config" "config" {
   token_reviewer_jwt = %q
   pem_keys = [%q]
   issuer = %q
-}`, backend, kubernetesCAcert, jwt, kubernetesPEMfile, issuer)
+  disable_iss_validation = %t
+}`, backend, kubernetesCAcert, jwt, kubernetesPEMfile, issuer, disableIssValidation)
 }

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -43,9 +43,9 @@ The following arguments are supported:
 
 * `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes.io/serviceaccount` will be used as the default issuer.
 
-* `disable_iss_validation` - (Optional) Disable JWT issuer validation. Allows to skip ISS validation.
+* `disable_iss_validation` - (Optional) Disable JWT issuer validation. Allows to skip ISS validation. Requires Vault `v1.5.4+` or Vault auth kubernetes plugin `v0.7.1+`
 
-* `disable_local_ca_jwt` - (Optional) Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.
+* `disable_local_ca_jwt` - (Optional) Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod. Requires Vault `v1.5.4+` or Vault auth kubernetes plugin `v0.7.1+`
  
 
 ## Attributes Reference

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -44,6 +44,8 @@ The following arguments are supported:
 * `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes.io/serviceaccount` will be used as the default issuer.
 
 * `disable_iss_validation` - (Optional) Disable JWT issuer validation. Allows to skip ISS validation.
+
+* `disable_local_ca_jwt` - (Optional) Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.
  
 
 ## Attributes Reference

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -20,11 +20,12 @@ resource "vault_auth_backend" "kubernetes" {
 }
 
 resource "vault_kubernetes_auth_backend_config" "example" {
-  backend            = "${vault_auth_backend.kubernetes.path}"
-  kubernetes_host    = "http://example.com:443"
-  kubernetes_ca_cert = "-----BEGIN CERTIFICATE-----\nexample\n-----END CERTIFICATE-----"
-  token_reviewer_jwt = "ZXhhbXBsZQo="
-  issuer             = "api"
+  backend                = "${vault_auth_backend.kubernetes.path}"
+  kubernetes_host        = "http://example.com:443"
+  kubernetes_ca_cert     = "-----BEGIN CERTIFICATE-----\nexample\n-----END CERTIFICATE-----"
+  token_reviewer_jwt     = "ZXhhbXBsZQo="
+  issuer                 = "api"
+  disable_iss_validation = "true"
 }
 ```
 
@@ -40,7 +41,10 @@ The following arguments are supported:
 
 * `pem_keys` - (Optional) List of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.
 
-* `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes.io/serviceaccount` will be used as the default issuer. 
+* `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes.io/serviceaccount` will be used as the default issuer.
+
+* `disable_iss_validation` - (Optional) Disable JWT issuer validation. Allows to skip ISS validation.
+ 
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

This PR adds new `disable_iss_validation` and `disable_local_ca_jwt` options in Vault k8s auth backend introduced in: https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/91
https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/97

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Add `disable_iss_validation` config param to k8s auth backend
Add `disable_local_ca_jwt` config param to k8s auth backend
```

Output from acceptance testing:

```
$ TESTARGS="--run TestAccKubernetes" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run TestAccKubernetes -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/generate    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/codegen (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/generated       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation    (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/schema  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_basic
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_basic (0.27s)
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_full
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_full (0.24s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_basic
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_basic (0.24s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_full
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_full (0.24s)
=== RUN   TestAccKubernetesAuthBackendConfig_import
--- PASS: TestAccKubernetesAuthBackendConfig_import (0.26s)
=== RUN   TestAccKubernetesAuthBackendConfig_basic
--- PASS: TestAccKubernetesAuthBackendConfig_basic (0.13s)
=== RUN   TestAccKubernetesAuthBackendConfig_update
--- PASS: TestAccKubernetesAuthBackendConfig_update (0.22s)
=== RUN   TestAccKubernetesAuthBackendConfig_full
--- PASS: TestAccKubernetesAuthBackendConfig_full (0.13s)
=== RUN   TestAccKubernetesAuthBackendConfig_fullUpdate
--- PASS: TestAccKubernetesAuthBackendConfig_fullUpdate (0.22s)
=== RUN   TestAccKubernetesAuthBackendRole_import
--- PASS: TestAccKubernetesAuthBackendRole_import (0.15s)
=== RUN   TestAccKubernetesAuthBackendRole_basic
--- PASS: TestAccKubernetesAuthBackendRole_basic (0.13s)
=== RUN   TestAccKubernetesAuthBackendRole_update
--- PASS: TestAccKubernetesAuthBackendRole_update (0.23s)
=== RUN   TestAccKubernetesAuthBackendRole_full
--- PASS: TestAccKubernetesAuthBackendRole_full (0.13s)
=== RUN   TestAccKubernetesAuthBackendRole_fullUpdate
--- PASS: TestAccKubernetesAuthBackendRole_fullUpdate (0.41s)
=== RUN   TestAccKubernetesAuthBackendRole_fullDeprecated
--- PASS: TestAccKubernetesAuthBackendRole_fullDeprecated (0.23s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   (cached)
```
