### PR TITLE
Add local to audit resource

### DIFF
--- a/vault/resource_audit.go
+++ b/vault/resource_audit.go
@@ -24,29 +24,32 @@ func auditResource() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "Path in which to enable the audit device",
+				Description: "Path in which to enable the audit device.",
 			},
-
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Type of the audit device, such as 'file'",
+				Description: "Type of the audit device, such as 'file'.",
 			},
-
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Human-friendly description of the audit device",
+				Description: "Human-friendly description of the audit device.",
 			},
-
+			"local": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Specifies if the audit device is a local only. Local audit devices are not replicated nor (if a secondary) removed by replication.",
+			},
 			"options": {
 				Type:        schema.TypeMap,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Required:    true,
 				ForceNew:    true,
-				Description: "Configuration options to pass to the audit device itself",
+				Description: "Configuration options to pass to the audit device itself.",
 			},
 		},
 	}
@@ -55,9 +58,12 @@ func auditResource() *schema.Resource {
 func auditWrite(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
+	description := d.Get("description").(string)
+	local := d.Get("local").(bool)
+	mountType := d.Get("type").(string)
 	path := d.Get("path").(string)
 	if path == "" {
-		path = d.Get("type").(string)
+		path = mountType
 	}
 
 	optionsRaw := d.Get("options").(map[string]interface{})
@@ -68,13 +74,14 @@ func auditWrite(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Enabling audit backend %s in Vault", path)
+	opts := &api.EnableAuditOptions{
+		Type:        mountType,
+		Description: description,
+		Local:       local,
+		Options:     options,
+	}
 
-	if err := client.Sys().EnableAudit(
-		path,
-		d.Get("type").(string),
-		d.Get("description").(string),
-		options,
-	); err != nil {
+	if err := client.Sys().EnableAuditWithOptions(path, opts); err != nil {
 		return fmt.Errorf("error enabling audit backend: %s", err)
 	}
 
@@ -121,6 +128,7 @@ func auditRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	// Local is not returned by the List operation
 	d.Set("path", path)
 	d.Set("type", audit.Type)
 	d.Set("description", audit.Description)

--- a/vault/resource_audit_test.go
+++ b/vault/resource_audit_test.go
@@ -30,6 +30,7 @@ resource "vault_audit" "test" {
 	path = "%s"
 	type = "file"
 	description = "Example file audit for vault"
+	local = true
 	options = {
 		path = "stdout"
 	}
@@ -70,6 +71,10 @@ func testResourceAudit_initialCheck(expectedPath string) resource.TestCheckFunc 
 
 		if wanted := "file"; audit.Type != wanted {
 			return fmt.Errorf("type is %v; wanted %v", audit.Type, wanted)
+		}
+
+		if wanted := true; audit.Local != wanted {
+			return fmt.Errorf("local is %v; wanted %v", audit.Local, wanted)
 		}
 
 		if wanted := "stdout"; audit.Options["path"] != wanted {

--- a/website/docs/r/audit.html.md
+++ b/website/docs/r/audit.html.md
@@ -26,7 +26,7 @@ resource "vault_audit" "test" {
 resource "vault_audit" "test" {
   type = "socket"
   path = "app_socket"
-  local = "false"
+  local = false
 
   options = {
     address     = "127.0.0.1:8000"

--- a/website/docs/r/audit.html.md
+++ b/website/docs/r/audit.html.md
@@ -26,6 +26,7 @@ resource "vault_audit" "test" {
 resource "vault_audit" "test" {
   type = "socket"
   path = "app_socket"
+  local = "false"
 
   options = {
     address     = "127.0.0.1:8000"
@@ -44,6 +45,8 @@ The following arguments are supported:
 * `path` - (optional) The path to mount the audit device. This defaults to the type.
 
 * `description` - (Optional) Human-friendly description of the audit device.
+
+* `local` - (Optional) Specifies if the audit device is a local only. Local audit devices are not replicated nor (if a secondary) removed by replication.
 
 * `options` - (Required) Configuration options to pass to the audit device itself.
 


### PR DESCRIPTION
This adds the `local` parameter to the `audit` backend resource to configure the replication setting of the audit backend. This resource was using a deprecated SDK method so I can changed it to the newer one (`EnableAuditWithOptions`).

```release-note
* `resource/vault_audit `: added support for local mount to configure replicating the audit backend
```

Output from acceptance testing:

```
$ TESTARGS="--run TestResourceAudit" make testacc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run TestResourceAudit -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/terraform-providers/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode	1.309s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode	0.721s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet	1.047s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role	2.817s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template	2.006s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation	0.997s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestResourceAudit
--- PASS: TestResourceAudit (0.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	2.671s
```
