### PR TITLE
Add optional TTL to data.vault_aws_access_credentials

### DIFF
--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -115,6 +115,11 @@ func awsAccessCredentialsDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "True if the duration of this lease can be extended through renewal.",
 			},
+			"ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Human-friendly description of the mount for the backend.",
+			},
 		},
 	}
 }
@@ -131,6 +136,10 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 	// If the ARN is empty and only one is specified in the role definition, this should work without issue
 	data := map[string][]string{
 		"role_arn": {arn},
+	}
+
+	if v, ok := d.GetOk("ttl"); ok {
+		data["ttl"] = []string{v.(string)}
 	}
 
 	log.Printf("[DEBUG] Reading %q from Vault with data %#v", path, data)

--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -118,7 +118,7 @@ func awsAccessCredentialsDataSource() *schema.Resource {
 			"ttl": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Human-friendly description of the mount for the backend.",
+				Description: "User specified Time-To-Live for the STS token. Uses the Role defined default_sts_ttl when not specified",
 			},
 		},
 	}

--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -75,6 +75,10 @@ in addition to the keys.
 from the configured role. If the role does not have multiple ARNs, this does
 not need to be specified.
 
+* `ttl` - (Optional) Specifies the TTL for the use of the STS token. This
+is specified as a string with a duration suffix. Valid only when
+`credential_type` is `assumed_role` or `federation_token`
+
 ## Attributes Reference
 
 In addition to the arguments above, the following attributes are exported:


### PR DESCRIPTION
Add optional `ttl` parameter to `data.vault_aws_access_credentials` data source.

Closes https://github.com/terraform-providers/terraform-provider-vault/issues/863

Output from acceptance testing:

```
$ make testacc TEST=./vault TESTARGS="-run=TestAccDataSourceAWSAccessCredentials"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./vault -v -run=TestAccDataSourceAWSAccessCredentials -timeout 120m
=== RUN   TestAccDataSourceAWSAccessCredentials_basic
--- PASS: TestAccDataSourceAWSAccessCredentials_basic (55.20s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn
--- PASS: TestAccDataSourceAWSAccessCredentials_sts (4.85s)
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn (3.00s)
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn (1.85s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts_ttl
--- PASS: TestAccDataSourceAWSAccessCredentials_sts_ttl (3.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   63.808s
...
```
