### PR TITLE
docs: update 'time to leave' to 'time to live'

### DIFF
--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -78,7 +78,7 @@ func pkiSecretBackendCertResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Time to leave.",
+				Description: "Time to live.",
 			},
 			"format": {
 				Type:         schema.TypeString,

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -77,7 +77,7 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Time to leave.",
+				Description: "Time to live.",
 			},
 			"format": {
 				Type:         schema.TypeString,

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -76,7 +76,7 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Time to leave.",
+				Description: "Time to live.",
 			},
 			"format": {
 				Type:         schema.TypeString,

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -83,7 +83,7 @@ func pkiSecretBackendSignResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Time to leave.",
+				Description: "Time to live.",
 			},
 			"format": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Small typo in these descriptions - 'ttl' should be 'time to live' (as documented
for example, here: https://www.vaultproject.io/api-docs/secret/pki#ttl).

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
~Relates OR Closes~ N/A

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
(I didn't run these as it's a doc only change... let me know if you'd still like me to do this.)
```
