### PR TITLE
vault_ssh_secret_backend_role: add allowed_users_template argument

### DIFF
--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -87,6 +87,11 @@ func sshSecretBackendRoleResource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
+			"allowed_users_template": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"allowed_users": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -160,6 +165,11 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("default_critical_options"); ok {
 		data["default_critical_options"] = v
+	}
+
+	if v, ok := d.GetOk("allowed_users_template"); ok {
+		data["allowed_users_template"] = v.(bool)
+
 	}
 
 	if v, ok := d.GetOk("allowed_users"); ok {
@@ -241,6 +251,7 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("allowed_extensions", role.Data["allowed_extensions"])
 	d.Set("default_extensions", role.Data["default_extensions"])
 	d.Set("default_critical_options", role.Data["default_critical_options"])
+	d.Set("allowed_users_template", role.Data["allowed_users_template"])
 	d.Set("allowed_users", role.Data["allowed_users"])
 	d.Set("default_user", role.Data["default_user"])
 	d.Set("key_id_format", role.Data["key_id_format"])

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -33,6 +33,7 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_extensions", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_extensions.%", "0"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_critical_options.%", "0"),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users_template", "false"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", ""),
@@ -57,6 +58,7 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_extensions", "ext1,ext2"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_extensions.ext1", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_critical_options.opt1", ""),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users_template", "true"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users", "usr1,usr2"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", "usr"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
@@ -115,6 +117,7 @@ func TestAccSSHSecretBackendRole_import(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_extensions", "ext1,ext2"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_extensions.ext1", ""),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_critical_options.opt1", ""),
+					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users_template", "true"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users", "usr1,usr2"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", "usr"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
@@ -188,7 +191,8 @@ resource "vault_ssh_secret_backend_role" "test_role" {
 	allowed_extensions       = "ext1,ext2"
 	default_extensions       = { "ext1" = "" }
 	default_critical_options = { "opt1" = "" }
-	allowed_users            = "usr1,usr2"
+        allowed_users_template   = true
+        allowed_users            = "usr1,usr2"
 	default_user             = "usr"
 	key_id_format            = "{{role_name}}-test"
 	key_type                 = "ca"

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 * `default_critical_options` - (Optional) Specifies a map of critical options that certificates have when signed.
 
+* `allowed_users_template` - (Optional) Specifies if `allowed_users` can be declared using identity template policies. Non-templated users are also permitted.
+
 * `allowed_users` - (Optional) Specifies a comma-separated list of usernames that are to be allowed, only if certain usernames are to be allowed.
 
 * `default_user` - (Optional) Specifies the default username for which a credential will be generated.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

The `allowed_users_template` option was added to vault in `v1.4.0` see ([GH-7548](|https://github.com/hashicorp/vault/pull/7548))

I oriented this PR to https://github.com/terraform-providers/terraform-provider-vault/pull/809 which seemed to be very similar.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
* This PR closes #839 
<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/vault_ssh_secret_backend_role: Support new `allowed_users_template` argument
```

Output from acceptance testing:

```
$ TESTARGS="--run SSHSecretBackendRole" make testacc
...
=== RUN   TestAccSSHSecretBackendRole_basic
--- PASS: TestAccSSHSecretBackendRole_basic (0.48s)
=== RUN   TestAccSSHSecretBackendRoleOTP_basic
--- PASS: TestAccSSHSecretBackendRoleOTP_basic (0.27s)
=== RUN   TestAccSSHSecretBackendRole_import
--- PASS: TestAccSSHSecretBackendRole_import (0.31s)
PASS
...
```
