### PR TITLE
Fix vault_transit_secret_cache_config documentation

### DIFF
--- a/website/docs/r/transit_secret_backend_cache_config.html.md
+++ b/website/docs/r/transit_secret_backend_cache_config.html.md
@@ -1,12 +1,12 @@
 ---
 layout: "vault"
-page_title: "Vault: vault_transit_secret_backend_cache_config resource"
-sidebar_current: "docs-vault-resource-transit-secret-backend-cache-config"
+page_title: "Vault: vault_transit_secret_cache_config resource"
+sidebar_current: "docs-vault-resource-transit-secret-cache-config"
 description: |-
   Configure the cache for the Transit Secret Backend in Vault.
 ---
 
-# vault\_transit\_secret\_backend\_cache\_config
+# vault\_transit\_secret\_cache\_config
 
 Configure the cache for the Transit Secret Backend in Vault.
 
@@ -21,7 +21,7 @@ resource "vault_mount" "transit" {
   max_lease_ttl_seconds     = 86400
 }
 
-resource "vault_transit_secret_backend_cache_config" "cfg" {
+resource "vault_transit_secret_cache_config" "cfg" {
   backend = "${vault_mount.transit.path}"
   size    = 500
 }


### PR DESCRIPTION
Fixed `vault_transit_secret_cache_config` documentation to match with the resource name - https://github.com/terraform-providers/terraform-provider-vault/blob/v2.15.0/vault/provider.go#L599-L603

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccTransitCacheConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccTransitCacheConfig -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/terraform-providers/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/terraform-providers/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccTransitCacheConfig
--- PASS: TestAccTransitCacheConfig (0.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.092s
```
