### PR TITLE
Fix Terraform crash when creating an entity that already exists

### DIFF
--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -105,6 +105,18 @@ func identityEntityCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error writing IdentityEntity to %q: %s", name, err)
 	}
+
+	if resp == nil {
+		path := identityEntityNamePath(name)
+		entityMsg := "Unable to determine entity id."
+
+		if entity, err := client.Logical().Read(path); err == nil {
+			entityMsg = fmt.Sprintf("Entity resource ID %q may be imported.", entity.Data["id"])
+		}
+
+		return fmt.Errorf("Identity Entity %q already exists. %s", name, entityMsg)
+	}
+
 	log.Printf("[DEBUG] Wrote IdentityEntity %q", name)
 
 	d.SetId(resp.Data["id"].(string))

--- a/website/docs/r/identity_entity.html.md
+++ b/website/docs/r/identity_entity.html.md
@@ -46,3 +46,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - The `id` of the created entity.
+
+## Import
+
+Identity entity can be imported using the `id`, e.g.
+
+```
+$ terraform import vault_identity_entity.test "ae6f8ued-0f1a-9f6b-2915-1a2be20dc053"
+```


### PR DESCRIPTION
Fixes terraform crash due to `panic: runtime error: invalid memory address or nil pointer dereference` when trying to write an identity entity that already exists.

Related issues: https://github.com/terraform-providers/terraform-provider-vault/issues/451, https://github.com/terraform-providers/terraform-provider-vault/issues/734

Output from acceptance testing:

```
❯ make testacc TESTARGS='-run=TestAccIdentityEntity'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIdentityEntity -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/generate    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/codegen (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/generated       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation    (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/schema  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (0.19s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (0.19s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (0.17s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (0.17s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (0.09s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (0.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   1.231s

...
```
